### PR TITLE
퀘스트 생성 페이지에서 더 많은 장소 조회하기

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ detektVersion=1.21.0
 jibVersion=3.3.0
 jacksonModuleKotlinVersion=2.12.3
 awsSdkVersion=2.17.292
+guavaVersion=31.1-jre

--- a/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/web/MapsService.kt
+++ b/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/web/MapsService.kt
@@ -17,7 +17,6 @@ interface MapsService {
 
     data class SearchByKeywordOption(
         val region: Region? = null,
-        val page: Int = 1,
     ) {
         sealed interface Region
         data class CircleRegion(
@@ -32,7 +31,6 @@ interface MapsService {
 
     data class SearchByCategoryOption(
         val region: Region,
-        val page: Int = 1,
     ) {
         sealed interface Region
         data class CircleRegion(
@@ -40,8 +38,8 @@ interface MapsService {
             val radiusMeters: Int,
         ) : Region
         data class RectangleRegion(
-            val leftTopLocation: Location,
-            val rightBottomLocation: Location,
+            val leftBottomLocation: Location,
+            val rightTopLocation: Location,
         ) : Region
     }
 }

--- a/subprojects/bounded_context/place/infra/build.gradle.kts
+++ b/subprojects/bounded_context/place/infra/build.gradle.kts
@@ -25,4 +25,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion")
 
     implementation("io.github.microutils:kotlin-logging-jvm:$kotlinLoggingVersion")
+
+    val guavaVersion: String by project
+    implementation("com.google.guava:guava:$guavaVersion")
 }

--- a/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/service/InProcessClubQuestTargetPlaceSearcher.kt
+++ b/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/service/InProcessClubQuestTargetPlaceSearcher.kt
@@ -2,6 +2,7 @@ package club.staircrusher.quest.infra.adapter.out.service
 
 import club.staircrusher.place.application.port.out.web.MapsService
 import club.staircrusher.place.application.port.`in`.PlaceService
+import club.staircrusher.place.domain.model.Building
 import club.staircrusher.place.domain.model.Place
 import club.staircrusher.quest.application.port.out.web.ClubQuestTargetPlacesSearcher
 import club.staircrusher.stdlib.geography.Location
@@ -10,6 +11,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.geography.Length
+import club.staircrusher.stdlib.geography.LocationUtils
+import kotlin.math.ceil
 
 @Component
 class InProcessClubQuestTargetPlaceSearcher(
@@ -21,18 +25,79 @@ class InProcessClubQuestTargetPlaceSearcher(
         PlaceCategory.MARKET,
         PlaceCategory.HOSPITAL,
         PlaceCategory.PHARMACY,
+        PlaceCategory.CONVENIENCE_STORE
     )
 
+    /**
+     * 지정된 지역으로 그냥 검색하면 너무 많은 장소가 누락되는 것으로 확인되었다.
+     * 장소 누락을 최대한 방지하기 위해, 다음과 같은 로직을 태운다.
+     * 1. 지정된 지역을 여러 청크로 나눠서 카테고리 검색 -> 해당 지역 내의 건물 목록 획득
+     * 2. 1에서 획득한 건물의 주소로 키워드 검색을 하여 장소 목록 획득
+     */
     override suspend fun searchPlaces(centerLocation: Location, radiusMeters: Int): List<Place> {
+        val buildingsInRegion = searchBuildingsInRegion(centerLocation, radiusMeters)
+        return searchPlacesInBuildings(buildingsInRegion)
+    }
+
+    private suspend fun searchBuildingsInRegion(centerLocation: Location, radiusMeters: Int): List<Building> {
+        val radius = Length.ofMeters(radiusMeters)
+        val leftBottomLocation = centerLocation.minusLng(radius).minusLat(radius)
+        val rightTopLocation = centerLocation.plusLng(radius).plusLat(radius)
+
+        val chunkCount = determineChunkCount(radiusMeters)
+        val chunkedRectangles = (1..chunkCount).flatMap { lngIdx ->
+            (1..chunkCount).map { latIdx ->
+                val chunkLeftBottomLocation = getAvgLocation(
+                    leftBottomLocation,
+                    rightTopLocation,
+                    (lngIdx - 1).toDouble() / chunkCount,
+                    (latIdx - 1).toDouble() / chunkCount,
+                )
+                val chunkRightTopLocation = getAvgLocation(
+                    leftBottomLocation,
+                    rightTopLocation,
+                    lngIdx.toDouble() / chunkCount,
+                    latIdx.toDouble() / chunkCount,
+                )
+                Pair(chunkLeftBottomLocation, chunkRightTopLocation)
+            }
+        }
+        return chunkedRectangles
+            .flatMap { (leftBottomLocation, rightTopLocation) ->
+                getBuildingsInRectangle(leftBottomLocation, rightTopLocation)
+            }
+            .removeDuplicates { it.id }
+            .filter { LocationUtils.calculateDistance(it.location, centerLocation) <= radius }
+    }
+
+    private suspend fun searchPlacesInBuildings(buildings: List<Building>): List<Place> {
+        return coroutineScope {
+            buildings
+                .map { building ->
+                    async {
+                        placeService.findAllByKeyword(
+                            keyword = building.address.toString(),
+                            option = MapsService.SearchByKeywordOption(),
+                        )
+                    }
+                }
+                .let { awaitAll(*it.toTypedArray()) }
+                .flatten()
+        }
+            .filter { it.category in targetPlaceCategories }
+    }
+
+    private suspend fun getBuildingsInRectangle(leftBottomLocation: Location, rightTopLocation: Location): List<Building> {
         return coroutineScope {
             targetPlaceCategories
                 .map {
                     async {
                         placeService.findAllByCategory(
-                            it, MapsService.SearchByCategoryOption(
-                                region = MapsService.SearchByCategoryOption.CircleRegion(
-                                    centerLocation = centerLocation,
-                                    radiusMeters = radiusMeters,
+                            category = it,
+                            option = MapsService.SearchByCategoryOption(
+                                region = MapsService.SearchByCategoryOption.RectangleRegion(
+                                    leftBottomLocation = leftBottomLocation,
+                                    rightTopLocation = rightTopLocation,
                                 ),
                             )
                         )
@@ -40,6 +105,24 @@ class InProcessClubQuestTargetPlaceSearcher(
                 }
                 .let { awaitAll(*it.toTypedArray()) }
                 .flatten()
+                .map { it.building!! }
+                .removeDuplicates { it.id }
         }
+    }
+
+    @Suppress("MagicNumber") private val chunkTargetLength = Length.ofMeters(150)
+    private fun determineChunkCount(radiusMeters: Int): Int {
+        return ceil(radiusMeters.toDouble() * 2 / chunkTargetLength.meter).toInt()
+    }
+
+    private fun getAvgLocation(l1: Location, l2: Location, l2LngRatio: Double, l2LatRatio: Double): Location {
+        return Location(
+            lng = l1.lng * (1 - l2LngRatio) + l2.lng * l2LngRatio,
+            lat = l1.lat * (1 - l2LatRatio) + l2.lat * l2LatRatio,
+        )
+    }
+
+    private fun <T, ID> List<T>.removeDuplicates(idGetter: (T) -> ID): List<T> {
+        return associateBy { idGetter(it) }.values.toList()
     }
 }

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/Length.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/Length.kt
@@ -6,10 +6,14 @@ data class Length(
     companion object {
 
         fun ofMeters(meters: Double) = Length(meters)
+        fun ofMeters(meters: Int) = ofMeters(meters.toDouble())
         @Suppress("MagicNumber")
         fun ofKilometers(kilometers: Double) = Length(kilometers * 1000)
     }
 
     operator fun plus(other: Length) = Length(meter + other.meter)
     operator fun minus(other: Length) = Length(meter - other.meter)
+    operator fun compareTo(other: Length): Int {
+        return meter.compareTo(other.meter)
+    }
 }

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/Location.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/Location.kt
@@ -1,9 +1,41 @@
+@file:Suppress("MagicNumber")
 package club.staircrusher.stdlib.geography
 
 import at.kopyk.CopyExtensions
+import kotlin.math.abs
 
 @CopyExtensions
 data class Location(
     val lng: Double,
     val lat: Double,
-)
+) {
+    fun plusLng(length: Length) = copy(
+        lng = lng + length.toLngDiff(this)
+    )
+
+    fun minusLng(length: Length) = copy(
+        lng = lng - length.toLngDiff(this)
+    )
+
+    fun plusLat(length: Length) = copy(
+        lat = lat + length.toLatDiff()
+    )
+
+    fun minusLat(length: Length) = copy(
+        lat = lat - length.toLatDiff()
+    )
+}
+
+/**
+ * length를 longitude와 latitude 차이로 환산하는 함수.
+ * 적도에서 위/경도 0.00001 차이 = 1.11m임을 기반으로 계산한다.
+ * - latitude 차이 - longitude가 어디든 상관 없이 1m = 0.00001 / 1.11이다.
+ * - longitude 차이 - 적도에서 남/북극에 가까워질수록 1m가 만들어내는 차이가 커지는데, 구의 모양을 고려하면 (90 / (90 - |latitude|))에 정비례하여 커진다.
+ */
+private fun Length.toLngDiff(location: Location): Double {
+    return (0.00001 / 1.11) * (90 / (90 - abs(location.lat))) * meter
+}
+
+private fun Length.toLatDiff(): Double {
+    return (0.00001 / 1.11) * meter
+}


### PR DESCRIPTION
- 퀘스트 생성 시 그냥 중심 위치 / 반경으로 카카오 지도 API를 조회할 경우 장소가 그리 많이 조회되지 않습니다.
- 이 문제를 해결하기 위해, 아래와 같이 장소 조회 로직을 변경합니다.
  1. 검색해야 하는 반경을 여러 정사각형으로 잘라서 장소를 조회해 오는데, 이 때 목적은 장소 목록이 아니라 건물 목록을 취득하는 것입니다.
  2. 1에서 얻은 각 건물에 대해 건물 주소로 키워드 장소 검색을 합니다. 주소로 키워드 장소 검색을 하면 해당 건물 안의 장소들이 많이 조회됩니다.
- 카카오 지도 API를 사용할 때 항상 1페이지만 조회하던 버그를 수정합니다.