### PR TITLE
인증된 요청에 대한 응답이 항상 root path로 redirect 되는 문제 해결

### DIFF
--- a/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccSecurityConfigTest.kt
+++ b/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccSecurityConfigTest.kt
@@ -56,6 +56,9 @@ class SccSecurityConfigTest {
         mvc.get("/echoUserId") {
             header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
         }.andExpect {
+            status {
+                isOk()
+            }
             content {
                 string(userId)
             }

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationFilter.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationFilter.kt
@@ -12,4 +12,8 @@ class SccAuthenticationFilter(
         val accessToken = request.getHeader(HttpHeaders.AUTHORIZATION)?.replace("Bearer ", "")
         accessToken?.let { BeforeAuthSccAuthentication(it) }
     }
-)
+) {
+    init {
+        successHandler = SccAuthenticationSuccessHandler()
+    }
+}

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationSuccessHandler.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationSuccessHandler.kt
@@ -1,0 +1,21 @@
+package club.staircrusher.spring_web.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+
+/**
+ * 인증이 성공했을 때의 동작을 결정하는 AuthenticationSuccessHandler의 기본값은 SavedRequestAwareAuthenticationSuccessHandler이다.
+ * 근데 SavedRequestAwareAuthenticationSuccessHandler는 인증이 성공하면 root path로 redirect를 시켜버린다.
+ * 즉, 인증이 성공하는 경우 root path로 redirect하는 응답이 먼저 씌여진 후 controller 로직이 실행되는데,
+ * 이때 Spring MVC은 이미 응답이 쓰여져 있으므로 controller 로직의 결과물을 무시하고 무조건 root path로 redirect 시킨다.
+ *
+ * 이를 방지하기 위해 인증 성공 시 아무것도 안 하는 AuthenticationSuccessHandler를 사용한다.
+ * @see [SccAuthenticationFilter]
+ */
+class SccAuthenticationSuccessHandler : SimpleUrlAuthenticationSuccessHandler() {
+    override fun handle(request: HttpServletRequest?, response: HttpServletResponse?, authentication: Authentication?) {
+        // No-op
+    }
+}

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthentication.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthentication.kt
@@ -12,7 +12,7 @@ class SccAppAuthentication(
     }
 
     override fun getAuthorities(): Collection<GrantedAuthority> {
-        return listOf(GrantedAuthority { authority })
+        return listOf(GrantedAuthority { "ROLE_$authority" })
     }
 
     override fun getCredentials(): String {


### PR DESCRIPTION
- 요청에 access token을 올바르게 넣어주기만 하면 멀쩡한 API가 고장나는 문제가 있었는데, 주석에 대충 문제 원인과 해결책을 달아두었습니다. [참고한 글](https://stackoverflow.com/questions/50157911/spring-security-5-authentication-always-return-302)
- 대충 왜 이렇게 해놨는진 알겠는데, 이게 default 동작이라니... Spring Security 찢어버리고 싶네요