### PR TITLE
Image tag를 latest가 아니라 버전으로 관리하기

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+version=1.0.0-SNAPSHOT
+
 kotlin.code.style=official
 kotlinVersion=1.8.20
 kotlinxSerializationVersion=1.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-version=1.0.0-SNAPSHOT
-
 kotlin.code.style=official
 kotlinVersion=1.8.20
 kotlinxSerializationVersion=1.5.0

--- a/subprojects/packaging/build.gradle.kts
+++ b/subprojects/packaging/build.gradle.kts
@@ -54,7 +54,7 @@ jib {
     to {
         image = "public.ecr.aws/q0g6g7m8/scc-server"
         credHelper.helper = "ecr-login"
-        val version = property("version") as? String ?: throw IllegalArgumentException("No property exists!")
+        val version = property("version") as? String ?: throw IllegalArgumentException("No property `version` exists!")
         tags = setOf(version)
     }
     container {

--- a/subprojects/packaging/build.gradle.kts
+++ b/subprojects/packaging/build.gradle.kts
@@ -55,11 +55,6 @@ jib {
         image = "public.ecr.aws/q0g6g7m8/scc-server"
         credHelper.helper = "ecr-login"
         val version = property("version") as? String ?: throw IllegalArgumentException("No property exists!")
-        val isProductionRelease = property("isProductionRelease") as? Boolean ?: false
-        when (isProductionRelease) {
-            false -> check(version.lowercase().endsWith("snapshot")) { "Version for a non-production release should end with `SNAPSHOT`." }
-            true -> check(!version.lowercase().endsWith("snapshot")) { "Version for a production release should not end with `SNAPSHOT`." }
-        }
         tags = setOf(version)
     }
     container {

--- a/subprojects/packaging/build.gradle.kts
+++ b/subprojects/packaging/build.gradle.kts
@@ -54,7 +54,13 @@ jib {
     to {
         image = "public.ecr.aws/q0g6g7m8/scc-server"
         credHelper.helper = "ecr-login"
-        tags = setOf("latest")
+        val version = property("version") as? String ?: throw IllegalArgumentException("No property exists!")
+        val isProductionRelease = property("isProductionRelease") as? Boolean ?: false
+        when (isProductionRelease) {
+            false -> check(version.lowercase().endsWith("snapshot")) { "Version for a non-production release should end with `SNAPSHOT`." }
+            true -> check(!version.lowercase().endsWith("snapshot")) { "Version for a production release should not end with `SNAPSHOT`." }
+        }
+        tags = setOf(version)
     }
     container {
         entrypoint = listOf("./app/run-java.sh")


### PR DESCRIPTION
- 이미지를 만들 때 image tag를 latest가 아니라 버저닝을 적용합니다.
- development release와 production release로 나뉘며, 전자는 `-SNAPSHOT` postfix를 강제하고, 후자는 `-SNAPSHOT` postfix가 없는 것을 강제합니다.
- production release를 할 때는 gradle 실행 옵션에 `-P isProductionRelease=true`를 주면 됩니다.