### PR TITLE
Fix: SQL query params에 empty list가 들어가는 경우 syntax 에러가 발생한다

### DIFF
--- a/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/persistence/BuildingRepository.kt
+++ b/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/persistence/BuildingRepository.kt
@@ -19,6 +19,12 @@ class BuildingRepository(db: DB): BuildingRepository{
     }
 
     override fun findByIdIn(ids: Collection<String>): List<Building> {
+        if (ids.isEmpty()) {
+            // empty list로 쿼리를 할 경우 sqldelight가 제대로 처리하지 못하는 문제가 있다.
+            // select * from entity where entity.id in (); <- 이런 식으로 쿼리를 날리는데, () 부분이 syntax error이다.
+            // 따라서 ids가 empty면 early return을 해준다.
+            return emptyList()
+        }
         return buildingQueries.findByIdIn(ids).executeAsList().map { it.toDomainModel() }
     }
 

--- a/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/persistence/PlaceRepository.kt
+++ b/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/persistence/PlaceRepository.kt
@@ -30,6 +30,12 @@ class PlaceRepository(
     }
 
     override fun findByIdIn(ids: Collection<String>): List<Place> {
+        if (ids.isEmpty()) {
+            // empty list로 쿼리를 할 경우 sqldelight가 제대로 처리하지 못하는 문제가 있다.
+            // select * from entity where entity.id in (); <- 이런 식으로 쿼리를 날리는데, () 부분이 syntax error이다.
+            // 따라서 ids가 empty면 early return을 해준다.
+            return emptyList()
+        }
         val places = placeQueries.findByIdIn(ids).executeAsList()
         val buildingIds = places.mapNotNull { it.building_id }
         val buildings = buildingRepository.findByIdIn(buildingIds).associateBy { it.id }

--- a/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/UserRepository.kt
+++ b/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/UserRepository.kt
@@ -41,6 +41,12 @@ class UserRepository(
     }
 
     override fun findByIdIn(ids: Collection<String>): List<User> {
+        if (ids.isEmpty()) {
+            // empty list로 쿼리를 할 경우 sqldelight가 제대로 처리하지 못하는 문제가 있다.
+            // select * from entity where entity.id in (); <- 이런 식으로 쿼리를 날리는데, () 부분이 syntax error이다.
+            // 따라서 ids가 empty면 early return을 해준다.
+            return emptyList()
+        }
         return queries.findByIdIn(ids = ids)
             .executeAsList()
             .map { it.toDomainModel() }


### PR DESCRIPTION
- ㅈㄱㄴ
- 구글링 진짜 조금 해봤는데, sqldelight 옵션 등으로 문제를 해결할 수 있는 방법이 없는 듯해서 일단 repository 구현체에서 문제를 수정합니다.