### PR TITLE
Separate place and accessibility registration

### DIFF
--- a/subprojects/api/scc-api/api-spec.yaml
+++ b/subprojects/api/scc-api/api-spec.yaml
@@ -269,20 +269,10 @@ paths:
             schema:
               $ref: '#/components/schemas/RegisterBuildingAccessibilityRequestDto'
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  accessibilityInfo:
-                    $ref: '#/components/schemas/AccessibilityInfoDto'
-                  registeredUserOrder:
-                    type: integer
-                    description: "'n번째 정복자'를 표시해주기 위한 값."
-                required:
-                  - accessibilityInfo
-                  - registeredUserOrder
+        '204':
+          description: |
+            장소 id를 알 수 없으므로 GetAccessibilityInfo를 내려줄 수 없다.
+            따라서 건물 장소 등록 이후에 명시적으로 /getAccessibility API를 별도로 호출하도록 한다.
 
   /listPlacesInBuilding:
     post:

--- a/subprojects/api/scc-api/api-spec.yaml
+++ b/subprojects/api/scc-api/api-spec.yaml
@@ -148,30 +148,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  buildingAccessibility:
-                    $ref: '#/components/schemas/BuildingAccessibility'
-                    description: 정보가 아직 채워지지 않았으면 null.
-                  buildingAccessibilityComments:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/BuildingAccessibilityComment'
-                    description: 정보가 아직 채워지지 않았으면 empty list.
-                  placeAccessibility:
-                    $ref: '#/components/schemas/PlaceAccessibility'
-                    description: 정보가 아직 채워지지 않았으면 null.
-                  placeAccessibilityComments:
-                    items:
-                      $ref: '#/components/schemas/PlaceAccessibilityComment'
-                    description: 정보가 아직 채워지지 않았으면 empty list.
-                  hasOtherPlacesToRegisterInBuilding:
-                    type: boolean
-                    description: "'이 건물의 다른 점포 등록하기'를 보여줄지 여부."
-                required:
-                  - buildingAccessibilityComments
-                  - placeAccessibilityComments
-                  - hasOtherPlacesToRegisterInBuilding
+                $ref: '#/components/schemas/AccessibilityInfoDto'
 
   /getImageUploadUrls:
     post:
@@ -221,60 +198,10 @@ paths:
               type: object
               properties:
                 buildingAccessibilityParams:
-                  type: object
+                  $ref: '#/components/schemas/RegisterBuildingAccessibilityRequestDto'
                   description: 각 건물에 대해 1번만 등록될 수 있다.
-                  properties:
-                    buildingId:
-                      type: string
-                    entranceStairInfo:
-                      $ref: '#/components/schemas/StairInfo'
-                    entranceImageUrls:
-                      type: array
-                      items:
-                        type: string
-                    hasSlope:
-                      type: boolean
-                    hasElevator:
-                      type: boolean
-                    elevatorStairInfo:
-                      $ref: '#/components/schemas/StairInfo'
-                    elevatorImageUrls:
-                      type: array
-                      items:
-                        type: string
-                    comment:
-                      type: string
-                  required:
-                    - buildingId
-                    - entranceStairInfo
-                    - entranceImageUrls
-                    - hasSlope
-                    - hasElevator
-                    - elevatorStairInfo
-                    - elevatorImageUrls
                 placeAccessibilityParams:
-                  type: object
-                  properties:
-                    placeId:
-                      type: string
-                    isFirstFloor:
-                      type: boolean
-                    stairInfo:
-                      $ref: '#/components/schemas/StairInfo'
-                    hasSlope:
-                      type: boolean
-                    imageUrls:
-                      type: array
-                      items:
-                        type: string
-                    comment:
-                      type: string
-                  required:
-                    - placeId
-                    - isFirstFloor
-                    - stairInfo
-                    - hasSlope
-                    - imageUrls
+                  $ref: '#/components/schemas/RegisterPlaceAccessibilityRequestDto'
               required:
                 - placeAccessibilityParams
       responses:
@@ -305,6 +232,56 @@ paths:
                   - buildingAccessibilityComments
                   - placeAccessibility
                   - placeAccessibilityComments
+                  - registeredUserOrder
+
+  /registerPlaceAccessibility:
+    post:
+      summary: 점포의 접근성 정보를 등록한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterPlaceAccessibilityRequestDto'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessibilityInfo:
+                    $ref: '#/components/schemas/AccessibilityInfoDto'
+                  registeredUserOrder:
+                    type: integer
+                    description: "'n번째 정복자'를 표시해주기 위한 값."
+                required:
+                  - accessibilityInfo
+                  - registeredUserOrder
+
+  /registerBuildingAccessibility:
+    post:
+      summary: 건물 접근성 정보를 등록한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterBuildingAccessibilityRequestDto'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessibilityInfo:
+                    $ref: '#/components/schemas/AccessibilityInfoDto'
+                  registeredUserOrder:
+                    type: integer
+                    description: "'n번째 정복자'를 표시해주기 위한 값."
+                required:
+                  - accessibilityInfo
                   - registeredUserOrder
 
   /listPlacesInBuilding:
@@ -750,13 +727,96 @@ components:
         isAccessibilityRegistrable:
           type: boolean
           description: 접근성 정보를 등록할 수 있는지 여부.
-
       required:
         - place
         - building
         - hasBuildingAccessibility
         - hasPlaceAccessibility
         - isAccessibilityRegistrable
