### PR TITLE
bounded context 관련 gradle module, source set 구조 확립 & accessibility bounded context 옮기기

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,4 +29,30 @@ subprojects {
     tasks.withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "1.8"
     }
+
+    if (project.path.startsWith(":bounded_context:")) {
+        sourceSets {
+            val domainSourceSet = create("domain") {
+            }
+
+            val applicationSourceSet = create("application") {
+                compileClasspath += domainSourceSet.compileClasspath
+                runtimeClasspath += domainSourceSet.runtimeClasspath
+            }
+
+            val outputAdapterSourceSet = create("output-adapter") {
+                listOf(domainSourceSet, applicationSourceSet).forEach { sourceSet ->
+                    compileClasspath += sourceSet.compileClasspath
+                    runtimeClasspath += sourceSet.runtimeClasspath
+                }
+            }
+
+            val inputAdapterSourceSet = create("input-adapter") {
+                listOf(domainSourceSet, applicationSourceSet).forEach { sourceSet ->
+                    compileClasspath += sourceSet.compileClasspath
+                    runtimeClasspath += sourceSet.runtimeClasspath
+                }
+            }
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,26 +32,55 @@ subprojects {
 
     if (project.path.startsWith(":bounded_context:")) {
         sourceSets {
+            /**
+             * parameter로 받는 source set의 output을 다른 project의 dependency로 사용할 수 있도록 노출해주는 함수.
+             * 이 함수를 사용한 source set은 아래 코드 예시처럼 다른 project에서 의존해서 사용할 수 있다.
+             *
+             * dependencies {
+             *     // someBoundedContext의 application source set의 코드에 의존한다.
+             *     outputAdapterImplementation(project(":someBoundedContext", "application"))
+             * }
+             *
+             * refs: https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000138910-Gradle-dependency-on-non-main-source-set-module#community_comment_115000181524
+             */
+            fun exposeArtifact(sourceSet: SourceSet) {
+                val jarTask = project.tasks.register("${sourceSet.name}Jar", org.gradle.jvm.tasks.Jar::class) {
+                    from(sourceSet.output)
+                    group = "build"
+                }
+                project.configurations {
+                    val configurationName = sourceSet.name
+                    create(configurationName)
+                    project.artifacts.add(configurationName, jarTask)
+                }
+            }
+
             val domainSourceSet = create("domain") {
             }
 
             val applicationSourceSet = create("application") {
-                compileClasspath += domainSourceSet.compileClasspath
-                runtimeClasspath += domainSourceSet.runtimeClasspath
+                compileClasspath += domainSourceSet.compileClasspath + domainSourceSet.output
+                runtimeClasspath += domainSourceSet.runtimeClasspath + domainSourceSet.output
+
+                exposeArtifact(this)
             }
 
             val outputAdapterSourceSet = create("output-adapter") {
                 listOf(domainSourceSet, applicationSourceSet).forEach { sourceSet ->
-                    compileClasspath += sourceSet.compileClasspath
-                    runtimeClasspath += sourceSet.runtimeClasspath
+                    compileClasspath += sourceSet.compileClasspath + sourceSet.output
+                    runtimeClasspath += sourceSet.runtimeClasspath + sourceSet.output
                 }
+
+                exposeArtifact(this)
             }
 
             val inputAdapterSourceSet = create("input-adapter") {
                 listOf(domainSourceSet, applicationSourceSet).forEach { sourceSet ->
-                    compileClasspath += sourceSet.compileClasspath
-                    runtimeClasspath += sourceSet.runtimeClasspath
+                    compileClasspath += sourceSet.compileClasspath + sourceSet.output
+                    runtimeClasspath += sourceSet.runtimeClasspath + sourceSet.output
                 }
+
+                exposeArtifact(this)
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,17 @@
 rootProject.name = "scc-server"
 
-include("subprojects:script")
+fileTree("subprojects").filter { it.name == "build.gradle.kts" }.forEach {
+    val parentDir = it.parentFile
+    val projectName = buildString {
+        var dir = parentDir
+        while (dir.name != "subprojects") {
+            if (dir != parentDir) {
+                insert(0, ":")
+            }
+            insert(0, dir.name)
+            dir = dir.parentFile
+        }
+    }
+    include(projectName)
+    project(":$projectName").projectDir = parentDir
+}

--- a/subprojects/bounded_context/accessibility/build.gradle.kts
+++ b/subprojects/bounded_context/accessibility/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    domainImplementation(project(":stdlib"))
+
+    outputAdapterImplementation(project(":bounded_context:place", "application"))
+}

--- a/subprojects/bounded_context/accessibility/src/application/kotlin/club/staircrusher/accessibility/application/AccessibilityApplicationService.kt
+++ b/subprojects/bounded_context/accessibility/src/application/kotlin/club/staircrusher/accessibility/application/AccessibilityApplicationService.kt
@@ -1,0 +1,87 @@
+package club.staircrusher.accessibility.application
+
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.accessibility.domain.model.BuildingAccessibilityComment
+import club.staircrusher.accessibility.domain.model.PlaceAccessibility
+import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
+import club.staircrusher.accessibility.domain.repository.BuildingAccessibilityCommentRepository
+import club.staircrusher.accessibility.domain.repository.BuildingAccessibilityRepository
+import club.staircrusher.accessibility.domain.repository.PlaceAccessibilityCommentRepository
+import club.staircrusher.accessibility.domain.repository.PlaceAccessibilityRepository
+import club.staircrusher.accessibility.domain.service.BuildingAccessibilityCommentService
+import club.staircrusher.accessibility.domain.service.BuildingAccessibilityService
+import club.staircrusher.accessibility.domain.service.PlaceAccessibilityCommentService
+import club.staircrusher.accessibility.domain.service.PlaceAccessibilityService
+import club.staircrusher.accessibility.domain.service.PlaceService
+import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+class AccessibilityApplicationService(
+    private val transactionManager: TransactionManager,
+    private val placeService: PlaceService,
+    private val placeAccessibilityRepository: PlaceAccessibilityRepository,
+    private val placeAccessibilityCommentRepository: PlaceAccessibilityCommentRepository,
+    private val buildingAccessibilityRepository: BuildingAccessibilityRepository,
+    private val buildingAccessibilityCommentRepository: BuildingAccessibilityCommentRepository,
+    private val placeAccessibilityService: PlaceAccessibilityService,
+    private val placeAccessibilityCommentService: PlaceAccessibilityCommentService,
+    private val buildingAccessibilityService: BuildingAccessibilityService,
+    private val buildingAccessibilityCommentService: BuildingAccessibilityCommentService,
+) {
+    data class GetAccessibilityResult(
+        val buildingAccessibility: BuildingAccessibility?,
+        val buildingAccessibilityComments: List<BuildingAccessibilityComment>,
+        val placeAccessibility: PlaceAccessibility?,
+        val placeAccessibilityComments: List<PlaceAccessibilityComment>,
+        val hasOtherPlacesToRegisterInSameBuilding: Boolean,
+    )
+
+    fun getAccessibility(placeId: String): GetAccessibilityResult = transactionManager.doInTransaction {
+        val place = placeService.findPlace(placeId) ?: throw IllegalArgumentException("Cannot find place with $placeId")
+        GetAccessibilityResult(
+            buildingAccessibility = buildingAccessibilityRepository.findByBuildingId(place.buildingId),
+            buildingAccessibilityComments = buildingAccessibilityCommentRepository.findByBuildingId(place.buildingId),
+            placeAccessibility = placeAccessibilityRepository.findByPlaceId(placeId),
+            placeAccessibilityComments = placeAccessibilityCommentRepository.findByPlaceId(placeId),
+            hasOtherPlacesToRegisterInSameBuilding = placeAccessibilityRepository.hasAccessibilityNotRegisteredPlaceInBuilding(place.buildingId)
+        )
+    }
+
+    data class RegisterAccessibilityResult(
+        val placeAccessibility: PlaceAccessibility,
+        val placeAccessibilityComment: PlaceAccessibilityComment?,
+        val buildingAccessibility: BuildingAccessibility?,
+        val buildingAccessibilityComment: BuildingAccessibilityComment?,
+    )
+
+    fun register(
+        createPlaceAccessibilityParams: PlaceAccessibilityService.CreateParams,
+        createPlaceAccessibilityCommentParams: PlaceAccessibilityCommentService.CreateParams?,
+        createBuildingAccessibilityParams: BuildingAccessibilityService.CreateParams?,
+        createBuildingAccessibilityCommentParams: BuildingAccessibilityCommentService.CreateParams?,
+    ): RegisterAccessibilityResult = transactionManager.doInTransaction(TransactionIsolationLevel.SERIALIZABLE) {
+        val placeAccessibility = placeAccessibilityService.create(createPlaceAccessibilityParams)
+        val placeAccessibilityComment = createPlaceAccessibilityCommentParams?.let { placeAccessibilityCommentService.create(it) }
+        val buildingAccessibility = createBuildingAccessibilityParams?.let { buildingAccessibilityService.create(it) }
+        val buildingAccessibilityComment = createBuildingAccessibilityCommentParams?.let { buildingAccessibilityCommentService.create(it) }
+
+        RegisterAccessibilityResult(
+            placeAccessibility = placeAccessibility,
+            placeAccessibilityComment = placeAccessibilityComment,
+            buildingAccessibility = buildingAccessibility,
+            buildingAccessibilityComment = buildingAccessibilityComment,
+        )
+    }
+
+    fun registerBuildingAccessibilityComment(
+        params: BuildingAccessibilityCommentService.CreateParams,
+    ): BuildingAccessibilityComment = transactionManager.doInTransaction(TransactionIsolationLevel.SERIALIZABLE) {
+        buildingAccessibilityCommentService.create(params)
+    }
+
+    fun registerPlaceAccessibilityComment(
+        params: PlaceAccessibilityCommentService.CreateParams,
+    ): PlaceAccessibilityComment = transactionManager.doInTransaction(TransactionIsolationLevel.SERIALIZABLE) {
+        placeAccessibilityCommentService.create(params)
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/application/kotlin/club/staircrusher/accessibility/application/BuildingAccessibilityUpvoteApplicationService.kt
+++ b/subprojects/bounded_context/accessibility/src/application/kotlin/club/staircrusher/accessibility/application/BuildingAccessibilityUpvoteApplicationService.kt
@@ -1,0 +1,23 @@
+package club.staircrusher.accessibility.application
+
+import club.staircrusher.accessibility.domain.repository.BuildingAccessibilityRepository
+import club.staircrusher.accessibility.domain.service.BuildingAccessibilityUpvoteService
+import club.staircrusher.stdlib.auth.AuthUser
+import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+class BuildingAccessibilityUpvoteApplicationService(
+    private val transactionManager: TransactionManager,
+    private val buildingAccessibilityRepository: BuildingAccessibilityRepository,
+    private val buildingAccessibilityUpvoteService: BuildingAccessibilityUpvoteService,
+) {
+    fun giveUpvote(authUser: AuthUser, buildingAccessibilityId: String) = transactionManager.doInTransaction(TransactionIsolationLevel.SERIALIZABLE) {
+        val buildingAccessibility = buildingAccessibilityRepository.findById(buildingAccessibilityId)
+        buildingAccessibilityUpvoteService.giveUpvote(authUser, buildingAccessibility)
+    }
+
+    fun cancelUpvote(authUser: AuthUser, buildingAccessibilityId: String) = transactionManager.doInTransaction(TransactionIsolationLevel.SERIALIZABLE) {
+        val buildingAccessibility = buildingAccessibilityRepository.findById(buildingAccessibilityId)
+        buildingAccessibilityUpvoteService.cancelUpvote(authUser, buildingAccessibility)
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/BuildingAccessibility.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/BuildingAccessibility.kt
@@ -1,0 +1,14 @@
+package club.staircrusher.accessibility.domain.model
+
+import java.time.Instant
+
+data class BuildingAccessibility(
+    val id: String,
+    val buildingId: String,
+    val entranceStairInfo: StairInfo,
+    val hasSlope: Boolean,
+    val hasElevator: Boolean,
+    val elevatorStairInfo: StairInfo,
+    val userId: String?,
+    val createdAt: Instant,
+)

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/BuildingAccessibilityComment.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/BuildingAccessibilityComment.kt
@@ -1,0 +1,11 @@
+package club.staircrusher.accessibility.domain.model
+
+import java.time.Instant
+
+data class BuildingAccessibilityComment(
+    val id: String,
+    val buildingId: String,
+    val userId: String?,
+    val comment: String,
+    val createdAt: Instant,
+)

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/BuildingAccessibilityUpvote.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/BuildingAccessibilityUpvote.kt
@@ -1,0 +1,11 @@
+package club.staircrusher.accessibility.domain.model
+
+import java.time.Instant
+
+data class BuildingAccessibilityUpvote(
+    val id: String,
+    val userId: String,
+    val buildingAccessibility: BuildingAccessibility,
+    var createdAt: Instant,
+    var deletedAt: Instant? = null,
+)

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/Place.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/Place.kt
@@ -1,0 +1,9 @@
+package club.staircrusher.accessibility.domain.model
+
+/**
+ * Value Object.
+ */
+data class Place(
+    val id: String,
+    val buildingId: String,
+)

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/PlaceAccessibility.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/PlaceAccessibility.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.accessibility.domain.model
+
+import java.time.Instant
+
+data class PlaceAccessibility(
+    val id: String,
+    val placeId: String,
+    val isFirstFloor: Boolean,
+    val stairInfo: StairInfo,
+    val hasSlope: Boolean,
+    val userId: String?,
+    val createdAt: Instant,
+)

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/PlaceAccessibilityComment.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/PlaceAccessibilityComment.kt
@@ -1,0 +1,11 @@
+package club.staircrusher.accessibility.domain.model
+
+import java.time.Instant
+
+data class PlaceAccessibilityComment(
+    val id: String,
+    val placeId: String,
+    val userId: String?,
+    val comment: String,
+    val createdAt: Instant,
+)

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/StairInfo.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/model/StairInfo.kt
@@ -1,0 +1,9 @@
+package club.staircrusher.accessibility.domain.model
+
+enum class StairInfo {
+    UNDEFINED,
+    NONE,
+    ONE,
+    TWO_TO_FIVE,
+    OVER_SIX,
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/BuildingAccessibilityCommentRepository.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/BuildingAccessibilityCommentRepository.kt
@@ -1,0 +1,9 @@
+package club.staircrusher.accessibility.domain.repository
+
+import club.staircrusher.accessibility.domain.model.BuildingAccessibilityComment
+import club.staircrusher.stdlib.domain.repository.EntityRepository
+
+
+interface BuildingAccessibilityCommentRepository : EntityRepository<BuildingAccessibilityComment, String> {
+    fun findByBuildingId(buildingId: String): List<BuildingAccessibilityComment>
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/BuildingAccessibilityRepository.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/BuildingAccessibilityRepository.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.accessibility.domain.repository
+
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.stdlib.domain.repository.EntityRepository
+import club.staircrusher.stdlib.geography.EupMyeonDong
+
+interface BuildingAccessibilityRepository : EntityRepository<BuildingAccessibility, String> {
+    fun findByBuildingIds(buildingIds: Collection<String>): List<BuildingAccessibility>
+    fun findByBuildingId(buildingId: String): BuildingAccessibility?
+    fun findByPlaceIds(placeIds: Collection<String>): List<BuildingAccessibility>
+    fun findByEupMyeonDong(eupMyeonDong: EupMyeonDong): List<BuildingAccessibility>
+    fun countByUserId(userId: String): Int
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/BuildingAccessibilityUpvoteRepository.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/BuildingAccessibilityUpvoteRepository.kt
@@ -1,0 +1,11 @@
+package club.staircrusher.accessibility.domain.repository
+
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.accessibility.domain.model.BuildingAccessibilityUpvote
+import club.staircrusher.stdlib.domain.repository.EntityRepository
+
+interface BuildingAccessibilityUpvoteRepository : EntityRepository<BuildingAccessibilityUpvote, String> {
+    fun findByUserAndBuildingAccessibilityAndNotDeleted(userId: String, buildingAccessibility: BuildingAccessibility): BuildingAccessibilityUpvote?
+    fun getTotalUpvoteCount(userId: String): Int
+    fun getTotalUpvoteCount(buildingAccessibility: BuildingAccessibility): Int
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/PlaceAccessibilityCommentRepository.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/PlaceAccessibilityCommentRepository.kt
@@ -1,0 +1,8 @@
+package club.staircrusher.accessibility.domain.repository
+
+import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
+import club.staircrusher.stdlib.domain.repository.EntityRepository
+
+interface PlaceAccessibilityCommentRepository : EntityRepository<PlaceAccessibilityComment, String> {
+    fun findByPlaceId(placeId: String): List<PlaceAccessibilityComment>
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/PlaceAccessibilityRepository.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/repository/PlaceAccessibilityRepository.kt
@@ -1,0 +1,17 @@
+package club.staircrusher.accessibility.domain.repository
+
+import club.staircrusher.accessibility.domain.model.PlaceAccessibility
+import club.staircrusher.stdlib.domain.repository.EntityRepository
+import club.staircrusher.stdlib.geography.EupMyeonDong
+
+interface PlaceAccessibilityRepository : EntityRepository<PlaceAccessibility, String> {
+    fun findByPlaceIds(placeIds: Collection<String>): List<PlaceAccessibility>
+    fun findByPlaceId(placeId: String): PlaceAccessibility?
+    fun findByUserId(userId: String): List<PlaceAccessibility>
+    fun countByEupMyeonDong(eupMyeonDong: EupMyeonDong): Int
+    fun countByUserId(userId: String): Int
+    fun countByUserIdGroupByEupMyeonDongId(userId: String): Map<String, Int>
+    fun hasAccessibilityNotRegisteredPlaceInBuilding(buildingId: String): Boolean
+    fun countAll(): Int
+    fun listConquerRankingEntries(): List<Pair<String, Int>>
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/BuildingAccessibilityCommentService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/BuildingAccessibilityCommentService.kt
@@ -1,0 +1,34 @@
+package club.staircrusher.accessibility.domain.service
+
+import club.staircrusher.accessibility.domain.model.BuildingAccessibilityComment
+import club.staircrusher.accessibility.domain.repository.BuildingAccessibilityCommentRepository
+import club.staircrusher.stdlib.domain.DomainException
+import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
+import java.time.Clock
+
+class BuildingAccessibilityCommentService(
+    private val clock: Clock,
+    private val buildingAccessibilityCommentRepository: BuildingAccessibilityCommentRepository,
+) {
+    data class CreateParams(
+        val buildingId: String,
+        val userId: String?,
+        val comment: String,
+    )
+
+    fun create(params: CreateParams): BuildingAccessibilityComment {
+        val normalizedComment = params.comment.trim()
+        if (normalizedComment.isBlank()) {
+            throw DomainException("한 글자 이상의 의견을 제출해주세요.")
+        }
+        return buildingAccessibilityCommentRepository.add(
+            BuildingAccessibilityComment(
+            id = EntityIdGenerator.generateRandom(),
+            buildingId = params.buildingId,
+            userId = params.userId,
+            comment = normalizedComment,
+            createdAt = clock.instant(),
+        )
+        )
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/BuildingAccessibilityCommentService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/BuildingAccessibilityCommentService.kt
@@ -21,14 +21,12 @@ class BuildingAccessibilityCommentService(
         if (normalizedComment.isBlank()) {
             throw DomainException("한 글자 이상의 의견을 제출해주세요.")
         }
-        return buildingAccessibilityCommentRepository.add(
-            BuildingAccessibilityComment(
+        return buildingAccessibilityCommentRepository.add(BuildingAccessibilityComment(
             id = EntityIdGenerator.generateRandom(),
             buildingId = params.buildingId,
             userId = params.userId,
             comment = normalizedComment,
             createdAt = clock.instant(),
-        )
-        )
+        ))
     }
 }

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/BuildingAccessibilityService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/BuildingAccessibilityService.kt
@@ -1,0 +1,44 @@
+package club.staircrusher.accessibility.domain.service
+
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.accessibility.domain.model.StairInfo
+import club.staircrusher.accessibility.domain.repository.BuildingAccessibilityRepository
+import club.staircrusher.stdlib.domain.DomainException
+import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
+import java.time.Clock
+
+class BuildingAccessibilityService(
+    private val clock: Clock,
+    private val buildingAccessibilityRepository: BuildingAccessibilityRepository,
+) {
+    data class CreateParams(
+        val buildingId: String,
+        val entranceStairInfo: StairInfo,
+        val hasSlope: Boolean,
+        val hasElevator: Boolean,
+        val elevatorStairInfo: StairInfo,
+        val userId: String?,
+    )
+
+    fun create(params: CreateParams): BuildingAccessibility {
+        if (buildingAccessibilityRepository.findByBuildingId(params.buildingId) != null) {
+            throw DomainException("이미 접근성 정보가 등록된 건물입니다.")
+        }
+        if (params.hasElevator && params.elevatorStairInfo == StairInfo.UNDEFINED ||
+            !params.hasElevator && params.elevatorStairInfo != StairInfo.UNDEFINED) {
+            throw DomainException("엘레베이터 유무 정보와 엘레베이터까지의 계단 개수 정보가 맞지 않습니다.") // TODO: 테스트 추가
+        }
+        return buildingAccessibilityRepository.add(
+            BuildingAccessibility(
+                id = EntityIdGenerator.generateRandom(),
+                buildingId = params.buildingId,
+                entranceStairInfo = params.entranceStairInfo,
+                hasSlope = params.hasSlope,
+                hasElevator = params.hasElevator,
+                elevatorStairInfo = params.elevatorStairInfo,
+                userId = params.userId,
+                createdAt = clock.instant(),
+            )
+        )
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/BuildingAccessibilityUpvoteService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/BuildingAccessibilityUpvoteService.kt
@@ -1,0 +1,40 @@
+package club.staircrusher.accessibility.domain.service
+
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.accessibility.domain.model.BuildingAccessibilityUpvote
+import club.staircrusher.accessibility.domain.repository.BuildingAccessibilityUpvoteRepository
+import club.staircrusher.stdlib.auth.AuthUser
+import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
+import java.time.Clock
+
+class BuildingAccessibilityUpvoteService(
+    private val clock: Clock,
+    private val buildingAccessibilityUpvoteRepository: BuildingAccessibilityUpvoteRepository,
+) {
+    fun giveUpvote(user: AuthUser, buildingAccessibility: BuildingAccessibility): BuildingAccessibilityUpvote {
+        val existingUpvote = buildingAccessibilityUpvoteRepository.findByUserAndBuildingAccessibilityAndNotDeleted(user.id, buildingAccessibility)
+        if (existingUpvote != null) {
+            return existingUpvote
+        }
+
+        return buildingAccessibilityUpvoteRepository.add(
+            BuildingAccessibilityUpvote(
+            id = EntityIdGenerator.generateRandom(),
+            userId = user.id,
+            buildingAccessibility = buildingAccessibility,
+            createdAt = clock.instant()
+        )
+        )
+    }
+
+    fun cancelUpvote(user: AuthUser, buildingAccessibility: BuildingAccessibility) {
+        buildingAccessibilityUpvoteRepository.findByUserAndBuildingAccessibilityAndNotDeleted(user.id, buildingAccessibility)?.let {
+            it.deletedAt = clock.instant()
+            buildingAccessibilityUpvoteRepository.add(it)
+        }
+    }
+
+    fun isUpvoted(user: AuthUser, buildingAccessibility: BuildingAccessibility): Boolean {
+        return buildingAccessibilityUpvoteRepository.findByUserAndBuildingAccessibilityAndNotDeleted(user.id, buildingAccessibility) != null
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/ConquerRankingService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/ConquerRankingService.kt
@@ -1,0 +1,35 @@
+package club.staircrusher.accessibility.domain.service
+
+import club.staircrusher.accessibility.domain.repository.PlaceAccessibilityRepository
+
+class ConquerRankingService(
+    private val placeAccessibilityRepository: PlaceAccessibilityRepository,
+) {
+    private val registeredCountByUserId = mutableMapOf<String, Int>()
+    private var isInitialized = false
+
+    @Synchronized
+    private fun initIfNot() {
+        if (isInitialized) {
+            return
+        }
+        val rankingEntries = placeAccessibilityRepository.listConquerRankingEntries()
+        rankingEntries.forEach { (userId, registeredCount) ->
+            registeredCountByUserId[userId] = registeredCount
+        }
+        isInitialized = true
+    }
+
+    fun getRanking(userId: String): Int? {
+        initIfNot()
+
+        val registeredCount = registeredCountByUserId[userId] ?: return null
+        return registeredCountByUserId.values.count { it > registeredCount } + 1
+    }
+
+    fun updateRanking(userId: String) {
+        initIfNot()
+
+        registeredCountByUserId[userId] = placeAccessibilityRepository.countByUserId(userId)
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/PlaceAccessibilityCommentService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/PlaceAccessibilityCommentService.kt
@@ -1,0 +1,34 @@
+package club.staircrusher.accessibility.domain.service
+
+import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
+import club.staircrusher.accessibility.domain.repository.PlaceAccessibilityCommentRepository
+import club.staircrusher.stdlib.domain.DomainException
+import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
+import java.time.Clock
+
+class PlaceAccessibilityCommentService(
+    private val clock: Clock,
+    private val placeAccessibilityCommentRepository: PlaceAccessibilityCommentRepository,
+) {
+    data class CreateParams(
+        val placeId: String,
+        val userId: String?,
+        val comment: String,
+    )
+
+    fun create(params: CreateParams): PlaceAccessibilityComment {
+        val normalizedComment = params.comment.trim()
+        if (normalizedComment.isBlank()) {
+            throw DomainException("한 글자 이상의 의견을 제출해주세요.")
+        }
+        return placeAccessibilityCommentRepository.add(
+            PlaceAccessibilityComment(
+            id = EntityIdGenerator.generateRandom(),
+            placeId = params.placeId,
+            userId = params.userId,
+            comment = normalizedComment,
+            createdAt = clock.instant(),
+        )
+        )
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/PlaceAccessibilityService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/PlaceAccessibilityService.kt
@@ -1,0 +1,43 @@
+package club.staircrusher.accessibility.domain.service
+
+import club.staircrusher.accessibility.domain.model.PlaceAccessibility
+import club.staircrusher.accessibility.domain.model.StairInfo
+import club.staircrusher.accessibility.domain.repository.PlaceAccessibilityRepository
+import club.staircrusher.stdlib.domain.DomainException
+import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
+import java.time.Clock
+
+class PlaceAccessibilityService(
+    private val clock: Clock,
+    private val placeAccessibilityRepository: PlaceAccessibilityRepository,
+    private val conquerRankingService: ConquerRankingService,
+) {
+    data class CreateParams(
+        val placeId: String,
+        val isFirstFloor: Boolean,
+        val stairInfo: StairInfo,
+        val hasSlope: Boolean,
+        val userId: String?,
+    )
+
+    fun create(params: CreateParams): PlaceAccessibility {
+        if (placeAccessibilityRepository.findByPlaceId(params.placeId) != null) {
+            throw DomainException("이미 접근성 정보가 등록된 장소입니다.")
+        }
+        val result = placeAccessibilityRepository.add(
+            PlaceAccessibility(
+                id = EntityIdGenerator.generateRandom(),
+                placeId = params.placeId,
+                isFirstFloor = params.isFirstFloor,
+                stairInfo = params.stairInfo,
+                hasSlope = params.hasSlope,
+                userId = params.userId,
+                createdAt = clock.instant(),
+            )
+        )
+
+        params.userId?.let { conquerRankingService.updateRanking(it) }
+
+        return result
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/PlaceService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/PlaceService.kt
@@ -1,0 +1,7 @@
+package club.staircrusher.accessibility.domain.service
+
+import club.staircrusher.accessibility.domain.model.Place
+
+interface PlaceService {
+    fun findPlace(placeId: String): Place?
+}

--- a/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/SearchAccessibilityService.kt
+++ b/subprojects/bounded_context/accessibility/src/domain/kotlin/club/staircrusher/accessibility/domain/service/SearchAccessibilityService.kt
@@ -1,0 +1,40 @@
+package club.staircrusher.accessibility.domain.service
+
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.accessibility.domain.model.Place
+import club.staircrusher.accessibility.domain.model.PlaceAccessibility
+import club.staircrusher.accessibility.domain.repository.BuildingAccessibilityRepository
+import club.staircrusher.accessibility.domain.repository.PlaceAccessibilityRepository
+
+class SearchAccessibilityService(
+    private val placeAccessibilityRepository: PlaceAccessibilityRepository,
+    private val buildingAccessibilityRepository: BuildingAccessibilityRepository,
+) {
+    data class Result(
+        private val places: List<Place>,
+        private val placeAccessibilities: List<PlaceAccessibility>,
+        private val buildingAccessibilities: List<BuildingAccessibility>,
+    ) {
+        private val accessibilityByPlaceId = run {
+            val placeAccessibilityByPlaceId = placeAccessibilities.associateBy { it.placeId }
+            val buildingAccessibilityByBuildingId = buildingAccessibilities.associateBy { it.buildingId }
+            places.map {
+                it.id to Pair(placeAccessibilityByPlaceId[it.id], buildingAccessibilityByBuildingId[it.buildingId])
+            }.toMap()
+        }
+
+        fun getAccessibility(placeId: String): Pair<PlaceAccessibility?, BuildingAccessibility?> {
+            return accessibilityByPlaceId[placeId] ?: throw IllegalArgumentException("search() 메소드의 인자로 넣은 place가 아닙니다.")
+        }
+    }
+
+    fun search(places: List<Place>): Result {
+        val placeAccessibilities = placeAccessibilityRepository.findByPlaceIds(places.map { it.id })
+        val buildingAccessibilities = buildingAccessibilityRepository.findByBuildingIds(places.map { it.buildingId })
+        return Result(
+            places = places,
+            placeAccessibilities = placeAccessibilities,
+            buildingAccessibilities = buildingAccessibilities,
+        )
+    }
+}

--- a/subprojects/bounded_context/accessibility/src/output-adapter/kotlin/club/staircrusher/accessibility/output_adapter/service/InMemoryPlaceService.kt
+++ b/subprojects/bounded_context/accessibility/src/output-adapter/kotlin/club/staircrusher/accessibility/output_adapter/service/InMemoryPlaceService.kt
@@ -1,0 +1,16 @@
+package club.staircrusher.accessibility.output_adapter.service
+
+import club.staircrusher.accessibility.domain.model.Place
+import club.staircrusher.accessibility.domain.service.PlaceService
+import club.staircrusher.place.application.PlaceApplicationService
+
+class InMemoryPlaceService(
+    private val placeApplicationService: PlaceApplicationService,
+) : PlaceService {
+    override fun findPlace(placeId: String): Place? {
+        return placeApplicationService.findPlace(placeId)?.let { Place(
+            id = it.id,
+            buildingId = it.building.id,
+        ) }
+    }
+}

--- a/subprojects/bounded_context/place/build.gradle.kts
+++ b/subprojects/bounded_context/place/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    domainImplementation(project(":stdlib"))
+}

--- a/subprojects/bounded_context/place/src/application/kotlin/club/staircrusher/place/application/PlaceApplicationService.kt
+++ b/subprojects/bounded_context/place/src/application/kotlin/club/staircrusher/place/application/PlaceApplicationService.kt
@@ -1,0 +1,12 @@
+package club.staircrusher.place.application
+
+import club.staircrusher.place.domain.entity.Place
+import club.staircrusher.place.domain.repository.PlaceRepository
+
+class PlaceApplicationService(
+    private val placeRepository: PlaceRepository,
+) {
+    fun findPlace(placeId: String): Place? {
+        return placeRepository.findByIdOrNull(placeId)
+    }
+}

--- a/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/entity/Building.kt
+++ b/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/entity/Building.kt
@@ -1,0 +1,12 @@
+package club.staircrusher.place.domain.entity
+
+import club.staircrusher.stdlib.geography.Location
+
+data class Building(
+    val id: String,
+    val name: String?,
+    val location: Location,
+    val address: BuildingAddress,
+    val siGunGuId: String,
+    val eupMyeonDongId: String,
+)

--- a/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/entity/BuildingAddress.kt
+++ b/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/entity/BuildingAddress.kt
@@ -1,0 +1,26 @@
+package club.staircrusher.place.domain.entity
+
+data class BuildingAddress(
+    val siDo: String,
+    val siGunGu: String,
+    val eupMyeonDong: String,
+    val li: String,
+    val roadName: String,
+    val mainBuildingNumber: String,
+    val subBuildingNumber: String
+) {
+    override fun toString(): String {
+        // refs: https://www.juso.go.kr/CommonPageLink.do?link=/street/GuideBook
+        return buildString {
+            append("$siDo $siGunGu ")
+            if (!eupMyeonDong.endsWith("동")) {
+                append("$eupMyeonDong ")
+            }
+            append("$roadName ")
+            append(mainBuildingNumber)
+            if (subBuildingNumber.isNotBlank() && subBuildingNumber != "0") {
+                append("-$subBuildingNumber")
+            }
+        }
+    }
+}

--- a/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/entity/Place.kt
+++ b/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/entity/Place.kt
@@ -1,0 +1,16 @@
+package club.staircrusher.place.domain.entity
+
+import club.staircrusher.stdlib.geography.Location
+
+data class Place(
+    val id: String,
+    val name: String,
+    val location: Location,
+    val building: Building,
+    val siGunGuId: String,
+    val eupMyeonDongId: String,
+    val category: PlaceCategory? = null,
+) {
+    val address: BuildingAddress
+        get() = building.address
+}

--- a/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/entity/PlaceCategory.kt
+++ b/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/entity/PlaceCategory.kt
@@ -1,0 +1,22 @@
+package club.staircrusher.place.domain.entity
+
+enum class PlaceCategory(val humanReadableName: String) {
+    MARKET(humanReadableName = "대형마트"),
+    CONVENIENCE_STORE(humanReadableName = "편의점"),
+    KINDERGARTEN(humanReadableName = "어린이집, 유치원"),
+    SCHOOL(humanReadableName = "학교"),
+    ACADEMY(humanReadableName = "학원"),
+    PARKING_LOT(humanReadableName = "주차장"),
+    GAS_STATION(humanReadableName = "주유소, 충전소"),
+    SUBWAY_STATION(humanReadableName = "지하철역"),
+    BANK(humanReadableName = "은행"),
+    CULTURAL_FACILITIES(humanReadableName = "화시설"),
+    AGENCY(humanReadableName = "중개업소"),
+    PUBLIC_OFFICE(humanReadableName = "공공기관"),
+    ATTRACTION(humanReadableName = "관광명소"),
+    ACCOMODATION(humanReadableName = "숙박"),
+    RESTAURANT(humanReadableName = "음식점"),
+    CAFE(humanReadableName = "카페"),
+    HOSPITAL(humanReadableName = "병원"),
+    PHARMACY(humanReadableName = "약국"),
+}

--- a/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/repository/BuildingRepository.kt
+++ b/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/repository/BuildingRepository.kt
@@ -1,0 +1,10 @@
+package club.staircrusher.place.domain.repository
+
+import club.staircrusher.stdlib.domain.repository.EntityRepository
+import club.staircrusher.stdlib.geography.EupMyeonDong
+import club.staircrusher.place.domain.entity.Building
+
+interface BuildingRepository : EntityRepository<Building, String> {
+    fun countByEupMyeonDong(eupMyeonDong: EupMyeonDong): Int
+    fun findByIdIn(ids: Collection<String>): List<Building>
+}

--- a/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/repository/PlaceRepository.kt
+++ b/subprojects/bounded_context/place/src/domain/kotlin/club/staircrusher/place/domain/repository/PlaceRepository.kt
@@ -1,0 +1,20 @@
+package club.staircrusher.place.domain.repository
+
+import club.staircrusher.stdlib.domain.repository.EntityRepository
+import club.staircrusher.stdlib.geography.EupMyeonDong
+import club.staircrusher.place.domain.entity.Place
+
+interface PlaceRepository : EntityRepository<Place, String> {
+    fun findByNameContains(searchTextRegex: String): List<Place>
+    /**
+     * fetch join:
+     * - building
+     */
+    fun findByBuildingId(buildingId: String): List<Place>
+    /**
+     * fetch join:
+     * - building
+     */
+    fun findByIdIn(ids: Collection<String>): List<Place>
+    fun countByEupMyeonDong(eupMyeonDong: EupMyeonDong): Int
+}

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/auth/AuthUser.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/auth/AuthUser.kt
@@ -1,0 +1,5 @@
+package club.staircrusher.stdlib.auth
+
+data class AuthUser(
+    val id: String,
+)

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/DomainException.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/DomainException.kt
@@ -1,0 +1,3 @@
+package club.staircrusher.stdlib.domain
+
+class DomainException(val msg: String) : RuntimeException(msg)

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/entity/EntityIdGenerator.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/entity/EntityIdGenerator.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.stdlib.domain.entity
+
+import java.util.UUID
+
+object EntityIdGenerator {
+    fun generateRandom(): String {
+        return UUID.randomUUID().toString()
+    }
+
+    fun generateFixed(key: String): String {
+        return UUID.nameUUIDFromBytes(key.toByteArray()).toString()
+    }
+}

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/repository/EntityRepository.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/repository/EntityRepository.kt
@@ -1,0 +1,8 @@
+package club.staircrusher.stdlib.domain.repository
+
+interface EntityRepository<ENTITY, ID> {
+    fun add(entity: ENTITY): ENTITY
+    fun removeAll()
+    fun findById(id: ID): ENTITY
+    fun findByIdOrNull(id: ID): ENTITY?
+}

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/EupMyeonDong.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/EupMyeonDong.kt
@@ -1,0 +1,8 @@
+package club.staircrusher.stdlib.geography
+
+// SiGunGu는 DB에 저장하지 않고 TSV를 파싱해서 in-memory로 관리한다.
+data class EupMyeonDong(
+    val id: String,
+    val name: String,
+    val siGunGu: SiGunGu,
+)

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/Location.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/Location.kt
@@ -1,0 +1,6 @@
+package club.staircrusher.stdlib.geography
+
+data class Location(
+    val lng: Double,
+    val lat: Double,
+)

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/SiGunGu.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/SiGunGu.kt
@@ -1,0 +1,9 @@
+package club.staircrusher.stdlib.geography
+
+// SiGunGu는 DB에 저장하지 않고 TSV를 파싱해서 in-memory로 관리한다.
+data class SiGunGu(
+    val id: String,
+    val name: String,
+    // 시도는 굳이 엔티티로 만들 필요가 없어서 string으로 대체한다.
+    val sido: String,
+)

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/TransactionIsolationLevel.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/TransactionIsolationLevel.kt
@@ -1,0 +1,15 @@
+package club.staircrusher.stdlib.persistence
+
+import java.sql.Connection
+
+enum class TransactionIsolationLevel {
+    REPEATABLE_READ {
+        override fun toConnectionIsolationLevel() = Connection.TRANSACTION_REPEATABLE_READ
+    },
+    SERIALIZABLE {
+        override fun toConnectionIsolationLevel() = Connection.TRANSACTION_SERIALIZABLE
+    },
+    ;
+
+    abstract fun toConnectionIsolationLevel(): Int
+}

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/TransactionManager.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/TransactionManager.kt
@@ -1,0 +1,11 @@
+package club.staircrusher.stdlib.persistence
+
+interface TransactionManager {
+    fun <T> doInTransaction(block: () -> T): T
+    fun <T> doInTransaction(isolationLevel: TransactionIsolationLevel, block: () -> T): T
+
+    /**
+     * 테스트용 메소드.
+     */
+    fun doAndRollback(block: () -> Any)
+}


### PR DESCRIPTION
- bounded context 관련 gradle module, source set 구조 확립
  - bounded context 별로 gradle module을 나누고, 각 gradle module 내에 domain / application / input-adapter / output-adapter source set이 존재하도록 gradle을 설정합니다.
  - adapter -> application -> domain의 의존성을 가집니다.
  - application / input-adapter / output-adapter는 다른 module이 의존할 수 있도록 output을 노출하고, domain은 노출하지 않습니다.
    - application - 바운디드 컨텍스트 사이에 의존이 있을 수 있으므로 노출합니다.
    - input-adapter / output-adapter - packaging 모듈에서 의존해야 하므로 노출합니다.
- accessibility bounded context 옮기기
  - 기존 accessibility bounded context를 domain / application 까지만 옮깁니다. input-adapter는 protocol buffer에 의존해서 일단 옮기지 않습니다(swagger로 마이그레이션 예정).
  - accessibility 바운디드 컨텍스트를 옮길 때 필요한 일부 코드들도 함께 옮겼는데, gradle module 구조 등은 제 임의로 정했으니 확인하시고 코멘트 부탁드려용
  - 테스트는 아직 안 옮겼습니다 ㅜㅜ koin이라는 이상한 라이브러리를 쓰는 관계로...