### PR TITLE
API 구현하기 - 2 & Spring Security 붙이기

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,10 @@ subprojects {
     dependencies {
         val jUnitJupiterVersion: String by project
         testImplementation("org.junit.jupiter:junit-jupiter:$jUnitJupiterVersion")
+
+        if (project.name == "infra") {
+            implementation(project(":spring-web"))
+        }
     }
 
     tasks.test {

--- a/subprojects/api/scc-api/api-spec.yaml
+++ b/subprojects/api/scc-api/api-spec.yaml
@@ -28,10 +28,10 @@ paths:
                 - nickname
                 - password
       responses:
-        '201':
+        '204':
           description: |
             빈 response body를 내려준다.
-            대신 Header의 X-OURMAP-ACCESS-KEY에 access token을 내려준다. (회원가입하면 자동 로그인)
+            대신 Header의 X-SCC-ACCESS-KEY에 access token을 내려준다. (회원가입하면 자동 로그인)
             클라이언트는 이 토큰을 Bearer auth의 토큰으로 사용하면 된다.
 
   /login:
@@ -55,7 +55,7 @@ paths:
         '204':
           description: |
             빈 response body를 내려준다.
-            대신 Header의 X-OURMAP-ACCESS-KEY에 access token을 내려준다. (회원가입하면 자동 로그인)
+            대신 Header의 X-SCC-ACCESS-KEY에 access token을 내려준다. (회원가입하면 자동 로그인)
             클라이언트는 이 토큰을 Bearer auth의 토큰으로 사용하면 된다.
 
   /listAdministrativeAreas:

--- a/subprojects/api/scc-api/api-spec.yaml
+++ b/subprojects/api/scc-api/api-spec.yaml
@@ -417,6 +417,8 @@ paths:
                 properties:
                   user:
                     $ref: '#/components/schemas/User'
+                required:
+                  - user
 
 components:
    # Reusable schemas (data models)

--- a/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/user/UserApplicationService.kt
+++ b/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/user/UserApplicationService.kt
@@ -6,7 +6,9 @@ import club.staircrusher.user.domain.entity.User
 import club.staircrusher.user.domain.repository.UserRepository
 import club.staircrusher.user.domain.service.UserAuthService
 import club.staircrusher.user.domain.service.UserService
+import org.springframework.stereotype.Component
 
+@Component
 class UserApplicationService(
     private val transactionManager: TransactionManager,
     private val userRepository: UserRepository,

--- a/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/user/UserAuthApplicationService.kt
+++ b/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/user/UserAuthApplicationService.kt
@@ -4,15 +4,18 @@ import club.staircrusher.stdlib.persistence.TransactionManager
 import club.staircrusher.user.domain.repository.UserRepository
 import club.staircrusher.user.domain.service.UserAuthService
 import club.staircrusher.user.domain.exception.UserAuthenticationException
+import org.springframework.stereotype.Component
 import java.sql.SQLException
 
+@Component
 class UserAuthApplicationService(
     private val transactionManager: TransactionManager,
     private val userRepository: UserRepository,
     private val userAuthService: UserAuthService,
 ) {
     // User ID를 반환한다.
-    fun verify(accessToken: String): String = transactionManager.doInTransaction {
+    fun verify(accessToken: String?): String = transactionManager.doInTransaction {
+        accessToken ?: throw UserAuthenticationException()
         val userId = userAuthService.verifyAccessToken(accessToken).userId
         try {
             userRepository.findById(userId)

--- a/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/service/UserAuthService.kt
+++ b/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/service/UserAuthService.kt
@@ -26,6 +26,7 @@ class UserAuthService(
         ))
     }
 
+    @Throws(TokenVerificationException::class)
     fun verifyAccessToken(token: String): UserAccessTokenPayload {
         return try {
             tokenManager.verify(token, UserAccessTokenPayload::class)

--- a/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/service/UserAuthService.kt
+++ b/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/service/UserAuthService.kt
@@ -4,7 +4,9 @@ import club.staircrusher.stdlib.domain.DomainException
 import club.staircrusher.user.domain.entity.User
 import club.staircrusher.user.domain.repository.UserRepository
 import club.staircrusher.user.domain.exception.UserAuthenticationException
+import org.springframework.stereotype.Component
 
+@Component
 class UserAuthService(
     private val tokenManager: TokenManager,
     private val userRepository: UserRepository,

--- a/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/service/UserService.kt
+++ b/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/service/UserService.kt
@@ -4,8 +4,10 @@ import club.staircrusher.stdlib.domain.DomainException
 import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.user.domain.entity.User
 import club.staircrusher.user.domain.repository.UserRepository
+import org.springframework.stereotype.Component
 import java.time.Clock
 
+@Component
 class UserService(
     private val clock: Clock,
     private val userRepository: UserRepository,

--- a/subprojects/bounded_context/user/infra/build.gradle.kts
+++ b/subprojects/bounded_context/user/infra/build.gradle.kts
@@ -1,5 +1,13 @@
+plugins {
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+}
+
 dependencies {
     implementation("at.favre.lib:bcrypt:0.9.0")
     implementation("com.auth0:java-jwt:3.18.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.11.0")
+
+    api(project(":api"))
+    implementation("org.springframework.boot:spring-boot-starter-web")
 }

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/AuthController.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/AuthController.kt
@@ -2,6 +2,7 @@ package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.LoginPostRequest
 import club.staircrusher.api.spec.dto.SignUpPostRequest
+import club.staircrusher.spring_web.SccSecurityConfig.Companion.accessTokenHeader
 import club.staircrusher.user.application.user.UserApplicationService
 import club.staircrusher.user.application.user.UserAuthApplicationService
 import org.springframework.http.HttpRequest
@@ -39,9 +40,5 @@ class AuthController(
             .noContent()
             .header(accessTokenHeader, result.accessToken)
             .build()
-    }
-
-    companion object {
-        private const val accessTokenHeader = "X-SCC-ACCESS-KEY"
     }
 }

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/AuthController.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/AuthController.kt
@@ -1,0 +1,47 @@
+package club.staircrusher.user.infra.adapter.`in`.controller
+
+import club.staircrusher.api.spec.dto.LoginPostRequest
+import club.staircrusher.api.spec.dto.SignUpPostRequest
+import club.staircrusher.user.application.user.UserApplicationService
+import club.staircrusher.user.application.user.UserAuthApplicationService
+import org.springframework.http.HttpRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthController(
+    private val userApplicationService: UserApplicationService,
+    private val userAuthApplicationService: UserAuthApplicationService,
+) {
+    @PostMapping("/signUp")
+    fun signUp(@RequestBody request: SignUpPostRequest): ResponseEntity<Unit> {
+        val result = userApplicationService.signUp(
+            nickname = request.nickname,
+            password = request.password,
+            instagramId = request.instagramId,
+        )
+        return ResponseEntity
+            .noContent()
+            .header(accessTokenHeader, result.accessToken)
+            .build()
+    }
+
+    @PostMapping("/login")
+    fun login(@RequestBody request: LoginPostRequest, httpRequest: HttpRequest): ResponseEntity<Unit> {
+        val accessToken = httpRequest.headers.getFirst(accessTokenHeader)
+        val result = userApplicationService.login(
+            nickname = request.nickname,
+            password = request.password,
+        )
+        return ResponseEntity
+            .noContent()
+            .header(accessTokenHeader, result.accessToken)
+            .build()
+    }
+
+    companion object {
+        private const val accessTokenHeader = "X-SCC-ACCESS-KEY"
+    }
+}

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
@@ -1,0 +1,27 @@
+package club.staircrusher.user.infra.adapter.`in`.controller
+
+import club.staircrusher.api.spec.dto.UpdateUserInfoPost200Response
+import club.staircrusher.api.spec.dto.UpdateUserInfoPostRequest
+import club.staircrusher.spring_web.app.SccAppAuthentication
+import club.staircrusher.user.application.user.UserApplicationService
+import club.staircrusher.user.infra.adapter.`in`.converter.toDTO
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class UserController(
+    private val userApplicationService: UserApplicationService,
+) {
+    @PostMapping("/updateUserInfo")
+    fun updateUserInfo(@RequestBody request: UpdateUserInfoPostRequest, authentication: SccAppAuthentication): UpdateUserInfoPost200Response {
+        val updatedUser = userApplicationService.updateUserInfo(
+            userId = authentication.principal,
+            nickname = request.nickname,
+            instagramId = request.instagramId,
+        )
+        return UpdateUserInfoPost200Response(
+            user = updatedUser.toDTO(),
+        )
+    }
+}

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/converter/UserConverter.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/converter/UserConverter.kt
@@ -1,0 +1,9 @@
+package club.staircrusher.user.infra.adapter.`in`.converter
+
+import club.staircrusher.user.domain.entity.User
+
+fun User.toDTO() = club.staircrusher.api.spec.dto.User(
+    id = id,
+    nickname = nickname,
+    instagramId = instagramId,
+)

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/NoopUserRepository.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/NoopUserRepository.kt
@@ -5,7 +5,7 @@ import club.staircrusher.user.domain.repository.UserRepository
 import org.springframework.stereotype.Component
 
 @Component
-class NoopUserRepository : UserRepository {
+class NoOpUserRepository : UserRepository {
     override fun findByNickname(nickname: String): User? {
         return null
     }

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/NoopUserRepository.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/NoopUserRepository.kt
@@ -1,0 +1,36 @@
+package club.staircrusher.user.infra.adapter.out.persistence
+
+import club.staircrusher.user.domain.entity.User
+import club.staircrusher.user.domain.repository.UserRepository
+import org.springframework.stereotype.Component
+
+@Component
+class NoopUserRepository : UserRepository {
+    override fun findByNickname(nickname: String): User? {
+        return null
+    }
+
+    override fun findByIdIn(ids: List<String>): List<User> {
+        return emptyList()
+    }
+
+    override fun save(entity: User): User {
+        return entity
+    }
+
+    override fun saveAll(entity: Collection<User>): User {
+        return entity.first()
+    }
+
+    override fun removeAll() {
+        // No-op
+    }
+
+    override fun findById(id: String): User {
+        throw IllegalArgumentException("User of id $id does not exist.")
+    }
+
+    override fun findByIdOrNull(id: String): User? {
+        return null
+    }
+}

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/service/BCryptPasswordEncryptor.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/service/BCryptPasswordEncryptor.kt
@@ -2,7 +2,9 @@ package club.staircrusher.user.infra.service
 
 import at.favre.lib.crypto.bcrypt.BCrypt
 import club.staircrusher.user.domain.service.PasswordEncryptor
+import org.springframework.stereotype.Component
 
+@Component
 object BCryptPasswordEncryptor : PasswordEncryptor {
     private val bcrypt = BCrypt.withDefaults()
     private val verifier = BCrypt.verifyer()

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/service/JWTTokenManager.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/service/JWTTokenManager.kt
@@ -4,13 +4,15 @@ import club.staircrusher.user.domain.service.TokenManager
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.springframework.stereotype.Component
 import java.time.Clock
 import java.time.Duration
 import java.util.Date
 import kotlin.reflect.KClass
 
+@Component
 class JWTTokenManager(
-    secret: String,
+    secret: String = "secret",
     private val clock: Clock,
 ) : TokenManager {
     private val objectMapper = jacksonObjectMapper()

--- a/subprojects/packaging/build.gradle.kts
+++ b/subprojects/packaging/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
+
+    implementation(project(":spring-web"))
 }

--- a/subprojects/spring-web/build.gradle.kts
+++ b/subprojects/spring-web/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+}
+
+dependencies {
+    implementation(project(":bounded_context:user:application"))
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    api("org.springframework.boot:spring-boot-starter-security")
+
+    testImplementation(project(":bounded_context:user:infra"))
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/SccSecurityConfig.kt
+++ b/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/SccSecurityConfig.kt
@@ -1,0 +1,33 @@
+package club.staircrusher.spring_web
+
+import club.staircrusher.spring_web.app.SccAppAccessTokenFilter
+import club.staircrusher.spring_web.app.SccAppAuthenticationFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
+
+@Configuration
+open class SccSecurityConfig {
+    @Bean
+    open fun filterChain(
+        http: HttpSecurity,
+        sccAppAccessTokenFilter: SccAppAccessTokenFilter,
+        sccAppAuthenticationFilter: SccAppAuthenticationFilter,
+    ): SecurityFilterChain {
+        val result = http
+            .addFilterAfter(sccAppAccessTokenFilter, BasicAuthenticationFilter::class.java)
+            .addFilterAfter(sccAppAuthenticationFilter, SccAppAccessTokenFilter::class.java)
+            .authorizeRequests {
+                it
+                    .antMatchers("/updateUserInfo").authenticated()
+            }
+            .build()
+        return result
+    }
+
+    companion object {
+        const val accessTokenHeader = "X-SCC-ACCESS-KEY"
+    }
+}

--- a/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAccessTokenFilter.kt
+++ b/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAccessTokenFilter.kt
@@ -1,0 +1,24 @@
+package club.staircrusher.spring_web.app
+
+import club.staircrusher.spring_web.SccSecurityConfig.Companion.accessTokenHeader
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class SccAppAccessTokenFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val accessToken = request.getHeader(accessTokenHeader)
+        if (accessToken != null) {
+            SecurityContextHolder.getContext().authentication = SccAppAuthentication(accessToken = accessToken)
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthentication.kt
+++ b/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthentication.kt
@@ -1,0 +1,48 @@
+package club.staircrusher.spring_web.app
+
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.CredentialsContainer
+import org.springframework.security.core.GrantedAuthority
+
+class SccAppAuthentication(
+    private var accessToken: String?,
+) : Authentication, CredentialsContainer {
+    private var userId: String? = null
+
+    override fun getName(): String? {
+        return null
+    }
+
+    override fun getAuthorities(): Collection<GrantedAuthority> {
+        return emptyList()
+    }
+
+    override fun getCredentials(): String? {
+        return accessToken
+    }
+
+    override fun getDetails() {
+    }
+
+    override fun getPrincipal(): String {
+        return userId ?: "Not authenticated yet."
+    }
+
+    override fun isAuthenticated(): Boolean {
+        return userId != null
+    }
+
+    override fun setAuthenticated(isAuthenticated: Boolean) {
+        throw IllegalArgumentException("Do not explicitly call this method. Call setUserInfo() instead.")
+    }
+
+    fun setUserInfo(userId: String) {
+        this.userId = userId
+    }
+
+    override fun eraseCredentials() {
+        // https://docs.spring.io/spring-security/reference/servlet/authentication/architecture.html#servlet-authentication-authentication
+        // authentication이 올바르게 처리되면 credential을 날려준다.
+        accessToken = null
+    }
+}

--- a/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthenticationArgumentResolver.kt
+++ b/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthenticationArgumentResolver.kt
@@ -1,0 +1,27 @@
+package club.staircrusher.spring_web.app
+
+import org.springframework.core.MethodParameter
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class SccAppAuthenticationArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.parameterType == SccAppAuthentication::class.java
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): SccAppAuthentication {
+        return SecurityContextHolder.getContext().authentication as? SccAppAuthentication
+            ?: throw AuthenticationCredentialsNotFoundException("Cannot resolve SccAppAuthentication from SecurityContext.")
+    }
+}

--- a/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthenticationFilter.kt
+++ b/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthenticationFilter.kt
@@ -1,0 +1,21 @@
+package club.staircrusher.spring_web.app
+
+import club.staircrusher.spring_web.SccSecurityConfig
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationConverter
+import org.springframework.security.web.authentication.AuthenticationFilter
+import org.springframework.stereotype.Component
+
+@Component
+class SccAppAuthenticationFilter(
+    sccAppAuthenticationManager: SccAppAuthenticationManager,
+) : AuthenticationFilter(
+    sccAppAuthenticationManager,
+    object : AuthenticationConverter {
+        override fun convert(request: HttpServletRequest): Authentication? {
+            val accessToken = request.getHeader(SccSecurityConfig.accessTokenHeader) ?: return null
+            return SccAppAuthentication(accessToken = accessToken)
+        }
+    }
+)

--- a/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthenticationManager.kt
+++ b/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthenticationManager.kt
@@ -1,0 +1,10 @@
+package club.staircrusher.spring_web.app
+
+import club.staircrusher.user.domain.service.UserAuthService
+import org.springframework.security.authentication.ProviderManager
+import org.springframework.stereotype.Component
+
+@Component
+class SccAppAuthenticationManager(
+    userAuthService: UserAuthService
+) : ProviderManager(SccAppAuthenticationProvider(userAuthService))

--- a/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthenticationProvider.kt
+++ b/subprojects/spring-web/src/main/kotlin/club/staircrusher/spring_web/app/SccAppAuthenticationProvider.kt
@@ -1,0 +1,33 @@
+package club.staircrusher.spring_web.app
+
+import club.staircrusher.user.domain.service.TokenVerificationException
+import club.staircrusher.user.domain.service.UserAuthService
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.security.authentication.AuthenticationProvider
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.core.Authentication
+
+class SccAppAuthenticationProvider(
+    private val userAuthService: UserAuthService,
+) : AuthenticationProvider {
+    override fun authenticate(authentication: Authentication): Authentication {
+        val sccAppAuthentication = authentication as SccAppAuthentication
+        if (authentication.isAuthenticated) {
+            return authentication
+        }
+
+        val accessToken = sccAppAuthentication.credentials ?: throw AuthenticationCredentialsNotFoundException("Access token does not exist.")
+        val tokenPayload = try {
+            userAuthService.verifyAccessToken(accessToken)
+        } catch (e: TokenVerificationException) {
+            throw BadCredentialsException("Invalid access token.")
+        }
+
+        sccAppAuthentication.setUserInfo(tokenPayload.userId)
+        return sccAppAuthentication
+    }
+
+    override fun supports(authentication: Class<*>): Boolean {
+        return SccAppAuthentication::class.java.isAssignableFrom(authentication)
+    }
+}

--- a/subprojects/spring-web/src/test/kotlin/club/staircrusher/spring_web/SccAppSecurityConfigTest.kt
+++ b/subprojects/spring-web/src/test/kotlin/club/staircrusher/spring_web/SccAppSecurityConfigTest.kt
@@ -1,0 +1,64 @@
+package club.staircrusher.spring_web
+
+import club.staircrusher.spring_web.app.SccAppAuthentication
+import club.staircrusher.user.domain.entity.User
+import club.staircrusher.user.domain.service.UserAuthService
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Clock
+import java.time.Instant
+
+@SpringBootApplication(scanBasePackages = ["club.staircrusher"])
+open class SccAppSecurityConfigTestApplication {
+    @Bean
+    open fun clock(): Clock {
+        return Clock.systemUTC()
+    }
+}
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SccAppSecurityConfigTest {
+    @Autowired
+    lateinit var userAuthService: UserAuthService
+
+    @Autowired
+    lateinit var mvc: MockMvc
+
+    @Test
+    fun test() {
+        val userId = "userId"
+        val accessToken = userAuthService.issueAccessToken(
+            User(
+                id = userId,
+                nickname = "",
+                encryptedPassword = "",
+                instagramId = null,
+                createdAt = Instant.now()
+            )
+        )
+        mvc.get("/echoUserId") {
+            header(SccSecurityConfig.accessTokenHeader, accessToken)
+        }.andExpect {
+            content {
+                string(userId)
+            }
+        }
+    }
+}
+
+@RestController
+class EchoUserIdController {
+    @GetMapping("/echoUserId")
+    fun echoUserId(authentication: SccAppAuthentication): String {
+        return authentication.principal
+    }
+}


### PR DESCRIPTION
- /signUp, /login, /updateUserInfo API를 구현합니다.
- 인증 쪽 구현하다 보니 Spring Security를 붙이는 게 좋을 것 같아서 붙였습니다.
  - SccAppAccessTokenFilter가 SecurityContextHolder에 SccAppAuthentication을 넣고, SccAppAuthenticationFilter가 SccAppAuthentication을 활용해서 인증하는 구조입니다.
  - 기본적으로 API들은 인증이 필요 없고, 일부 API에만 인증이 적용됩니다.