+
+    AccessibilityInfoDto:
+      type: object
+      properties:
+        buildingAccessibility:
+          $ref: '#/components/schemas/BuildingAccessibility'
+          description: 정보가 아직 채워지지 않았으면 null.
+        buildingAccessibilityComments:
+          type: array
+          items:
+            $ref: '#/components/schemas/BuildingAccessibilityComment'
+          description: 정보가 아직 채워지지 않았으면 empty list.
+        placeAccessibility:
+          $ref: '#/components/schemas/PlaceAccessibility'
+          description: 정보가 아직 채워지지 않았으면 null.
+        placeAccessibilityComments:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceAccessibilityComment'
+          description: 정보가 아직 채워지지 않았으면 empty list.
+        hasOtherPlacesToRegisterInBuilding:
+          type: boolean
+          description: "'이 건물의 다른 점포 등록하기'를 보여줄지 여부."
+      required:
+        - buildingAccessibilityComments
+        - placeAccessibilityComments
+        - hasOtherPlacesToRegisterInBuilding
+
+    RegisterBuildingAccessibilityRequestDto:
+      type: object
+      description: 각 건물에 대해 1번만 등록될 수 있다.
+      properties:
+        buildingId:
+          type: string
+        entranceStairInfo:
+          $ref: '#/components/schemas/StairInfo'
+        entranceImageUrls:
+          type: array
+          items:
+            type: string
+        hasSlope:
+          type: boolean
+        hasElevator:
+          type: boolean
+        elevatorStairInfo:
+          $ref: '#/components/schemas/StairInfo'
+        elevatorImageUrls:
+          type: array
+          items:
+            type: string
+        comment:
+          type: string
+      required:
+        - buildingId
+        - entranceStairInfo
+        - entranceImageUrls
+        - hasSlope
+        - hasElevator
+        - elevatorStairInfo
+        - elevatorImageUrls
+
+    RegisterPlaceAccessibilityRequestDto:
+      type: object
+      properties:
+        placeId:
+          type: string
+        isFirstFloor:
+          type: boolean
+        stairInfo:
+          $ref: '#/components/schemas/StairInfo'
+        hasSlope:
+          type: boolean
+        imageUrls:
+          type: array
+          items:
+            type: string
+        comment:
+          type: string
+      required:
+        - placeId
+        - isFirstFloor
+        - stairInfo
+        - hasSlope
+        - imageUrls
 
     ApiErrorResponse:
       type: object
@@ -780,4 +840,3 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiErrorResponse'
-

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/RegisterBuildingAccessibilityUseCase.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/RegisterBuildingAccessibilityUseCase.kt
@@ -1,0 +1,20 @@
+package club.staircrusher.accessibility.application.port.`in`
+
+import club.staircrusher.accessibility.application.port.`in`.result.RegisterBuildingAccessibilityResult
+import club.staircrusher.accessibility.application.port.out.persistence.BuildingAccessibilityCommentRepository
+import club.staircrusher.accessibility.application.port.out.persistence.BuildingAccessibilityRepository
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+@Component
+class RegisterBuildingAccessibilityUseCase(
+    private val transactionManager: TransactionManager,
+    private val accessibilityApplicationService: AccessibilityApplicationService,
+) {
+    fun handle(
+        createBuildingAccessibilityParams: BuildingAccessibilityRepository.CreateParams,
+        createBuildingAccessibilityCommentParams: BuildingAccessibilityCommentRepository.CreateParams?,
+    ) : RegisterBuildingAccessibilityResult = transactionManager.doInTransaction {
+        accessibilityApplicationService.doRegisterBuildingAccessibility(createBuildingAccessibilityParams, createBuildingAccessibilityCommentParams)
+    }
+}

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/RegisterPlaceAccessibilityUseCase.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/RegisterPlaceAccessibilityUseCase.kt
@@ -1,0 +1,24 @@
+package club.staircrusher.accessibility.application.port.`in`
+
+import club.staircrusher.accessibility.application.port.`in`.result.GetAccessibilityResult
+import club.staircrusher.accessibility.application.port.`in`.result.RegisterPlaceAccessibilityResult
+import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityCommentRepository
+import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityRepository
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+@Component
+class RegisterPlaceAccessibilityUseCase(
+    private val transactionManager: TransactionManager,
+    private val accessibilityApplicationService: AccessibilityApplicationService,
+) {
+    fun handle(
+        userId: String?,
+        createPlaceAccessibilityParams: PlaceAccessibilityRepository.CreateParams,
+        createPlaceAccessibilityCommentParams: PlaceAccessibilityCommentRepository.CreateParams?,
+    ) : Pair<RegisterPlaceAccessibilityResult, GetAccessibilityResult> = transactionManager.doInTransaction {
+        val registerResult = accessibilityApplicationService.doRegisterPlaceAccessibility(createPlaceAccessibilityParams, createPlaceAccessibilityCommentParams)
+        val getAccessibilityResult = accessibilityApplicationService.doGetAccessibility(createPlaceAccessibilityParams.placeId, userId)
+        Pair(registerResult, getAccessibilityResult)
+    }
+}

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/GetAccessibilityResult.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/GetAccessibilityResult.kt
@@ -1,0 +1,22 @@
+package club.staircrusher.accessibility.application.port.`in`.result
+
+import club.staircrusher.accessibility.application.port.`in`.AccessibilityApplicationService
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.accessibility.domain.model.BuildingAccessibilityComment
+import club.staircrusher.accessibility.domain.model.PlaceAccessibility
+import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
+
+data class GetAccessibilityResult(
+    val buildingAccessibility: AccessibilityApplicationService.WithUserInfo<BuildingAccessibility>?,
+    val buildingAccessibilityUpvoteInfo: BuildingAccessibilityUpvoteInfo?,
+    val buildingAccessibilityComments: List<AccessibilityApplicationService.WithUserInfo<BuildingAccessibilityComment>>,
+    val placeAccessibility: AccessibilityApplicationService.WithUserInfo<PlaceAccessibility>?,
+    val placeAccessibilityComments: List<AccessibilityApplicationService.WithUserInfo<PlaceAccessibilityComment>>,
+    val hasOtherPlacesToRegisterInSameBuilding: Boolean,
+    val isLastPlaceAccessibilityInBuilding: Boolean,
+) {
+    data class BuildingAccessibilityUpvoteInfo(
+        val isUpvoted: Boolean,
+        val totalUpvoteCount: Int,
+    )
+}

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/RegisterBuildingAccessibilityResult.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/RegisterBuildingAccessibilityResult.kt
@@ -1,0 +1,11 @@
+package club.staircrusher.accessibility.application.port.`in`.result
+
+import club.staircrusher.accessibility.application.UserInfo
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.accessibility.domain.model.BuildingAccessibilityComment
+
+data class RegisterBuildingAccessibilityResult(
+    val buildingAccessibility: BuildingAccessibility?,
+    val buildingAccessibilityComment: BuildingAccessibilityComment?,
+    val userInfo: UserInfo?,
+)

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/RegisterPlaceAccessibilityResult.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/RegisterPlaceAccessibilityResult.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.accessibility.application.port.`in`.result
+
+import club.staircrusher.accessibility.application.UserInfo
+import club.staircrusher.accessibility.domain.model.PlaceAccessibility
+import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
+
+data class RegisterPlaceAccessibilityResult(
+    val placeAccessibility: PlaceAccessibility,
+    val placeAccessibilityComment: PlaceAccessibilityComment?,
+    val userInfo: UserInfo?,
+    val registrationOrder: Int, // n번째 정복자를 표현하기 위한 값.
+    val isLastPlaceAccessibilityInBuilding: Boolean,
+)

