### PR TITLE
디버깅을 위해 exception이 던져질 시 에러 메세지 무조건 노출하기

### DIFF
--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
@@ -14,7 +14,7 @@ import club.staircrusher.accessibility.domain.model.PlaceAccessibility
 import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
 import club.staircrusher.accessibility.domain.model.StairInfo
 import club.staircrusher.stdlib.di.annotation.Component
-import club.staircrusher.stdlib.domain.DomainException
+import club.staircrusher.stdlib.domain.SccDomainException
 import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
 import club.staircrusher.stdlib.persistence.TransactionManager
@@ -121,7 +121,7 @@ class AccessibilityApplicationService(
         createBuildingAccessibilityCommentParams: BuildingAccessibilityCommentRepository.CreateParams?,
     ): RegisterAccessibilityResult = transactionManager.doInTransaction(TransactionIsolationLevel.REPEATABLE_READ) {
         if (placeAccessibilityRepository.findByPlaceId(createPlaceAccessibilityParams.placeId) != null) {
-            throw DomainException("이미 접근성 정보가 등록된 장소입니다.")
+            throw SccDomainException("이미 접근성 정보가 등록된 장소입니다.")
         }
         val result = placeAccessibilityRepository.save(
             PlaceAccessibility(
@@ -137,7 +137,7 @@ class AccessibilityApplicationService(
         val placeAccessibilityComment = createPlaceAccessibilityCommentParams?.let {
             val normalizedComment = it.comment.trim()
             if (normalizedComment.isBlank()) {
-                throw DomainException("한 글자 이상의 의견을 제출해주세요.")
+                throw SccDomainException("한 글자 이상의 의견을 제출해주세요.")
             }
             placeAccessibilityCommentRepository.save(
                 PlaceAccessibilityComment(
@@ -151,13 +151,13 @@ class AccessibilityApplicationService(
         }
         val buildingAccessibility = createBuildingAccessibilityParams?.let {
             if (buildingAccessibilityRepository.findByBuildingId(it.buildingId) != null) {
-                throw DomainException("이미 접근성 정보가 등록된 건물입니다.")
+                throw SccDomainException("이미 접근성 정보가 등록된 건물입니다.")
             }
             if (
                 it.hasElevator && it.elevatorStairInfo == StairInfo.UNDEFINED ||
                 !it.hasElevator && it.elevatorStairInfo != StairInfo.UNDEFINED
             ) {
-                throw DomainException("엘레베이터 유무 정보와 엘레베이터까지의 계단 개수 정보가 맞지 않습니다.") // TODO: 테스트 추가
+                throw SccDomainException("엘레베이터 유무 정보와 엘레베이터까지의 계단 개수 정보가 맞지 않습니다.") // TODO: 테스트 추가
             }
             buildingAccessibilityRepository.save(
                 BuildingAccessibility(
@@ -175,7 +175,7 @@ class AccessibilityApplicationService(
         val buildingAccessibilityComment = createBuildingAccessibilityCommentParams?.let {
             val normalizedComment = it.comment.trim()
             if (normalizedComment.isBlank()) {
-                throw DomainException("한 글자 이상의 의견을 제출해주세요.")
+                throw SccDomainException("한 글자 이상의 의견을 제출해주세요.")
             }
             buildingAccessibilityCommentRepository.save(
                 BuildingAccessibilityComment(
@@ -203,7 +203,7 @@ class AccessibilityApplicationService(
     ): WithUserInfo<BuildingAccessibilityComment> = transactionManager.doInTransaction(TransactionIsolationLevel.REPEATABLE_READ) {
         val normalizedComment = params.comment.trim()
         if (normalizedComment.isBlank()) {
-            throw DomainException("한 글자 이상의 의견을 제출해주세요.")
+            throw SccDomainException("한 글자 이상의 의견을 제출해주세요.")
         }
         val comment = buildingAccessibilityCommentRepository.save(
             BuildingAccessibilityComment(
@@ -225,7 +225,7 @@ class AccessibilityApplicationService(
     ): WithUserInfo<PlaceAccessibilityComment> = transactionManager.doInTransaction(TransactionIsolationLevel.REPEATABLE_READ) {
         val normalizedComment = params.comment.trim()
         if (normalizedComment.isBlank()) {
-            throw DomainException("한 글자 이상의 의견을 제출해주세요.")
+            throw SccDomainException("한 글자 이상의 의견을 제출해주세요.")
         }
         val comment = placeAccessibilityCommentRepository.save(
             PlaceAccessibilityComment(

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityCommentController.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityCommentController.kt
@@ -7,7 +7,7 @@ import club.staircrusher.api.spec.dto.RegisterBuildingAccessibilityCommentPost20
 import club.staircrusher.api.spec.dto.RegisterBuildingAccessibilityCommentPostRequest
 import club.staircrusher.api.spec.dto.RegisterPlaceAccessibilityCommentPost200Response
 import club.staircrusher.api.spec.dto.RegisterPlaceAccessibilityCommentPostRequest
-import club.staircrusher.spring_web.authentication.app.SccAppAuthentication
+import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityController.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityController.kt
@@ -7,7 +7,7 @@ import club.staircrusher.api.spec.dto.GetAccessibilityPost200Response
 import club.staircrusher.api.spec.dto.GetAccessibilityPostRequest
 import club.staircrusher.api.spec.dto.RegisterAccessibilityPost200Response
 import club.staircrusher.api.spec.dto.RegisterAccessibilityPostRequest
-import club.staircrusher.spring_web.authentication.app.SccAppAuthentication
+import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityUpvoteController.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityUpvoteController.kt
@@ -2,7 +2,7 @@ package club.staircrusher.accessibility.infra.adapter.`in`.controller
 
 import club.staircrusher.accessibility.application.port.`in`.BuildingAccessibilityUpvoteApplicationService
 import club.staircrusher.api.spec.dto.GiveBuildingAccessibilityUpvotePostRequest
-import club.staircrusher.spring_web.authentication.app.SccAppAuthentication
+import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody

--- a/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -54,7 +54,7 @@ class KakaoMapsService(
             .baseUrl("https://dapi.kakao.com")
             .clientConnector(ReactorClientHttpConnector(httpClient))
             .codecs { it.defaultCodecs().kotlinSerializationJsonDecoder(decoder) }
-            .defaultHeaders { it.add(HttpHeaders.AUTHORIZATION, "KakaoAK $kakaoProperties") }
+            .defaultHeaders { it.add(HttpHeaders.AUTHORIZATION, "KakaoAK ${kakaoProperties.apiKey}") }
             .defaultStatusHandler(HttpStatusCode::isError) { response ->
                 response
                     .bodyToMono(KakaoError::class.java)

--- a/subprojects/bounded_context/place_search/infra/src/main/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/ConqueredPlaceController.kt
+++ b/subprojects/bounded_context/place_search/infra/src/main/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/ConqueredPlaceController.kt
@@ -2,7 +2,7 @@ package club.staircrusher.place_search.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.PlaceListItem
 import club.staircrusher.place_search.application.port.`in`.ListConqueredPlacesQuery
-import club.staircrusher.spring_web.authentication.app.SccAppAuthentication
+import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 

--- a/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
+++ b/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
@@ -1,7 +1,7 @@
 package club.staircrusher.user.application.port.`in`
 
 import club.staircrusher.stdlib.di.annotation.Component
-import club.staircrusher.stdlib.domain.DomainException
+import club.staircrusher.stdlib.domain.SccDomainException
 import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
 import club.staircrusher.stdlib.persistence.TransactionManager
@@ -31,10 +31,10 @@ class UserApplicationService(
         )
         val normalizedNickname = params.nickname.trim()
         if (normalizedNickname.length < 2) {
-            throw DomainException("최소 2자 이상의 닉네임을 설정해주세요.")
+            throw SccDomainException("최소 2자 이상의 닉네임을 설정해주세요.")
         }
         if (userRepository.findByNickname(normalizedNickname) != null) {
-            throw DomainException("${normalizedNickname}은 이미 사용 중인 닉네임입니다.")
+            throw SccDomainException("${normalizedNickname}은 이미 사용 중인 닉네임입니다.")
         }
         val user = userRepository.save(
             User(
@@ -53,9 +53,9 @@ class UserApplicationService(
         nickname: String,
         password: String
     ): LoginResult = transactionManager.doInTransaction {
-        val user = userRepository.findByNickname(nickname) ?: throw DomainException("잘못된 계정 아이디입니다.")
+        val user = userRepository.findByNickname(nickname) ?: throw SccDomainException("잘못된 계정 아이디입니다.")
         if (!passwordEncryptor.verify(password, user.encryptedPassword)) {
-            throw DomainException("잘못된 비밀번호입니다.")
+            throw SccDomainException("잘못된 비밀번호입니다.")
         }
         val accessToken = userAuthService.issueAccessToken(user)
         LoginResult(user, accessToken)
@@ -75,10 +75,10 @@ class UserApplicationService(
         user.nickname = run {
             val normalizedNickname = nickname.trim()
             if (normalizedNickname.length < 2) {
-                throw DomainException("최소 2자 이상의 닉네임을 설정해주세요.")
+                throw SccDomainException("최소 2자 이상의 닉네임을 설정해주세요.")
             }
             if (userRepository.findByNickname(normalizedNickname)?.takeIf { it.id != user.id } != null) {
-                throw DomainException("${normalizedNickname}은 이미 사용 중인 닉네임입니다.")
+                throw SccDomainException("${normalizedNickname}은 이미 사용 중인 닉네임입니다.")
             }
             normalizedNickname
         }

--- a/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/LoginTest.kt
+++ b/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/LoginTest.kt
@@ -1,7 +1,7 @@
 package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.LoginPostRequest
-import club.staircrusher.spring_web.authentication.SccSecurityFilterChainConfig
+import club.staircrusher.spring_web.security.SccSecurityFilterChainConfig
 import club.staircrusher.user.infra.adapter.`in`.controller.base.UserITBase
 import org.junit.jupiter.api.Test
 import kotlin.random.Random

--- a/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/SignUpTest.kt
+++ b/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/SignUpTest.kt
@@ -1,7 +1,7 @@
 package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.SignUpPostRequest
-import club.staircrusher.spring_web.authentication.SccSecurityFilterChainConfig
+import club.staircrusher.spring_web.security.SccSecurityFilterChainConfig
 import club.staircrusher.user.infra.adapter.`in`.controller.base.UserITBase
 import org.junit.jupiter.api.Test
 import kotlin.random.Random

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/AuthController.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/AuthController.kt
@@ -2,7 +2,7 @@ package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.LoginPostRequest
 import club.staircrusher.api.spec.dto.SignUpPostRequest
-import club.staircrusher.spring_web.authentication.SccSecurityFilterChainConfig
+import club.staircrusher.spring_web.security.SccSecurityFilterChainConfig
 import club.staircrusher.user.application.port.`in`.UserApplicationService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
@@ -2,7 +2,7 @@ package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.UpdateUserInfoPost200Response
 import club.staircrusher.api.spec.dto.UpdateUserInfoPostRequest
-import club.staircrusher.spring_web.authentication.app.SccAppAuthentication
+import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import club.staircrusher.user.application.port.`in`.UserApplicationService
 import club.staircrusher.user.infra.adapter.`in`.converter.toDTO
 import org.springframework.web.bind.annotation.PostMapping

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/security/UserBoundedContextSecurityConfig.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/security/UserBoundedContextSecurityConfig.kt
@@ -1,6 +1,6 @@
 package club.staircrusher.user.infra.adapter.`in`.security
 
-import club.staircrusher.spring_web.authentication.SccSecurityConfig
+import club.staircrusher.spring_web.security.SccSecurityConfig
 import club.staircrusher.stdlib.di.annotation.Component
 
 @Component

--- a/subprojects/spring_web/build.gradle.kts
+++ b/subprojects/spring_web/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     implementation(project(":bounded_context:user:application"))
     implementation("org.springframework.boot:spring-boot-starter-web")
     api("org.springframework.boot:spring-boot-starter-security")
+    val kotlinLoggingVersion: String by project
+    implementation("io.github.microutils:kotlin-logging-jvm:$kotlinLoggingVersion")
 
     val jacksonModuleKotlinVersion: String by project
     integrationTestImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonModuleKotlinVersion")

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/ClockConfiguration.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/ClockConfiguration.kt
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Clock
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 open class ClockConfiguration {
     @Bean
     open fun clock(): Clock {

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/ClockConfiguration.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/ClockConfiguration.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.spring_web.mock
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+open class ClockConfiguration {
+    @Bean
+    open fun clock(): Clock {
+        return Clock.systemUTC()
+    }
+}

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/EchoUserIdController.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/EchoUserIdController.kt
@@ -1,6 +1,6 @@
-package club.staircrusher.spring_web
+package club.staircrusher.spring_web.security
 
-import club.staircrusher.spring_web.authentication.app.SccAppAuthentication
+import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/EchoUserIdSecurityConfig.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/EchoUserIdSecurityConfig.kt
@@ -1,6 +1,5 @@
-package club.staircrusher.spring_web
+package club.staircrusher.spring_web.security
 
-import club.staircrusher.spring_web.authentication.SccSecurityConfig
 import org.springframework.stereotype.Component
 
 @Component

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/NoopPasswordEncryptor.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/NoopPasswordEncryptor.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.spring_web
+package club.staircrusher.spring_web.security
 
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.user.domain.service.PasswordEncryptor

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccAppSecurityConfigTestApplication.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccAppSecurityConfigTestApplication.kt
@@ -1,11 +1,9 @@
-package club.staircrusher.spring_web
+package club.staircrusher.spring_web.security
 
 import club.staircrusher.stdlib.di.annotation.Component
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
-import java.time.Clock
 
 @SpringBootApplication(proxyBeanMethods = false)
 @ComponentScan(
@@ -14,9 +12,4 @@ import java.time.Clock
         ComponentScan.Filter(type = FilterType.ANNOTATION, classes = [Component::class]),
     ],
 )
-open class SccAppSecurityConfigTestApplication {
-    @Bean
-    open fun clock(): Clock {
-        return Clock.systemUTC()
-    }
-}
+open class SccAppSecurityConfigTestApplication

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccSecurityConfigTest.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccSecurityConfigTest.kt
@@ -1,6 +1,5 @@
-package club.staircrusher.spring_web
+package club.staircrusher.spring_web.security
 
-import club.staircrusher.spring_web.authentication.SccSecurityFilterChainConfig
 import club.staircrusher.user.domain.model.User
 import club.staircrusher.user.application.port.out.persistence.UserRepository
 import club.staircrusher.user.domain.service.UserAuthService

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/web/SccExceptionHandlerTest.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/web/SccExceptionHandlerTest.kt
@@ -1,0 +1,29 @@
+package club.staircrusher.spring_web.web
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SccExceptionHandlerTest {
+    @Autowired
+    lateinit var mvc: MockMvc
+
+    @Test
+    fun `SccDomainException 테스트`() {
+        mvc
+            .get("/throwSccDomainException")
+            .andExpect {
+                status {
+                    isBadRequest()
+                }
+                content {
+                    string("SccDomainException thrown.")
+                }
+            }
+    }
+}

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/web/SccExceptionHandlerTestApplication.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/web/SccExceptionHandlerTestApplication.kt
@@ -1,0 +1,15 @@
+package club.staircrusher.spring_web.web
+
+import club.staircrusher.stdlib.di.annotation.Component
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+
+@SpringBootApplication(proxyBeanMethods = false)
+@ComponentScan(
+    basePackages = ["club.staircrusher"],
+    includeFilters = [
+        ComponentScan.Filter(type = FilterType.ANNOTATION, classes = [Component::class]),
+    ],
+)
+open class SccExceptionHandlerTestApplication

--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/web/ThrowExceptionController.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/web/ThrowExceptionController.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.spring_web.web
+
+import club.staircrusher.stdlib.domain.SccDomainException
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ThrowExceptionController {
+    @GetMapping("/throwSccDomainException")
+    fun throwSccDomainException() {
+        throw SccDomainException("SccDomainException thrown.")
+    }
+}

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/BeforeAuthSccAuthentication.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/BeforeAuthSccAuthentication.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.spring_web.authentication
+package club.staircrusher.spring_web.security
 
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.GrantedAuthority

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationEntryPoint.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationEntryPoint.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.spring_web.authentication
+package club.staircrusher.spring_web.security
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationFilter.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationFilter.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.spring_web.authentication
+package club.staircrusher.spring_web.security
 
 import org.springframework.security.web.authentication.AuthenticationConverter
 import org.springframework.security.web.authentication.AuthenticationFilter

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationManager.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationManager.kt
@@ -1,6 +1,6 @@
-package club.staircrusher.spring_web.authentication
+package club.staircrusher.spring_web.security
 
-import club.staircrusher.spring_web.authentication.app.SccAppAuthenticationProvider
+import club.staircrusher.spring_web.security.app.SccAppAuthenticationProvider
 import club.staircrusher.user.application.port.`in`.UserApplicationService
 import club.staircrusher.user.application.port.`in`.UserAuthApplicationService
 import org.springframework.security.authentication.ProviderManager

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccSecurityConfig.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccSecurityConfig.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.spring_web.authentication
+package club.staircrusher.spring_web.security
 
 interface SccSecurityConfig {
     fun getAuthenticatedUrls(): List<String>

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccSecurityFilterChainConfig.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccSecurityFilterChainConfig.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.spring_web.authentication
+package club.staircrusher.spring_web.security
 
 import club.staircrusher.stdlib.di.annotation.Component
 import org.springframework.context.annotation.Bean

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthentication.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthentication.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.spring_web.authentication.app
+package club.staircrusher.spring_web.security.app
 
 import club.staircrusher.stdlib.auth.AuthUser
 import org.springframework.security.core.Authentication

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthenticationProvider.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthenticationProvider.kt
@@ -1,6 +1,6 @@
-package club.staircrusher.spring_web.authentication.app
+package club.staircrusher.spring_web.security.app
 
-import club.staircrusher.spring_web.authentication.BeforeAuthSccAuthentication
+import club.staircrusher.spring_web.security.BeforeAuthSccAuthentication
 import club.staircrusher.stdlib.auth.AuthUser
 import club.staircrusher.user.application.port.`in`.UserApplicationService
 import club.staircrusher.user.application.port.`in`.UserAuthApplicationService

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
@@ -1,0 +1,24 @@
+package club.staircrusher.spring_web.web
+
+import mu.KotlinLogging
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+// TODO: exception 별로 세분화
+// TODO: error 내려주기 위한 api spec 정의
+// TODO: 센트리 연동
+@ControllerAdvice
+class SccExceptionHandler {
+    @ExceptionHandler(Throwable::class)
+    fun handleThrowable(t: Throwable): ResponseEntity<String> {
+        logger.error(t) { t.message }
+        return ResponseEntity
+            .badRequest()
+            .body(t.message)
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
@@ -10,15 +10,13 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 // TODO: 센트리 연동
 @ControllerAdvice
 class SccExceptionHandler {
+    private val logger = KotlinLogging.logger {}
+
     @ExceptionHandler(Throwable::class)
     fun handleThrowable(t: Throwable): ResponseEntity<String> {
         logger.error(t) { t.message }
         return ResponseEntity
             .badRequest()
             .body(t.message)
-    }
-
-    companion object {
-        private val logger = KotlinLogging.logger {}
     }
 }

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/DomainException.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/DomainException.kt
@@ -1,3 +1,0 @@
-package club.staircrusher.stdlib.domain
-
-class DomainException(val msg: String) : RuntimeException(msg)

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/SccDomainException.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/SccDomainException.kt
@@ -1,0 +1,3 @@
+package club.staircrusher.stdlib.domain
+
+class SccDomainException(val msg: String) : RuntimeException(msg)

--- a/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/base/SccSpringITBase.kt
+++ b/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/base/SccSpringITBase.kt
@@ -1,6 +1,6 @@
 package club.staircrusher.testing.spring_it.base
 
-import club.staircrusher.spring_web.authentication.SccSecurityFilterChainConfig
+import club.staircrusher.spring_web.security.SccSecurityFilterChainConfig
 import club.staircrusher.stdlib.persistence.TransactionManager
 import club.staircrusher.testing.spring_it.ITDataGenerator
 import club.staircrusher.user.domain.model.User


### PR DESCRIPTION
- 한동안 API가 불안정할 거라서, 일단은 클라팀에게도 에러 메세지를 직접 보여지도록 합니다.
- 나중에는 exception 별로 분기를 타서 4xx / 5xx 구분하고 에러 메세지를 적당히 변환하는 등의 작업이 필요합니다.