### PR TITLE
카카오 지도 API 연동 시 발생하는 문제 수정

### DIFF
--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
@@ -96,12 +96,11 @@ class AccessibilityApplicationService(
     }
 
     fun getPlaceAccessibility(placeId: String): PlaceAccessibility? = transactionManager.doInTransaction {
-        placeService.findPlace(placeId) ?: error("Cannot find place with $placeId")
         placeAccessibilityRepository.findByPlaceId(placeId)
     }
 
     fun getBuildingAccessibility(placeId: String): BuildingAccessibility? = transactionManager.doInTransaction {
-        val place = placeService.findPlace(placeId) ?: error("Cannot find place with $placeId")
+        val place = placeService.findPlace(placeId) ?: return@doInTransaction null
         buildingAccessibilityRepository.findByBuildingId(place.buildingId)
     }
 

--- a/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/PlaceCacher.kt
+++ b/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/PlaceCacher.kt
@@ -20,7 +20,7 @@ class PlaceCacher(
     override fun onDomainEvent(event: PlaceSearchEvent) {
         transactionManager.doInTransaction {
             placeRepository.saveAll(event.searchResult.map(PlaceDTO::toPlace))
-            buildingRepository.saveAll(event.searchResult.mapNotNull { it.building?.toBuilding() })
+            buildingRepository.saveAll(event.searchResult.mapNotNull { it.building?.toBuilding() }.toSet())
         }
     }
 

--- a/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/PlaceCacher.kt
+++ b/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/PlaceCacher.kt
@@ -2,7 +2,9 @@ package club.staircrusher.place.application.port.`in`
 
 import club.staircrusher.domain_event.PlaceSearchEvent
 import club.staircrusher.domain_event.dto.PlaceDTO
+import club.staircrusher.place.application.port.out.persistence.BuildingRepository
 import club.staircrusher.place.application.port.out.persistence.PlaceRepository
+import club.staircrusher.place.application.toBuilding
 import club.staircrusher.place.application.toPlace
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.domain.event.DomainEvent
@@ -13,10 +15,12 @@ import club.staircrusher.stdlib.persistence.TransactionManager
 class PlaceCacher(
     private val transactionManager: TransactionManager,
     private val placeRepository: PlaceRepository,
+    private val buildingRepository: BuildingRepository,
 ) : DomainEventSubscriber<PlaceSearchEvent>() {
     override fun onDomainEvent(event: PlaceSearchEvent) {
         transactionManager.doInTransaction {
             placeRepository.saveAll(event.searchResult.map(PlaceDTO::toPlace))
+            buildingRepository.saveAll(event.searchResult.mapNotNull { it.building?.toBuilding() })
         }
     }
 

--- a/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/BuildingAddress.kt
+++ b/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/BuildingAddress.kt
@@ -7,7 +7,7 @@ data class BuildingAddress(
     val li: String,
     val roadName: String,
     val mainBuildingNumber: String,
-    val subBuildingNumber: String
+    val subBuildingNumber: String,
 ) {
     override fun toString(): String {
         // refs: https://www.juso.go.kr/CommonPageLink.do?link=/street/GuideBook

--- a/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -213,7 +213,7 @@ class KakaoMapsService(
             @SerialName("address_name")
             val addressName: String,
             @SerialName("category_group_code")
-            val categoryGroupCode: Category,
+            private val rawCategoryGroupCode: String,
             @SerialName("category_group_name")
             val categoryGroupName: String,
             @SerialName("category_name")
@@ -237,6 +237,13 @@ class KakaoMapsService(
         ) {
             val location: Location
                 get() = Location(lng = x.toDouble(), lat = y.toDouble())
+
+            val categoryGroupCode: Category?
+                get() = try {
+                    Category.valueOf(rawCategoryGroupCode)
+                } catch (t: Throwable) {
+                    null
+                }
 
             @Serializable
             enum class Category {

--- a/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -353,11 +353,7 @@ class KakaoMapsService(
         val siDo = addressNameTokens[0]
         val siGunGu = addressNameTokens[1]
         val eupMyeonDong = addressNameTokens[2]
-        val li = if (addressNameTokens[3].endsWith("리")) {
-            addressNameTokens[3]
-        } else {
-            ""
-        }
+        val li = addressNameTokens[3].takeIf { it.endsWith("리") } ?: ""
 
         val (roadName, buildingNumber) = roadAddressName.split(" ").takeLast(2)
         val buildingNumberTokens = buildingNumber.split("-")

--- a/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -174,6 +174,7 @@ class KakaoMapsService(
             if (it.categoryGroupCode == null) {
                 return@mapNotNull null // 운중천과 같이 점포가 아닌 곳도 내려온다. 이런 경우를 필터링해준다.
             }
+            @Suppress("TooGenericExceptionCaught", "SwallowedException")
             try {
                 Place(
                     id = it.id,
@@ -238,10 +239,11 @@ class KakaoMapsService(
             val location: Location
                 get() = Location(lng = x.toDouble(), lat = y.toDouble())
 
+            @Suppress("SwallowedException")
             val categoryGroupCode: Category?
                 get() = try {
                     Category.valueOf(rawCategoryGroupCode)
-                } catch (t: Throwable) {
+                } catch (_: IllegalArgumentException) {
                     null
                 }
 

--- a/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -1,10 +1,13 @@
 package club.staircrusher.place.infra.adapter.out.web
 
 import club.staircrusher.place.application.port.out.web.MapsService
+import club.staircrusher.place.domain.model.Building
+import club.staircrusher.place.domain.model.BuildingAddress
 import club.staircrusher.place.domain.model.Place
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.geography.Location
 import club.staircrusher.stdlib.place.PlaceCategory
+import club.staircrusher.stdlib.util.Hashing
 import io.netty.channel.ChannelOption
 import io.netty.handler.timeout.ReadTimeoutHandler
 import io.netty.handler.timeout.WriteTimeoutHandler
@@ -171,11 +174,15 @@ class KakaoMapsService(
             Place(
                 id = it.id,
                 name = it.placeName,
-                location = Location(
-                    lng = it.x.toDouble(),
-                    lat = it.y.toDouble(),
+                location = it.location,
+                building = Building(
+                    id = Hashing.getHash(it.roadAddressName, length = 36), // TODO: 정책 제대로 정하기; 근데 어차피 주소로 unique key를 만들어내긴 해야 할 듯.
+                    name = it.roadAddressName,
+                    location = it.location,
+                    address = it.parseToBuildingAddress(),
+                    siGunGuId = "temp", // TODO: 제대로 채우기
+                    eupMyeonDongId = "temp",
                 ),
-                building = null,
                 siGunGuId = null,
                 eupMyeonDongId = null,
                 category = it.categoryGroupCode.toPlaceCategory(),
@@ -217,6 +224,9 @@ class KakaoMapsService(
             @SerialName("y")
             val y: String,
         ) {
+            val location: Location
+                get() = Location(lng = x.toDouble(), lat = y.toDouble())
+
             @Serializable
             enum class Category {
                 MT1, //	대형마트
@@ -312,6 +322,36 @@ class KakaoMapsService(
                 val selectedRegion: String,
             )
         }
+    }
+
+    @Suppress("MagicNumber")
+    fun SearchResult.Document.parseToBuildingAddress(): BuildingAddress {
+        val addressNameTokens = addressName.split(" ")
+        val siDo = addressNameTokens[0]
+        val siGunGu = addressNameTokens[1]
+        val eupMyeonDong = addressNameTokens[2]
+        val li = if (addressNameTokens[3].endsWith("리")) {
+            addressNameTokens[3]
+        } else {
+            ""
+        }
+
+        val (roadName, buildingNumber) = roadAddressName.split(" ").takeLast(2)
+        val buildingNumberTokens = buildingNumber.split("-")
+        val (mainBuildingNumber, subBuildingNumber) = if (buildingNumberTokens.size == 1) {
+            Pair(buildingNumberTokens[0], "")
+        } else {
+            Pair(buildingNumberTokens[0], buildingNumberTokens[1])
+        }
+        return BuildingAddress(
+            siDo = siDo,
+            siGunGu = siGunGu,
+            eupMyeonDong = eupMyeonDong,
+            li = li,
+            roadName = roadName,
+            mainBuildingNumber = mainBuildingNumber,
+            subBuildingNumber = subBuildingNumber,
+        )
     }
 
     @Serializable

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
@@ -15,8 +15,20 @@ class SccExceptionHandler {
     @ExceptionHandler(Throwable::class)
     fun handleThrowable(t: Throwable): ResponseEntity<String> {
         logger.error(t) { t.message }
+        val errorMessage = buildString {
+            var cause: Throwable? = t
+            var isInitial = true
+            while (cause != null) {
+                if (!isInitial) {
+                    append("  Caused by ")
+                }
+                appendLine("${cause::class.simpleName}: ${cause.message}")
+                cause = cause.cause
+                isInitial = false
+            }
+        }
         return ResponseEntity
             .badRequest()
-            .body(t.message)
+            .body(errorMessage)
     }
 }

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/EupMyeonDongs.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/EupMyeonDongs.kt
@@ -1,8 +1,7 @@
 package club.staircrusher.stdlib.geography
 
+import club.staircrusher.stdlib.util.Hashing
 import club.staircrusher.stdlib.util.TextResourceReader
-import java.security.MessageDigest
-import java.util.Base64
 
 
 val eupMyeonDongById = run {
@@ -10,10 +9,10 @@ val eupMyeonDongById = run {
     val eupMyeonDongs = lines.map { line ->
         val (siDo, siGunGu, eupMyeonDong) = line.split("\t")
         EupMyeonDong(
-            id = getHash("$siDo $siGunGu $eupMyeonDong".toByteArray(), length = 36),
+            id = Hashing.getHash("$siDo $siGunGu $eupMyeonDong", length = 36),
             name = eupMyeonDong,
             siGunGu = SiGunGu(
-                id = getHash("$siDo $siGunGu".toByteArray(), length = 36),
+                id = Hashing.getHash("$siDo $siGunGu", length = 36),
                 name = siGunGu,
                 siDo = siDo,
             ),
@@ -21,16 +20,4 @@ val eupMyeonDongById = run {
     }
     require(eupMyeonDongs.size == eupMyeonDongs.map { it.id }.toSet().size)
     eupMyeonDongs.associateBy { it.id }
-}
-
-private fun getHash(byteArray: ByteArray, length: Int? = null): String {
-    val md = MessageDigest.getInstance("SHA-256")
-    md.update(byteArray)
-    return Base64.getEncoder().encodeToString(md.digest()).let {
-        if (length != null) {
-            it.take(length)
-        } else {
-            it
-        }
-    }
 }

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/util/Hashing.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/util/Hashing.kt
@@ -1,0 +1,19 @@
+package club.staircrusher.stdlib.util
+
+import java.security.MessageDigest
+import java.util.Base64
+
+object Hashing {
+    fun getHash(value: String, length: Int? = null): String {
+        val byteArray = value.toByteArray()
+        val md = MessageDigest.getInstance("SHA-256")
+        md.update(byteArray)
+        return Base64.getEncoder().encodeToString(md.digest()).let {
+            if (length != null) {
+                it.take(length)
+            } else {
+                it
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 몇 가지 문제가 있었는데, 일단 땜빵으로 해결합니다.
  - 카카오 지도 API 조회 결과를 도메인 모델로 변환할 때 Building을 안 채워주던 문제 -> 대충 채워줬습니다.
  - `/searchPlaces` API에서 점포 / 건물의 accessibility를 조회하는데, 이 때 SearchPlaces 도메인 이벤트는 던졌으나 아직 처리는 되지 않아서 place / building이 존재하지 않아 accessibility 조회가 실패하는 문제 -> accessibility 조회 시 place / building 존재 여부는 체크하지 않도록 수정했습니다.
- 로컬에서 테스트 완료!