--- a/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/DeleteAccessibilityTest.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/DeleteAccessibilityTest.kt
@@ -5,8 +5,8 @@ import club.staircrusher.accessibility.application.port.out.persistence.PlaceAcc
 import club.staircrusher.accessibility.domain.model.BuildingAccessibility
 import club.staircrusher.accessibility.domain.model.PlaceAccessibility
 import club.staircrusher.accesssibility.infra.adapter.`in`.controller.base.AccessibilityITBase
+import club.staircrusher.api.spec.dto.AccessibilityInfoDto
 import club.staircrusher.api.spec.dto.DeleteAccessibilityPostRequest
-import club.staircrusher.api.spec.dto.GetAccessibilityPost200Response
 import club.staircrusher.api.spec.dto.GetAccessibilityPostRequest
 import club.staircrusher.place.domain.model.Building
 import club.staircrusher.place.domain.model.Place
@@ -50,7 +50,7 @@ class DeleteAccessibilityTest : AccessibilityITBase() {
         mvc
             .sccRequest("/getAccessibility", getAccessibilityParams1)
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertNull(result.placeAccessibility)
                 assertTrue(result.placeAccessibilityComments.isEmpty())
                 assertNotNull(result.buildingAccessibility)
@@ -73,7 +73,7 @@ class DeleteAccessibilityTest : AccessibilityITBase() {
         mvc
             .sccRequest("/getAccessibility", getAccessibilityParams2)
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertNull(result.placeAccessibility)
                 assertTrue(result.placeAccessibilityComments.isEmpty())
                 assertNull(result.buildingAccessibility)

--- a/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityTest.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityTest.kt
@@ -6,7 +6,7 @@ import club.staircrusher.accessibility.domain.model.PlaceAccessibility
 import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
 import club.staircrusher.accessibility.infra.adapter.`in`.controller.toModel
 import club.staircrusher.accesssibility.infra.adapter.`in`.controller.base.AccessibilityITBase
-import club.staircrusher.api.spec.dto.GetAccessibilityPost200Response
+import club.staircrusher.api.spec.dto.AccessibilityInfoDto
 import club.staircrusher.api.spec.dto.GetAccessibilityPostRequest
 import club.staircrusher.place.domain.model.Building
 import club.staircrusher.place.domain.model.Place
@@ -34,7 +34,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
         mvc
             .sccRequest("/getAccessibility", params, user = user)
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertEquals(buildingAccessibility.id, result.buildingAccessibility!!.id)
                 assertEquals(buildingAccessibility.buildingId, result.buildingAccessibility!!.buildingId)
                 assertEquals(buildingAccessibility.entranceStairInfo, result.buildingAccessibility!!.entranceStairInfo.toModel())
@@ -76,7 +76,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
         mvc
             .sccRequest("/getAccessibility", params, user = user)
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertTrue(result.placeAccessibility!!.deletionInfo!!.isLastInBuilding)
                 assertTrue(result.hasOtherPlacesToRegisterInBuilding)
             }
@@ -96,7 +96,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
                 }
             }
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertNull(result.placeAccessibility!!.deletionInfo)
             }
     }
@@ -118,7 +118,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
                 }
             }
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertNull(result.placeAccessibility!!.deletionInfo)
             }
     }
@@ -139,7 +139,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
                 }
             }
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertFalse(result.placeAccessibility!!.deletionInfo!!.isLastInBuilding)
             }
     }
@@ -158,7 +158,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
                 }
             }
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertTrue(result.placeAccessibility!!.deletionInfo!!.isLastInBuilding)
             }
 
