### PR TITLE
에러를 더 분명하게 처리하기

### DIFF
--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/security/AccessibilityBoundedContextSecurityConfig.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/security/AccessibilityBoundedContextSecurityConfig.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.accessibility.infra.adapter.`in`.security
+
+import club.staircrusher.spring_web.security.SccSecurityConfig
+import club.staircrusher.stdlib.di.annotation.Component
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+
+@Component
+class AccessibilityBoundedContextSecurityConfig : SccSecurityConfig {
+    override fun requestMatchers() = listOf(
+        "/giveBuildingAccessibilityUpvote",
+        "/cancelBuildingAccessibilityUpvote",
+    ).map { AntPathRequestMatcher(it) }
+}

--- a/subprojects/bounded_context/place_search/infra/src/main/kotlin/club/staircrusher/place_search/infra/adapter/in/security/PlaceSearchBoundedContextSecurityConfig.kt
+++ b/subprojects/bounded_context/place_search/infra/src/main/kotlin/club/staircrusher/place_search/infra/adapter/in/security/PlaceSearchBoundedContextSecurityConfig.kt
@@ -1,0 +1,12 @@
+package club.staircrusher.place_search.infra.adapter.`in`.security
+
+import club.staircrusher.spring_web.security.SccSecurityConfig
+import club.staircrusher.stdlib.di.annotation.Component
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+
+@Component
+class PlaceSearchBoundedContextSecurityConfig : SccSecurityConfig {
+    override fun requestMatchers() = listOf(
+        "/listConqueredPlaces",
+    ).map { AntPathRequestMatcher(it) }
+}

--- a/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/persistence/SqlDelightClubQuestRepository.kt
+++ b/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/persistence/SqlDelightClubQuestRepository.kt
@@ -25,7 +25,7 @@ class SqlDelightClubQuestRepository(
     }
 
     override fun findById(id: String): ClubQuest {
-        return findByIdOrNull(id) ?: throw IllegalArgumentException("User of id $id does not exist.")
+        return findByIdOrNull(id) ?: throw IllegalArgumentException("ClubQuest of id $id does not exist.")
     }
 
     override fun findByIdOrNull(id: String): ClubQuest? {

--- a/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
+++ b/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
@@ -3,6 +3,9 @@ package club.staircrusher.spring_web.web
 import club.staircrusher.stdlib.domain.SccDomainException
 import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.HttpMediaTypeNotSupportedException
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 
@@ -11,19 +14,31 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 class SccExceptionHandler {
     private val logger = KotlinLogging.logger {}
 
-    @ExceptionHandler
-    fun handle(e: SccDomainException): ResponseEntity<String>{
-        logger.info(e) { "Bad Request: ${e.msg}" }
-        return ResponseEntity
-            .badRequest()
-            .body(e.msg)
-    }
-
     @ExceptionHandler(Throwable::class)
     fun handleThrowable(t: Throwable): ResponseEntity<String> {
-        logger.error(t) { "Unexpected Error: ${t.message}" } // 일단은 모든 에러를 ERROR 레벨로 찍고, 불필요한 에러를 제외하는 식으로 간다.
-        return ResponseEntity
-            .internalServerError()
-            .body("알 수 없는 에러가 발생했습니다. 다시 시도해주세요.")
+        return when (t) {
+            is SccDomainException -> {
+                logger.info(t) { "Bad Request: ${t.msg}" }
+                ResponseEntity
+                    .badRequest()
+                    .body(t.msg)
+            }
+            is HttpRequestMethodNotSupportedException,
+            is HttpMediaTypeNotSupportedException,
+            is HttpMessageNotReadableException,
+            -> {
+                logger.info(t) { "Bad Request: ${t.message}" }
+                return ResponseEntity
+                    .badRequest()
+                    .body(t.message)
+            }
+            else -> {
+                logger.error(t) { "Unexpected Error: ${t.message}" } // 일단은 모든 에러를 ERROR 레벨로 찍고, 불필요한 에러를 제외하는 식으로 간다.
+                ResponseEntity
+                    .internalServerError()
+                    .body("알 수 없는 에러가 발생했습니다. 다시 시도해주세요.")
+            }
+        }
+
     }
 }


### PR DESCRIPTION
- authentication이 반드시 필요한 시나리오에 대해 인증이 필요하다는 spring security 설정을 추가합니다.
- 운영하면서 식별된, bad request로 처리해야 하는 exception들을 bad request로 처리합니다.
- access token 파싱 과정에서 발생할 수 있는 더 많은 종류의 exception을 잡아서 known exception으로 던집니다.