@@ -172,7 +172,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
                 }
             }
             .apply {
-                val result = getResult(GetAccessibilityPost200Response::class)
+                val result = getResult(AccessibilityInfoDto::class)
                 assertNull(result.placeAccessibility!!.deletionInfo)
             }
     }

--- a/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/RegisterAccessibilityTest.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/RegisterAccessibilityTest.kt
@@ -9,8 +9,8 @@ import club.staircrusher.accessibility.infra.adapter.`in`.controller.toModel
 import club.staircrusher.accesssibility.infra.adapter.`in`.controller.base.AccessibilityITBase
 import club.staircrusher.api.spec.dto.RegisterAccessibilityPost200Response
 import club.staircrusher.api.spec.dto.RegisterAccessibilityPostRequest
-import club.staircrusher.api.spec.dto.RegisterAccessibilityPostRequestBuildingAccessibilityParams
-import club.staircrusher.api.spec.dto.RegisterAccessibilityPostRequestPlaceAccessibilityParams
+import club.staircrusher.api.spec.dto.RegisterBuildingAccessibilityRequestDto
+import club.staircrusher.api.spec.dto.RegisterPlaceAccessibilityRequestDto
 import club.staircrusher.place.domain.model.BuildingAddress
 import club.staircrusher.place.domain.model.Place
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -173,7 +173,7 @@ class RegisterAccessibilityTest : AccessibilityITBase() {
 
     private fun getDefaultRequestParams(place: Place): RegisterAccessibilityPostRequest {
         return RegisterAccessibilityPostRequest(
-            buildingAccessibilityParams = RegisterAccessibilityPostRequestBuildingAccessibilityParams(
+            buildingAccessibilityParams = RegisterBuildingAccessibilityRequestDto(
                 buildingId = place.building.id,
                 entranceStairInfo = StairInfo.NONE.toDTO(),
                 entranceImageUrls = listOf("buildingAccessibilityEntranceImage"),
@@ -186,7 +186,7 @@ class RegisterAccessibilityTest : AccessibilityITBase() {
                 ),
                 comment = "건물 코멘트",
             ),
-            placeAccessibilityParams = RegisterAccessibilityPostRequestPlaceAccessibilityParams(
+            placeAccessibilityParams = RegisterPlaceAccessibilityRequestDto(
                 placeId = place.id,
                 isFirstFloor = false,
                 stairInfo = StairInfo.ONE.toDTO(),

--- a/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/RegisterBuildingAccessibilityTest.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/RegisterBuildingAccessibilityTest.kt
@@ -1,0 +1,162 @@
+package club.staircrusher.accesssibility.infra.adapter.`in`.controller
+
+import club.staircrusher.accessibility.application.port.out.persistence.BuildingAccessibilityRepository
+import club.staircrusher.accessibility.application.port.out.persistence.BuildingAccessibilityUpvoteRepository
+import club.staircrusher.accessibility.domain.model.StairInfo
+import club.staircrusher.accessibility.infra.adapter.`in`.controller.toDTO
+import club.staircrusher.accessibility.infra.adapter.`in`.controller.toModel
+import club.staircrusher.accesssibility.infra.adapter.`in`.controller.base.AccessibilityITBase
+import club.staircrusher.api.spec.dto.AccessibilityInfoDto
+import club.staircrusher.api.spec.dto.GetAccessibilityPostRequest
+import club.staircrusher.api.spec.dto.RegisterBuildingAccessibilityRequestDto
+import club.staircrusher.place.domain.model.Building
+import club.staircrusher.place.domain.model.BuildingAddress
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class RegisterBuildingAccessibilityTest : AccessibilityITBase() {
+    @Autowired
+    private lateinit var buildingAccessibilityRepository: BuildingAccessibilityRepository
+    @Autowired
+    private lateinit var buildingAccessibilityUpvoteRepository: BuildingAccessibilityUpvoteRepository
+
+    @BeforeEach
+    fun setUp() = transactionManager.doInTransaction {
+        buildingAccessibilityUpvoteRepository.removeAll()
+        buildingAccessibilityRepository.removeAll()
+    }
+
+    @Test
+    fun testRegisterBuildingAccessibility() {
+        repeat(3) { idx ->
+            val expectedRegisteredUserOrder = idx + 1
+            val user = transactionManager.doInTransaction {
+                testDataGenerator.createUser()
+            }
+            val place = transactionManager.doInTransaction {
+                testDataGenerator.createBuildingAndPlace(placeName = "장소장소")
+            }
+
+            val params = getDefaultRequestParams(place.building)
+            mvc.sccRequest("/registerBuildingAccessibility", params, user = user)
+            mvc
+                .sccRequest("/getAccessibility", GetAccessibilityPostRequest(place.id), user = user)
+                .apply {
+                    val result = getResult(AccessibilityInfoDto::class)
+                    val buildingAccessibility = result.buildingAccessibility!!
+                    assertEquals(place.building.id, buildingAccessibility.buildingId)
+                    assertEquals(StairInfo.NONE, buildingAccessibility.entranceStairInfo.toModel())
+                    assertEquals(1, buildingAccessibility.entranceImageUrls.size)
+                    assertEquals("buildingAccessibilityEntranceImage", buildingAccessibility.entranceImageUrls[0])
+                    assertTrue(buildingAccessibility.hasSlope)
+                    assertTrue(buildingAccessibility.hasElevator)
+                    assertEquals(StairInfo.TWO_TO_FIVE, buildingAccessibility.elevatorStairInfo.toModel())
+                    assertEquals(2, buildingAccessibility.elevatorImageUrls.size)
+                    assertEquals("buildingAccessibilityElevatorImage1", buildingAccessibility.elevatorImageUrls[0])
+                    assertEquals("buildingAccessibilityElevatorImage2", buildingAccessibility.elevatorImageUrls[1])
+                    assertFalse(buildingAccessibility.isUpvoted)
+                    assertEquals(0, buildingAccessibility.totalUpvoteCount)
+
+                    assertEquals(1, result.buildingAccessibilityComments.size)
+                    assertEquals(place.building.id, result.buildingAccessibilityComments[0].buildingId)
+                    assertEquals(user.id, result.buildingAccessibilityComments[0].user!!.id)
+                    assertEquals("건물 코멘트", result.buildingAccessibilityComments[0].comment)
+                }
+        }
+    }
+
+    @Test
+    fun `클라이언트에서 올려준 정보의 정합성이 맞지 않는 경우 에러가 난다`() {
+        val user = transactionManager.doInTransaction {
+            testDataGenerator.createUser()
+        }
+        val place = transactionManager.doInTransaction {
+            testDataGenerator.createBuildingAndPlace(placeName = "장소장소")
+        }
+
+        val params1 = getDefaultRequestParams(place.building).copy(
+            hasElevator = false,
+            elevatorStairInfo = StairInfo.TWO_TO_FIVE.toDTO(), // 엘리베이터가 없는데 계단 정보가 UNDEFINED가 아니다.
+        )
+        mvc
+            .sccRequest("/registerBuildingAccessibility", params1, user = user)
+            .andExpect {
+                status {
+                    isBadRequest()
+                }
+            }
+
+        val params2 = getDefaultRequestParams(place.building).copy(
+            hasElevator = true,
+            elevatorStairInfo = StairInfo.UNDEFINED.toDTO(), // 엘리베이터가 있는데 계단 정보가 UNDEFINED이다.
+        )
+        mvc
+            .sccRequest("/registerAccessibility", params2, user = user)
+            .andExpect {
+                status {
+                    isBadRequest()
+                }
+            }
+    }
+
+    @Test
+    fun `로그인되어 있지 않아도 등록이 잘 된다`() {
+        val place = transactionManager.doInTransaction {
+            testDataGenerator.createBuildingAndPlace(placeName = "장소장소")
+        }
+        mvc.sccRequest("/registerBuildingAccessibility", getDefaultRequestParams(place.building))
+        mvc
+            .sccRequest("/getAccessibility", GetAccessibilityPostRequest(place.id))
+            .apply {
+                val result = getResult(AccessibilityInfoDto::class)
+                assertNull(result.buildingAccessibility!!.registeredUserName)
+                assertNull(result.buildingAccessibilityComments[0].user)
+            }
+    }
+
+    @Test
+    fun `서울, 성남외의 지역을 등록하려면 에러가 난다`() {
+        val place = transactionManager.doInTransaction {
+            testDataGenerator.createBuildingAndPlace(
+                placeName = "장소장소",
+                buildingAddress = BuildingAddress(
+                    siDo = "경기도",
+                    siGunGu = "수원시",
+                    eupMyeonDong = "영통동",
+                    li = "",
+                    roadName = "봉영로",
+                    mainBuildingNumber = "83",
+                    subBuildingNumber = "21",
+                ),
+            )
+        }
+        mvc
+            .sccRequest("/registerBuildingAccessibility", getDefaultRequestParams(place.building))
+            .andExpect {
+                status {
+                    isBadRequest()
+                }
+            }
+    }
+
+    private fun getDefaultRequestParams(building: Building): RegisterBuildingAccessibilityRequestDto {
+        return RegisterBuildingAccessibilityRequestDto(
+            buildingId = building.id,
+            entranceStairInfo = StairInfo.NONE.toDTO(),
+            entranceImageUrls = listOf("buildingAccessibilityEntranceImage"),
+            hasSlope = true,
+            hasElevator = true,
+            elevatorStairInfo = StairInfo.TWO_TO_FIVE.toDTO(),
+            elevatorImageUrls = listOf(
+                "buildingAccessibilityElevatorImage1",
+                "buildingAccessibilityElevatorImage2",
+            ),
+            comment = "건물 코멘트",
+        )
+    }
+}

--- a/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/RegisterPlaceAccessibilityTest.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/RegisterPlaceAccessibilityTest.kt
@@ -1,0 +1,116 @@
+package club.staircrusher.accesssibility.infra.adapter.`in`.controller
+
+import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityRepository
+import club.staircrusher.accessibility.domain.model.StairInfo
+import club.staircrusher.accessibility.infra.adapter.`in`.controller.toDTO
+import club.staircrusher.accessibility.infra.adapter.`in`.controller.toModel
+import club.staircrusher.accesssibility.infra.adapter.`in`.controller.base.AccessibilityITBase
+import club.staircrusher.api.spec.dto.RegisterPlaceAccessibilityPost200Response
+import club.staircrusher.api.spec.dto.RegisterPlaceAccessibilityRequestDto
+import club.staircrusher.place.domain.model.BuildingAddress
+import club.staircrusher.place.domain.model.Place
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class RegisterPlaceAccessibilityTest : AccessibilityITBase() {
+    @Autowired
+    private lateinit var placeAccessibilityRepository: PlaceAccessibilityRepository
+
+    @BeforeEach
+    fun setUp() = transactionManager.doInTransaction {
+        placeAccessibilityRepository.removeAll()
+    }
+
+    @Test
+    fun testRegisterPlaceAccessibility() {
+        repeat(3) { idx ->
+            val expectedRegisteredUserOrder = idx + 1
+            val user = transactionManager.doInTransaction {
+                testDataGenerator.createUser()
+            }
+            val place = transactionManager.doInTransaction {
+                testDataGenerator.createBuildingAndPlace(placeName = "장소장소")
+            }
+
+            val params = getDefaultRequestParams(place)
+            mvc
+                .sccRequest("/registerPlaceAccessibility", params, user = user)
+                .apply {
+                    val result = getResult(RegisterPlaceAccessibilityPost200Response::class)
+                    val accessibilityInfo = result.accessibilityInfo
+                    assertNull(accessibilityInfo.buildingAccessibility)
+                    assertTrue(accessibilityInfo.buildingAccessibilityComments.isEmpty())
+
+                    val placeAccessibility = accessibilityInfo.placeAccessibility!!
+                    assertEquals(place.id, placeAccessibility.placeId)
+                    assertFalse(placeAccessibility.isFirstFloor)
+                    assertEquals(StairInfo.ONE, placeAccessibility.stairInfo.toModel())
+                    assertTrue(placeAccessibility.hasSlope)
+                    assertTrue(placeAccessibility.imageUrls.isEmpty())
+
+                    val placeAccessibilityComments = accessibilityInfo.placeAccessibilityComments
+                    assertEquals(1, placeAccessibilityComments.size)
+                    assertEquals(place.id, placeAccessibilityComments[0].placeId)
+                    assertEquals(user.id, placeAccessibilityComments[0].user!!.id)
+                    assertEquals("장소 코멘트", placeAccessibilityComments[0].comment)
+
+                    assertEquals(expectedRegisteredUserOrder, result.registeredUserOrder)
+                }
+        }
+    }
+
+    @Test
+    fun `로그인되어 있지 않아도 등록이 잘 된다`() {
+        val place = transactionManager.doInTransaction {
+            testDataGenerator.createBuildingAndPlace(placeName = "장소장소")
+        }
+        mvc
+            .sccRequest("/registerPlaceAccessibility", getDefaultRequestParams(place))
+            .apply {
+                val accessibilityInfo = getResult(RegisterPlaceAccessibilityPost200Response::class).accessibilityInfo
+                assertNull(accessibilityInfo.placeAccessibility!!.registeredUserName)
+                assertNull(accessibilityInfo.placeAccessibilityComments[0].user)
+            }
+    }
+
+    @Test
+    fun `서울, 성남외의 지역을 등록하려면 에러가 난다`() {
+        val place = transactionManager.doInTransaction {
+            testDataGenerator.createBuildingAndPlace(
+                placeName = "장소장소",
+                buildingAddress = BuildingAddress(
+                    siDo = "경기도",
+                    siGunGu = "수원시",
+                    eupMyeonDong = "영통동",
+                    li = "",
+                    roadName = "봉영로",
+                    mainBuildingNumber = "83",
+                    subBuildingNumber = "21",
+                ),
+            )
+        }
+        mvc
+            .sccRequest("/registerPlaceAccessibility", getDefaultRequestParams(place))
+            .andExpect {
+                status {
+                    isBadRequest()
+                }
+            }
+    }
+
+    private fun getDefaultRequestParams(place: Place): RegisterPlaceAccessibilityRequestDto {
+        return RegisterPlaceAccessibilityRequestDto(
+            placeId = place.id,
+            isFirstFloor = false,
+            stairInfo = StairInfo.ONE.toDTO(),
+            imageUrls = emptyList(),
+            hasSlope = true,
+            comment = "장소 코멘트",
+        )
+    }
+}

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityController.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityController.kt
@@ -5,7 +5,7 @@ import club.staircrusher.accessibility.application.port.`in`.GetImageUploadUrlsU
 import club.staircrusher.accessibility.application.port.out.persistence.BuildingAccessibilityCommentRepository
 import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityCommentRepository
 import club.staircrusher.api.converter.toDTO
-import club.staircrusher.api.spec.dto.GetAccessibilityPost200Response
+import club.staircrusher.api.spec.dto.AccessibilityInfoDto
 import club.staircrusher.api.spec.dto.GetAccessibilityPostRequest
 import club.staircrusher.api.spec.dto.GetImageUploadUrlsPost200ResponseInner
 import club.staircrusher.api.spec.dto.GetImageUploadUrlsPostRequest
@@ -25,9 +25,9 @@ class AccessibilityController(
     fun getAccessibility(
         @RequestBody request: GetAccessibilityPostRequest,
         authentication: SccAppAuthentication?,
-    ): GetAccessibilityPost200Response {
+    ): AccessibilityInfoDto {
         val result = accessibilityApplicationService.getAccessibility(request.placeId, authentication?.details?.id)
-        return GetAccessibilityPost200Response(
+        return AccessibilityInfoDto(
             buildingAccessibility = result.buildingAccessibility?.let {
                 it.value.toDTO(
                     isUpvoted = result.buildingAccessibilityUpvoteInfo?.isUpvoted ?: false,

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
@@ -10,8 +10,8 @@ import club.staircrusher.accessibility.application.port.out.persistence.Building
 import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityRepository
 import club.staircrusher.api.converter.toDTO
 import club.staircrusher.api.spec.dto.PlaceAccessibilityDeletionInfo
-import club.staircrusher.api.spec.dto.RegisterAccessibilityPostRequestBuildingAccessibilityParams
-import club.staircrusher.api.spec.dto.RegisterAccessibilityPostRequestPlaceAccessibilityParams
+import club.staircrusher.api.spec.dto.RegisterBuildingAccessibilityRequestDto
+import club.staircrusher.api.spec.dto.RegisterPlaceAccessibilityRequestDto
 import club.staircrusher.api.spec.dto.User
 import club.staircrusher.stdlib.auth.AuthUser
 
@@ -41,7 +41,7 @@ fun BuildingAccessibility.toDTO(
     registeredUserName = registeredUserName,
 )
 
-fun RegisterAccessibilityPostRequestBuildingAccessibilityParams.toModel(userId: String?) =
+fun RegisterBuildingAccessibilityRequestDto.toModel(userId: String?) =
     BuildingAccessibilityRepository.CreateParams(
         buildingId = buildingId,
         entranceStairInfo = entranceStairInfo.toModel(),
@@ -98,7 +98,7 @@ fun StairInfo.toDTO() = when (this) {
     StairInfo.OVER_SIX -> club.staircrusher.api.spec.dto.StairInfo.oVERSIX
 }
 
-fun RegisterAccessibilityPostRequestPlaceAccessibilityParams.toModel(userId: String?) =
+fun RegisterPlaceAccessibilityRequestDto.toModel(userId: String?) =
     PlaceAccessibilityRepository.CreateParams(
         placeId = placeId,
         isFirstFloor = isFirstFloor,

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
@@ -1,6 +1,7 @@
 package club.staircrusher.accessibility.infra.adapter.`in`.controller
 
 import club.staircrusher.accessibility.application.UserInfo
+import club.staircrusher.accessibility.application.port.`in`.result.GetAccessibilityResult
 import club.staircrusher.accessibility.domain.model.BuildingAccessibility
 import club.staircrusher.accessibility.domain.model.BuildingAccessibilityComment
 import club.staircrusher.accessibility.domain.model.PlaceAccessibility
@@ -9,6 +10,7 @@ import club.staircrusher.accessibility.domain.model.StairInfo
 import club.staircrusher.accessibility.application.port.out.persistence.BuildingAccessibilityRepository
 import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityRepository
 import club.staircrusher.api.converter.toDTO
+import club.staircrusher.api.spec.dto.AccessibilityInfoDto
 import club.staircrusher.api.spec.dto.PlaceAccessibilityDeletionInfo
 import club.staircrusher.api.spec.dto.RegisterBuildingAccessibilityRequestDto
 import club.staircrusher.api.spec.dto.RegisterPlaceAccessibilityRequestDto
@@ -39,6 +41,30 @@ fun BuildingAccessibility.toDTO(
     isUpvoted = isUpvoted,
     totalUpvoteCount = totalUpvoteCount,
     registeredUserName = registeredUserName,
+)
+
+fun GetAccessibilityResult.toDTO(authUser: AuthUser?) = AccessibilityInfoDto(
+    buildingAccessibility = buildingAccessibility?.let {
+        it.value.toDTO(
+            isUpvoted = buildingAccessibilityUpvoteInfo?.isUpvoted ?: false,
+            totalUpvoteCount = buildingAccessibilityUpvoteInfo?.totalUpvoteCount ?: 0,
+            registeredUserName = it.userInfo?.nickname,
+        )
+    },
+    placeAccessibility = placeAccessibility?.let {
+        it.value.toDTO(
+            registeredUserInfo = it.userInfo,
+            authUser = authUser,
+            isLastInBuilding = isLastPlaceAccessibilityInBuilding,
+        )
+    },
+    buildingAccessibilityComments = buildingAccessibilityComments.map {
+        it.value.toDTO(userInfo = it.userInfo)
+    },
+    placeAccessibilityComments = placeAccessibilityComments.map {
+        it.value.toDTO(userInfo = it.userInfo)
+    },
+    hasOtherPlacesToRegisterInBuilding = hasOtherPlacesToRegisterInSameBuilding,
 )
 
 fun RegisterBuildingAccessibilityRequestDto.toModel(userId: String?) =

--- a/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/Place.kt
+++ b/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/Place.kt
@@ -15,10 +15,4 @@ data class Place(
     val address: BuildingAddress
         // FIXME
         get() = building.address
-
-    val isAccessibilityRegistrable: Boolean
-        get() {
-            val addressStr = address.toString()
-            return addressStr.startsWith("서울") || addressStr.startsWith("경기 성남시")
-        }
 }

--- a/subprojects/bounded_context/place_search/infra/src/integrationTest/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/ListPlacesInBuildingTest.kt
+++ b/subprojects/bounded_context/place_search/infra/src/integrationTest/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/ListPlacesInBuildingTest.kt
@@ -3,12 +3,12 @@ package club.staircrusher.place_search.infra.adapter.`in`.controller
 import club.staircrusher.api.spec.dto.ListPlacesInBuildingPostRequest
 import club.staircrusher.api.spec.dto.PlaceListItem
 import club.staircrusher.place_search.infra.adapter.`in`.controller.base.PlaceSearchITBase
+import club.staircrusher.stdlib.testing.SccRandom
 import com.fasterxml.jackson.core.type.TypeReference
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.random.Random
 
 class ListPlacesInBuildingTest : PlaceSearchITBase() {
     @Test
@@ -22,7 +22,7 @@ class ListPlacesInBuildingTest : PlaceSearchITBase() {
             val building = testDataGenerator.createBuilding()
             testDataGenerator.registerBuildingAccessibilityIfNotExists(building)
             val places = (1..placesCount).map {
-                val place = testDataGenerator.createPlace(placeName = Random.nextBytes(32).toString(), building = building)
+                val place = testDataGenerator.createPlace(placeName = SccRandom.string(32), building = building)
                 if (it % 3 == 0) {
                     testDataGenerator.registerPlaceAccessibility(place)
                     accessibilityRegisteredPlaceIds.add(place.id)

--- a/subprojects/bounded_context/place_search/infra/src/integrationTest/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/SearchPlacesTest.kt
+++ b/subprojects/bounded_context/place_search/infra/src/integrationTest/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/SearchPlacesTest.kt
@@ -6,6 +6,7 @@ import club.staircrusher.api.spec.dto.SearchPlacesPostRequest
 import club.staircrusher.place.application.port.out.web.MapsService
 import club.staircrusher.place.domain.model.BuildingAddress
 import club.staircrusher.place_search.infra.adapter.`in`.controller.base.PlaceSearchITBase
+import club.staircrusher.stdlib.testing.SccRandom
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.boot.test.mock.mockito.MockBean
-import kotlin.random.Random
 
 class SearchPlacesTest : PlaceSearchITBase() {
     @MockBean
@@ -26,7 +26,7 @@ class SearchPlacesTest : PlaceSearchITBase() {
             testDataGenerator.createUser()
         }
         val place = transactionManager.doInTransaction {
-            testDataGenerator.createBuildingAndPlace(placeName = Random.nextBytes(32).toString())
+            testDataGenerator.createBuildingAndPlace(placeName = SccRandom.string(32))
         }
         val searchText = place.name.substring(2, 5)
         val radiusMeters = 500
@@ -73,7 +73,7 @@ class SearchPlacesTest : PlaceSearchITBase() {
         }
         val place = transactionManager.doInTransaction {
             testDataGenerator.createBuildingAndPlace(
-                placeName = Random.nextBytes(32).toString(),
+                placeName = SccRandom.string(32),
                 buildingAddress = BuildingAddress(
                     siDo = "경기도",
                     siGunGu = "수원시",

--- a/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/LoginTest.kt
+++ b/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/LoginTest.kt
@@ -2,14 +2,14 @@ package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.LoginPostRequest
 import club.staircrusher.spring_web.security.SccSecurityFilterChainConfig
+import club.staircrusher.stdlib.testing.SccRandom
 import club.staircrusher.user.infra.adapter.`in`.controller.base.UserITBase
 import org.junit.jupiter.api.Test
-import kotlin.random.Random
 
 class LoginTest : UserITBase() {
     @Test
     fun testLogin() {
-        val nickname = Random.nextBytes(32).toString()
+        val nickname = SccRandom.string(32)
         val password = "password"
         transactionManager.doInTransaction {
             testDataGenerator.createUser(nickname = nickname, password = password)

--- a/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/SignUpTest.kt
+++ b/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/SignUpTest.kt
@@ -2,14 +2,14 @@ package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.SignUpPostRequest
 import club.staircrusher.spring_web.security.SccSecurityFilterChainConfig
+import club.staircrusher.stdlib.testing.SccRandom
 import club.staircrusher.user.infra.adapter.`in`.controller.base.UserITBase
 import org.junit.jupiter.api.Test
-import kotlin.random.Random
 
 class SignUpTest : UserITBase() {
     @Test
     fun testSignUp() {
-        val nickname = Random.nextBytes(32).toString()
+        val nickname = SccRandom.string(32)
         val params = SignUpPostRequest(
             nickname = nickname,
             instagramId = "instagramId",

--- a/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/column_adapter/ListToTextColumnAdapter.kt
+++ b/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/column_adapter/ListToTextColumnAdapter.kt
@@ -4,7 +4,7 @@ import app.cash.sqldelight.ColumnAdapter
 
 abstract class ListToTextColumnAdapter<T> : ColumnAdapter<List<T>, String> {
     override fun decode(databaseValue: String): List<T> {
-        return databaseValue.split(delimiter).map(::convertElementFromTextColumn)
+        return databaseValue.split(delimiter).filter { it.isNotBlank() }.map(::convertElementFromTextColumn)
     }
 
     override fun encode(value: List<T>): String {

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/testing/SccRandom.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/testing/SccRandom.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.stdlib.testing
+
+import java.time.Instant
+import java.util.Base64
+import kotlin.random.Random
+
+object SccRandom {
+    private val random = Random(Instant.now().toEpochMilli())
+
+    fun string(length: Int): String {
+        return Base64.getEncoder().encodeToString(random.nextBytes(length)).take(length)
+    }
+}

--- a/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
+++ b/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
@@ -21,13 +21,12 @@ import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.stdlib.geography.Location
 import club.staircrusher.stdlib.geography.eupMyeonDongById
 import club.staircrusher.stdlib.geography.siGunGuById
+import club.staircrusher.stdlib.testing.SccRandom
 import club.staircrusher.user.application.port.out.persistence.UserRepository
 import club.staircrusher.user.domain.model.User
 import club.staircrusher.user.domain.service.PasswordEncryptor
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Clock
-import java.util.Base64
-import kotlin.random.Random
 
 @Suppress("MagicNumber", "TooManyFunctions")
 @Component
@@ -64,7 +63,7 @@ class ITDataGenerator {
 
 
     fun createUser(
-        nickname: String = generateRandomString(12),
+        nickname: String = SccRandom.string(12),
         password: String = "password",
         instagramId: String? = null
     ): User {
@@ -215,9 +214,5 @@ class ITDataGenerator {
                 createdAt = clock.instant(),
             ),
         )
-    }
-
-    private fun generateRandomString(length: Int): String {
-        return Base64.getEncoder().encodeToString(Random.nextBytes(length)).take(length)
     }
 }


### PR DESCRIPTION
- api PR: https://github.com/Stair-Crusher-Club/scc-api/pull/9
- 건물 정보 등록과 장소 정보 등록을 별도로 할 수 있도록 합니다.
- 관련해서, 기존 registerAccessibility 메소드를 쪼개서 재활용할 수 있도록 변경합니다.