### PR TITLE
정보 등록 허용 지역 관련 어드민 구현

### DIFF
--- a/admin-api/api-spec.yaml
+++ b/admin-api/api-spec.yaml
@@ -207,6 +207,40 @@ paths:
       responses:
         '204': {}
 
+    get:
+      summary: 정보 등록 가능 지역 목록을 조회한다.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccessibilityAllowedRegionDTO'
+
+  /accessibilityAllowedRegions/{regionId}:
+    parameters:
+      - in: path
+        name: regionId
+        schema:
+          type: string
+        required: true
+
+    get:
+      summary: 정보 등록 가능 지역을 조회한다.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessibilityAllowedRegionDTO'
+
+    delete:
+      summary: 정보 등록 가능 지역을 삭제한다.
+      responses:
+        '204': {}
+
 components:
   # Reusable schemas (data models)
   schemas:
@@ -317,4 +351,19 @@ components:
             $ref: '#/components/schemas/LocationDTO'
       required:
         - name
+        - boundaryVertices
+
+    AccessibilityAllowedRegionDTO:
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        boundaryVertices:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationDTO'
+      required:
+        - id
+        - type
         - boundaryVertices

--- a/admin-api/api-spec.yaml
+++ b/admin-api/api-spec.yaml
@@ -7,7 +7,6 @@ info:
 
 defaultContentType: application/json
 
-
 paths:
   /login:
     post:
@@ -106,7 +105,7 @@ paths:
 
   /clubQuests/{clubQuestId}:
     get:
-      summary: dryRun 생성 결과를 받아서 실제로 퀘스트를 생성한다.
+      summary: 퀘스트를 조회한다.
       parameters:
         - in: path
           name: clubQuestId
@@ -195,6 +194,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClubQuestDTO'
+
+  /accessibilityAllowedRegions:
+    post:
+      summary: 정보 등록 가능 지역을 생성한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAccessibilityAllowedRegionRequestDTO'
+      responses:
+        '204': {}
 
 components:
   # Reusable schemas (data models)
@@ -295,3 +306,15 @@ components:
         - isConquered
         - isClosed
         - isNotAccessible
+
+    CreateAccessibilityAllowedRegionRequestDTO:
+      properties:
+        name:
+          type: string
+        boundaryVertices:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationDTO'
+      required:
+        - name
+        - boundaryVertices

--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -5,8 +5,10 @@ import LoginPage from './page/Login/LoginPage';
 import ClubQuestsPage from './page/ClubQuests/ClubQuestsPage';
 import CreateClubQuestPage from './page/CreateClubQuest/CreateClubQuestPage';
 import ClubQuestPage from './page/ClubQuest/ClubQuestPage';
+import AccessibilityAllowedRegionsPage from "./page/AccessibilityAllowedRegions/AccessibilityAllowedRegionsPage";
 import CreateAccessibilityAllowedRegionPage
   from "./page/CreateAccessibilityAllowedRegion/CreateAccessibilityAllowedRegionPage";
+import AccessibilityAllowedRegionPage from "./page/AccessibilityAllowedRegion/AccessibilityAllowedRegionPage";
 import AuthContext, { getSavedAccessToken } from './context/AuthContext';
 import PageLayout from './PageLayout';
 import AuthGuard from './AuthGuard';
@@ -29,7 +31,9 @@ function App() {
                 <Route path="/" element={<HomePage />} />
                 <Route path="clubQuests" element={<ClubQuestsPage />} />
                 <Route path="clubQuest/create" element={<CreateClubQuestPage />} />
+                <Route path="accessibilityAllowedRegions" element={<AccessibilityAllowedRegionsPage />} />
                 <Route path="accessibilityAllowedRegion/create" element={<CreateAccessibilityAllowedRegionPage />} />
+                <Route path="accessibilityAllowedRegions/:id" element={<AccessibilityAllowedRegionPage />} />
               </Route>
             </Route>
           </Routes>

--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -5,10 +5,11 @@ import LoginPage from './page/Login/LoginPage';
 import ClubQuestsPage from './page/ClubQuests/ClubQuestsPage';
 import CreateClubQuestPage from './page/CreateClubQuest/CreateClubQuestPage';
 import ClubQuestPage from './page/ClubQuest/ClubQuestPage';
+import CreateAccessibilityAllowedRegionPage
+  from "./page/CreateAccessibilityAllowedRegion/CreateAccessibilityAllowedRegionPage";
 import AuthContext, { getSavedAccessToken } from './context/AuthContext';
 import PageLayout from './PageLayout';
 import AuthGuard from './AuthGuard';
-
 import "./App.scss";
 
 function App() {
@@ -28,6 +29,7 @@ function App() {
                 <Route path="/" element={<HomePage />} />
                 <Route path="clubQuests" element={<ClubQuestsPage />} />
                 <Route path="clubQuest/create" element={<CreateClubQuestPage />} />
+                <Route path="accessibilityAllowedRegion/create" element={<CreateAccessibilityAllowedRegionPage />} />
               </Route>
             </Route>
           </Routes>

--- a/admin-frontend/src/AppMenu.tsx
+++ b/admin-frontend/src/AppMenu.tsx
@@ -19,6 +19,9 @@ function AppMenu() {
         <Link to="/clubQuests">
           <Button minimal={true} text="퀘스트 관리"></Button>
         </Link>
+        <Link to="/accessibilityAllowedRegions">
+          <Button minimal={true} text="정보 등록 허용 지역 관리"></Button>
+        </Link>
       </NavbarGroup>
       <NavbarGroup align="right">
         <Button minimal={true} text="로그아웃" onClick={logout}></Button>

--- a/admin-frontend/src/page/AccessibilityAllowedRegion/AccessibilityAllowedRegionPage.scss
+++ b/admin-frontend/src/page/AccessibilityAllowedRegion/AccessibilityAllowedRegionPage.scss
@@ -1,0 +1,11 @@
+.accessibility-allowed-region-page-body {
+  height: calc(100vh - 40px);
+  display: flex;
+  flex-direction: column;
+
+  #map {
+    min-width: 200px;
+    height: calc(100vw - 40px);
+    max-height: 500px;
+  }
+}

--- a/admin-frontend/src/page/AccessibilityAllowedRegion/AccessibilityAllowedRegionPage.tsx
+++ b/admin-frontend/src/page/AccessibilityAllowedRegion/AccessibilityAllowedRegionPage.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {Button, ButtonGroup} from "@blueprintjs/core";
+import { AccessibilityAllowedRegionDTO } from '../../api';
+import { determineCenter, determineLevel } from '../../util/kakaoMap';
+import { AdminApi } from '../../AdminApi';
+import LatLng = kakao.maps.LatLng;
+
+import './AccessibilityAllowedRegionPage.scss';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+function AccessibilityAllowedRegionPage() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [map, setMap] = useState<any>(null);
+  const [accessibilityAllowedRegion, setAccessibilityAllowedRegion] = useState<AccessibilityAllowedRegionDTO | null>(null);
+
+  const { id: _rawAccessibilityAllowedRegionId } = useParams();
+  const accessibilityAllowedRegionId = _rawAccessibilityAllowedRegionId!
+
+  const navigate = useNavigate()
+
+  function withLoading(promise: Promise<any>): Promise<any> {
+    setIsLoading(true);
+    return promise.finally(() => setIsLoading(false));
+  }
+
+  useEffect(() => {
+    withLoading(
+      AdminApi.accessibilityAllowedRegionsRegionIdGet(accessibilityAllowedRegionId)
+        .then((res) => {
+          const accessibilityAllowedRegion = res.data;
+          setAccessibilityAllowedRegion(accessibilityAllowedRegion);
+          installMap(accessibilityAllowedRegion);
+        })
+    );
+  }, []);
+
+  const installMap = (accessibilityAllowedRegion: AccessibilityAllowedRegionDTO) => {
+    if (map == null) {
+      const container = document.getElementById('map');
+      const center = determineCenter(accessibilityAllowedRegion.boundaryVertices);
+      const options = {
+        center: new window.kakao.maps.LatLng(center.lat, center.lng),
+        level: determineLevel(accessibilityAllowedRegion.boundaryVertices),
+      };
+      const map = new window.kakao.maps.Map(container, options);
+      setMap(map);
+
+      const polygon = new kakao.maps.Polygon({
+        path: accessibilityAllowedRegion.boundaryVertices.map(it => (new LatLng(it.lat, it.lng))),
+        strokeWeight: 10, // 선의 두께입니다.
+        // strokeColor: '#39DE2A', // 선의 색깔입니다.
+        strokeOpacity: 1, // 선의 불투명도 입니다. 1에서 0 사이의 값이며 0에 가까울수록 투명합니다.
+        // strokeStyle: 'solid', // 선의 스타일입니다.
+        // fillColor: '#A2FF99', // 채우기 색깔입니다.
+        // fillOpacity: 0.7 // 채우기 불투명도 입니다.
+      });
+      polygon.setMap(map);
+    }
+  }
+
+  const onAccessibilityAllowedRegionDeleteBtnClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!window.confirm(`정말 ${accessibilityAllowedRegion?.name} 지역을 삭제하시겠습니까?`)) {
+      return;
+    }
+    await withLoading(
+        AdminApi.accessibilityAllowedRegionsRegionIdDelete(accessibilityAllowedRegion?.id!)
+    );
+    alert('삭제를 완료했습니다.');
+    navigate('/accessibilityAllowedRegions');
+  };
+
+  return (
+    <div>
+      <h1>{accessibilityAllowedRegion?.name}</h1>
+      <div className="accessibility-allowed-region-page-body">
+        <div id="map" className="body-item-fixed-height" />
+        <ButtonGroup>
+          <Button icon="trash" text="삭제하기" onClick={onAccessibilityAllowedRegionDeleteBtnClick} disabled={isLoading}></Button>
+        </ButtonGroup>
+      </div>
+    </div>
+  );
+}
+
+export default AccessibilityAllowedRegionPage;

--- a/admin-frontend/src/page/AccessibilityAllowedRegions/AccessibilityAllowedRegionsPage.scss
+++ b/admin-frontend/src/page/AccessibilityAllowedRegions/AccessibilityAllowedRegionsPage.scss
@@ -1,0 +1,5 @@
+.accessibility-allowed-regions {
+  .title-column {
+    min-width: 500px;
+  }
+}

--- a/admin-frontend/src/page/AccessibilityAllowedRegions/AccessibilityAllowedRegionsPage.tsx
+++ b/admin-frontend/src/page/AccessibilityAllowedRegions/AccessibilityAllowedRegionsPage.tsx
@@ -1,0 +1,78 @@
+import { Button, ButtonGroup } from '@blueprintjs/core';
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AdminApi } from '../../AdminApi';
+
+import './AccessibilityAllowedRegionsPage.scss';
+import {AccessibilityAllowedRegionDTO} from "../../api";
+
+function AccessibilityAllowedRegionsPage() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [accessibilityAllowedRegions, setAccessibilityAllowedRegions] = useState<AccessibilityAllowedRegionDTO[]>([]);
+  const navigate = useNavigate();
+
+  function withLoading(promise: Promise<any>): Promise<any> {
+    setIsLoading(true);
+    return promise.finally(() => setIsLoading(false));
+  }
+
+  useEffect(() => {
+    withLoading(
+      AdminApi.accessibilityAllowedRegionsGet()
+        .then(res => setAccessibilityAllowedRegions(res.data) )
+    );
+  }, []);
+
+  function onAccessibilityAllowedRegionClick(accessibilityAllowedRegion: AccessibilityAllowedRegionDTO) {
+    return () => {
+      navigate(`/accessibilityAllowedRegions/${accessibilityAllowedRegion.id}`);
+    };
+  }
+
+  function onAccessibilityAllowedRegionDeleteBtnClick(accessibilityAllowedRegion: AccessibilityAllowedRegionDTO) {
+    return async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!window.confirm(`정말 ${accessibilityAllowedRegion.name} 지역을 삭제하시겠습니까?`)) {
+        return;
+      }
+      await withLoading(
+        AdminApi.accessibilityAllowedRegionsRegionIdDelete(accessibilityAllowedRegion.id)
+      );
+      alert('삭제를 완료했습니다.');
+
+      const res = await AdminApi.accessibilityAllowedRegionsGet()
+      setAccessibilityAllowedRegions(res.data);
+    };
+  }
+
+  return (
+    <div>
+      <h1>정보 등록 허용 지역</h1>
+      <ButtonGroup alignText="right">
+        <Link to="/accessibilityAllowedRegion/create">
+          <Button text="새 정보 등록 허용 지역 생성" />
+        </Link>
+      </ButtonGroup>
+      <table className="accessibility-allowed-regions bp4-html-table bp4-html-table-bordered bp4-html-table-condensed bp4-interactive">
+        <thead>
+          <tr>
+            <th className="title-column">정보 등록 허용 지역 이름</th>
+            <th>삭제</th>
+          </tr>
+        </thead>
+        <tbody>
+          {accessibilityAllowedRegions.map((accessibilityAllowedRegion) => {
+            return (
+              <tr onClick={onAccessibilityAllowedRegionClick(accessibilityAllowedRegion)}>
+                <td>{accessibilityAllowedRegion.name}</td>
+                <td><Button icon="trash" disabled={isLoading} onClick={onAccessibilityAllowedRegionDeleteBtnClick(accessibilityAllowedRegion)} /></td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default AccessibilityAllowedRegionsPage;

--- a/admin-frontend/src/page/CreateAccessibilityAllowedRegion/CreateAccessibilityAllowedRegionPage.scss
+++ b/admin-frontend/src/page/CreateAccessibilityAllowedRegion/CreateAccessibilityAllowedRegionPage.scss
@@ -1,0 +1,23 @@
+.create-accessibility-allowed-region-page-body {
+  display: flex;
+  flex-direction: column;
+
+  #map {
+    min-width: 200px;
+    height: calc(100vw - 40px);
+    max-height: 500px;
+  }
+
+  .body-item-fixed-height {
+    flex: 0 0 auto;
+  }
+
+  .input-group {
+    display: inline-block;
+    margin: 3px 10px 3px 0;
+  }
+
+  .inline-flex {
+    display: inline-flex;
+  }
+}

--- a/admin-frontend/src/page/CreateAccessibilityAllowedRegion/CreateAccessibilityAllowedRegionPage.tsx
+++ b/admin-frontend/src/page/CreateAccessibilityAllowedRegion/CreateAccessibilityAllowedRegionPage.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, InputGroup, NumericInput } from '@blueprintjs/core';
+import { CreateAccessibilityAllowedRegionRequestDTO } from '../../api';
+import { AdminApi } from '../../AdminApi';
+
+import './CreateAccessibilityAllowedRegionPage.scss';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+function CreateAccessibilityAllowedRegionPage() {
+  const [isLoading, _setIsLoading] = useState(false);
+  const isLoadingRef = useRef(isLoading);
+  function setIsLoading(newValue: boolean) {
+    isLoadingRef.current = newValue;
+    _setIsLoading(newValue);
+  }
+
+  const [map, setMap] = useState<kakao.maps.Map | null>(null);
+  const [regionName, setRegionName] = useState('');
+  const [boundaryVertices, _setBoundaryVertices] = useState<kakao.maps.LatLng[]>([]);
+  const polygonVerticesRef = useRef(boundaryVertices)
+  function setPolygonVertices(value: kakao.maps.LatLng[]) {
+    polygonVerticesRef.current = value;
+    _setBoundaryVertices(value);
+  }
+  useEffect(createOrUpdatePolygon, [boundaryVertices]);
+  const [polygon, setPolygon] = useState<kakao.maps.Polygon | null>(null);
+
+  const navigate = useNavigate();
+
+  function withLoading(promise: Promise<any>): Promise<any> {
+    setIsLoading(true);
+    return promise.finally(() => setIsLoading(false));
+  }
+
+  useEffect(installMapOnce, []);
+
+  function installMapOnce() {
+    if (map) {
+      return;
+    }
+    const container = document.getElementById('map');
+    const newMap: kakao.maps.Map = new window.kakao.maps.Map(container, {
+      center: new window.kakao.maps.LatLng(37.5642135, 127.0016985), // 서울 중심 좌표
+      level: 8,
+    });
+    setMap(newMap);
+    window.kakao.maps.event.addListener(newMap, 'click', addPolygonVertex);
+    const zoomControl = new window.kakao.maps.ZoomControl();
+    newMap.addControl(zoomControl, window.kakao.maps.ControlPosition.RIGHT);
+  }
+
+  function addPolygonVertex(mouseEvent: kakao.maps.event.MouseEvent) {
+    const latLng = mouseEvent.latLng;
+    setPolygonVertices([...polygonVerticesRef.current, latLng]);
+  }
+
+  function createOrUpdatePolygon() {
+    if (polygon != null) {
+      polygon.setMap(null);
+    }
+
+    const newPolygon = new kakao.maps.Polygon({
+      path: polygonVerticesRef.current,
+      strokeWeight: 10, // 선의 두께입니다.
+      // strokeColor: '#39DE2A', // 선의 색깔입니다.
+      strokeOpacity: 1, // 선의 불투명도 입니다. 1에서 0 사이의 값이며 0에 가까울수록 투명합니다.
+      // strokeStyle: 'solid', // 선의 스타일입니다.
+      // fillColor: '#A2FF99', // 채우기 색깔입니다.
+      // fillOpacity: 0.7 // 채우기 불투명도 입니다.
+    });
+    newPolygon.setMap(map);
+    setPolygon(newPolygon);
+  }
+
+  function onDeleteLastVertex() {
+    setPolygonVertices(polygonVerticesRef.current.slice(0, -1));
+  }
+
+  function onDeleteAllVertices() {
+    setPolygonVertices([]);
+  }
+
+  async function createAccessibilityAllowedRegion() {
+    if (!window.confirm('퀘스트를 생성하시겠습니까?')) {
+      return;
+    }
+    withLoading((
+      async () => {
+        await AdminApi.accessibilityAllowedRegionsPost({
+          name: regionName,
+          boundaryVertices: boundaryVertices.map(it => ({ lng: it.getLng(), lat: it.getLat() })),
+        });
+        alert('정보 등록 허용 지역 생성을 완료했습니다.');
+        // navigate('/accessibilityAllowedRegions');
+      }
+    )());
+  }
+
+  return (
+    <div>
+      <h1>정보 등록 허용 지역 생성하기</h1>
+      <div className="create-accessibility-allowed-region-page-body">
+        <div id="map" className="body-item-fixed-height" />
+        <div>
+          <div className="input-group">
+            <span>지역 이름 :&nbsp;</span>
+            <InputGroup
+              className="inline-flex"
+              value={regionName}
+              onChange={(event) => { setRegionName(event.target.value); }}
+              disabled={isLoading}
+            />
+          </div>
+          <Button icon="confirm" text="확정하기 (정보 등록 허용 지역 생성)" onClick={createAccessibilityAllowedRegion} disabled={isLoading}></Button>
+          <Button icon="trash" text="마지막 점 없애기" onClick={onDeleteLastVertex} disabled={isLoading || boundaryVertices.length == 0}></Button>
+          <Button icon="trash" text="모든 점 없애기" onClick={onDeleteAllVertices} disabled={isLoading || boundaryVertices.length == 0}></Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CreateAccessibilityAllowedRegionPage;

--- a/admin-frontend/src/page/CreateAccessibilityAllowedRegion/CreateAccessibilityAllowedRegionPage.tsx
+++ b/admin-frontend/src/page/CreateAccessibilityAllowedRegion/CreateAccessibilityAllowedRegionPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, InputGroup, NumericInput } from '@blueprintjs/core';
-import { CreateAccessibilityAllowedRegionRequestDTO } from '../../api';
+import { Button, InputGroup } from '@blueprintjs/core';
 import { AdminApi } from '../../AdminApi';
 
 import './CreateAccessibilityAllowedRegionPage.scss';
@@ -87,7 +86,7 @@ function CreateAccessibilityAllowedRegionPage() {
   }
 
   async function createAccessibilityAllowedRegion() {
-    if (!window.confirm('퀘스트를 생성하시겠습니까?')) {
+    if (!window.confirm('정보 등록 허용 지역을 생성하시겠습니까?')) {
       return;
     }
     withLoading((
@@ -97,7 +96,7 @@ function CreateAccessibilityAllowedRegionPage() {
           boundaryVertices: boundaryVertices.map(it => ({ lng: it.getLng(), lat: it.getLat() })),
         });
         alert('정보 등록 허용 지역 생성을 완료했습니다.');
-        // navigate('/accessibilityAllowedRegions');
+        navigate('/accessibilityAllowedRegions');
       }
     )());
   }

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityAllowedRegionService.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityAllowedRegionService.kt
@@ -1,0 +1,18 @@
+package club.staircrusher.accessibility.application.port.`in`
+
+import club.staircrusher.accessibility.application.port.out.persistence.AccessibilityAllowedRegionRepository
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.geography.Location
+import club.staircrusher.stdlib.geography.LocationUtils
+
+@Component
+class AccessibilityAllowedRegionService(
+    private val accessibilityAllowedRegionRepository: AccessibilityAllowedRegionRepository,
+) {
+    fun isAccessibilityAllowed(location: Location): Boolean {
+        return accessibilityAllowedRegionRepository.findAll()
+            .any {
+                LocationUtils.isInPolygon(it.boundaryVertices, location)
+            }
+    }
+}

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/CreateAccessibilityAllowedRegionUseCase.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/CreateAccessibilityAllowedRegionUseCase.kt
@@ -2,9 +2,11 @@ package club.staircrusher.accessibility.application.port.`in`
 
 import club.staircrusher.accessibility.application.port.out.persistence.AccessibilityAllowedRegionRepository
 import club.staircrusher.accessibility.domain.model.AccessibilityAllowedRegion
+import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.geography.Location
 import club.staircrusher.stdlib.persistence.TransactionManager
 
+@Component
 class CreateAccessibilityAllowedRegionUseCase(
     private val transactionManager: TransactionManager,
     private val accessibilityAllowedRegionRepository: AccessibilityAllowedRegionRepository,

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/CreateAccessibilityAllowedRegionUseCase.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/CreateAccessibilityAllowedRegionUseCase.kt
@@ -1,0 +1,21 @@
+package club.staircrusher.accessibility.application.port.`in`
+
+import club.staircrusher.accessibility.application.port.out.persistence.AccessibilityAllowedRegionRepository
+import club.staircrusher.accessibility.domain.model.AccessibilityAllowedRegion
+import club.staircrusher.stdlib.geography.Location
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+class CreateAccessibilityAllowedRegionUseCase(
+    private val transactionManager: TransactionManager,
+    private val accessibilityAllowedRegionRepository: AccessibilityAllowedRegionRepository,
+) {
+    fun handle(
+        name: String,
+        boundaryVertices: List<Location>,
+    ): AccessibilityAllowedRegion = transactionManager.doInTransaction {
+        accessibilityAllowedRegionRepository.save(AccessibilityAllowedRegion(
+            name = name,
+            boundaryVertices = boundaryVertices,
+        ))
+    }
+}

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/AccessibilityAllowedRegionRepository.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/AccessibilityAllowedRegionRepository.kt
@@ -5,4 +5,5 @@ import club.staircrusher.stdlib.domain.repository.EntityRepository
 
 interface AccessibilityAllowedRegionRepository : EntityRepository<AccessibilityAllowedRegion, String> {
     fun findAll(): List<AccessibilityAllowedRegion>
+    fun remove(id: String)
 }

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/AccessibilityAllowedRegionRepository.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/AccessibilityAllowedRegionRepository.kt
@@ -1,0 +1,6 @@
+package club.staircrusher.accessibility.application.port.out.persistence
+
+import club.staircrusher.accessibility.domain.model.AccessibilityAllowedRegion
+import club.staircrusher.stdlib.domain.repository.EntityRepository
+
+interface AccessibilityAllowedRegionRepository : EntityRepository<AccessibilityAllowedRegion, String>

--- a/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/AccessibilityAllowedRegionRepository.kt
+++ b/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/AccessibilityAllowedRegionRepository.kt
@@ -3,4 +3,6 @@ package club.staircrusher.accessibility.application.port.out.persistence
 import club.staircrusher.accessibility.domain.model.AccessibilityAllowedRegion
 import club.staircrusher.stdlib.domain.repository.EntityRepository
 
-interface AccessibilityAllowedRegionRepository : EntityRepository<AccessibilityAllowedRegion, String>
+interface AccessibilityAllowedRegionRepository : EntityRepository<AccessibilityAllowedRegion, String> {
+    fun findAll(): List<AccessibilityAllowedRegion>
+}

--- a/subprojects/bounded_context/accessibility/domain/src/main/kotlin/club/staircrusher/accessibility/domain/model/AccessibilityAllowedRegion.kt
+++ b/subprojects/bounded_context/accessibility/domain/src/main/kotlin/club/staircrusher/accessibility/domain/model/AccessibilityAllowedRegion.kt
@@ -1,0 +1,35 @@
+package club.staircrusher.accessibility.domain.model
+
+import club.staircrusher.stdlib.clock.SccClock
+import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
+import club.staircrusher.stdlib.geography.Location
+import java.time.Instant
+
+class AccessibilityAllowedRegion(
+    val id: String,
+    val name: String,
+    val boundaryVertices: List<Location>,
+    val createdAt: Instant = SccClock.instant(),
+    updatedAt: Instant = createdAt,
+) {
+    constructor(
+        name: String,
+        boundaryVertices: List<Location>,
+    ) : this(
+        id = EntityIdGenerator.generateRandom(),
+        name = name,
+        boundaryVertices = boundaryVertices,
+        createdAt = SccClock.instant(),
+    )
+
+    var updatedAt: Instant = updatedAt
+        private set
+
+    override fun equals(other: Any?): Boolean {
+        return other is AccessibilityAllowedRegion && other.id == id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityRankController.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityRankController.kt
@@ -59,7 +59,7 @@ class AccessibilityRankController(
             !clusterIpAddressMatcher.matches(request)
             && !localIpAddressMatcher.matches(request)
         ) {
-            throw Exception("Unauthorized")
+            throw IllegalArgumentException("Unauthorized")
         }
         updateRanksUseCase.handle()
     }

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AdminAccessibilityAllowedRegionController.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AdminAccessibilityAllowedRegionController.kt
@@ -1,8 +1,13 @@
 package club.staircrusher.accessibility.infra.adapter.`in`.controller
 
 import club.staircrusher.accessibility.application.port.`in`.CreateAccessibilityAllowedRegionUseCase
+import club.staircrusher.accessibility.application.port.out.persistence.AccessibilityAllowedRegionRepository
 import club.staircrusher.admin_api.converter.toModel
+import club.staircrusher.admin_api.spec.dto.AccessibilityAllowedRegionDTO
 import club.staircrusher.admin_api.spec.dto.CreateAccessibilityAllowedRegionRequestDTO
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -10,9 +15,26 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class AdminAccessibilityAllowedRegionController(
     private val createAccessibilityAllowedRegionUseCase: CreateAccessibilityAllowedRegionUseCase,
+    private val accessibilityAllowedRegionRepository: AccessibilityAllowedRegionRepository,
 ) {
     @PostMapping("/admin/accessibilityAllowedRegions")
     fun createAccessibilityAllowedRegion(@RequestBody request: CreateAccessibilityAllowedRegionRequestDTO) {
         createAccessibilityAllowedRegionUseCase.handle(request.name, request.boundaryVertices.map { it.toModel() })
+    }
+
+    @GetMapping("/admin/accessibilityAllowedRegions")
+    fun listAllAccessibilityAllowedRegions(): List<AccessibilityAllowedRegionDTO> {
+        return accessibilityAllowedRegionRepository.findAll().sortedByDescending { it.createdAt }
+            .map { it.toDTO() }
+    }
+
+    @GetMapping("/admin/accessibilityAllowedRegions/{regionId}")
+    fun getAccessibilityAllowedRegion(@PathVariable regionId: String): AccessibilityAllowedRegionDTO {
+        return accessibilityAllowedRegionRepository.findById(regionId).toDTO()
+    }
+
+    @DeleteMapping("/admin/accessibilityAllowedRegions/{regionId}")
+    fun deleteAccessibilityAllowedRegion(@PathVariable regionId: String) {
+        return accessibilityAllowedRegionRepository.remove(regionId)
     }
 }

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AdminAccessibilityAllowedRegionController.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AdminAccessibilityAllowedRegionController.kt
@@ -1,0 +1,18 @@
+package club.staircrusher.accessibility.infra.adapter.`in`.controller
+
+import club.staircrusher.accessibility.application.port.`in`.CreateAccessibilityAllowedRegionUseCase
+import club.staircrusher.admin_api.converter.toModel
+import club.staircrusher.admin_api.spec.dto.CreateAccessibilityAllowedRegionRequestDTO
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AdminAccessibilityAllowedRegionController(
+    private val createAccessibilityAllowedRegionUseCase: CreateAccessibilityAllowedRegionUseCase,
+) {
+    @PostMapping("/admin/accessibilityAllowedRegions")
+    fun createAccessibilityAllowedRegion(@RequestBody request: CreateAccessibilityAllowedRegionRequestDTO) {
+        createAccessibilityAllowedRegionUseCase.handle(request.name, request.boundaryVertices.map { it.toModel() })
+    }
+}

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AdminConverters.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AdminConverters.kt
@@ -1,0 +1,11 @@
+package club.staircrusher.accessibility.infra.adapter.`in`.controller
+
+import club.staircrusher.accessibility.domain.model.AccessibilityAllowedRegion
+import club.staircrusher.admin_api.converter.toDTO
+import club.staircrusher.admin_api.spec.dto.AccessibilityAllowedRegionDTO
+
+fun AccessibilityAllowedRegion.toDTO() = AccessibilityAllowedRegionDTO(
+    id = id,
+    boundaryVertices = boundaryVertices.map { it.toDTO() },
+    name = name,
+)

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
@@ -1,3 +1,4 @@
+@file:Suppress("TooManyFunctions")
 package club.staircrusher.accessibility.infra.adapter.`in`.controller
 
 import club.staircrusher.accessibility.application.UserInfo

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/security/AccessibilityBoundedContextSecurityConfig.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/security/AccessibilityBoundedContextSecurityConfig.kt
@@ -3,7 +3,6 @@ package club.staircrusher.accessibility.infra.adapter.`in`.security
 import club.staircrusher.spring_web.security.SccSecurityConfig
 import club.staircrusher.stdlib.di.annotation.Component
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
-import org.springframework.web.bind.annotation.PostMapping
 
 @Component
 class AccessibilityBoundedContextSecurityConfig : SccSecurityConfig {

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/security/AccessibilityBoundedContextSecurityConfig.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/security/AccessibilityBoundedContextSecurityConfig.kt
@@ -16,5 +16,6 @@ class AccessibilityBoundedContextSecurityConfig : SccSecurityConfig {
         "/registerAccessibility",
         "/registerPlaceAccessibility",
         "/registerBuildingAccessibility",
+        "/admin/accessibilityAllowedRegions"
     ).map { AntPathRequestMatcher(it) }
 }

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/AccessibilityRankRepository.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/AccessibilityRankRepository.kt
@@ -7,6 +7,7 @@ import club.staircrusher.accessibility.infra.adapter.out.persistence.sqldelight.
 import club.staircrusher.infra.persistence.sqldelight.DB
 import club.staircrusher.stdlib.di.annotation.Component
 
+@Suppress("TooManyFunctions")
 @Component
 class AccessibilityRankRepository(
     val db: DB,

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/SqlDelightAccessibilityAllowedRegionRepository.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/SqlDelightAccessibilityAllowedRegionRepository.kt
@@ -17,6 +17,10 @@ class SqlDelightAccessibilityAllowedRegionRepository(
         return queries.findAll().executeAsList().map { it.toDomainModel() }
     }
 
+    override fun remove(id: String) {
+        queries.remove(id)
+    }
+
     override fun save(entity: AccessibilityAllowedRegion): AccessibilityAllowedRegion {
         queries.save(entity.toPersistenceModel())
         return entity

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/SqlDelightAccessibilityAllowedRegionRepository.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/SqlDelightAccessibilityAllowedRegionRepository.kt
@@ -5,7 +5,9 @@ import club.staircrusher.accessibility.domain.model.AccessibilityAllowedRegion
 import club.staircrusher.accessibility.infra.adapter.out.persistence.sqldelight.toDomainModel
 import club.staircrusher.accessibility.infra.adapter.out.persistence.sqldelight.toPersistenceModel
 import club.staircrusher.infra.persistence.sqldelight.DB
+import club.staircrusher.stdlib.di.annotation.Component
 
+@Component
 class SqlDelightAccessibilityAllowedRegionRepository(
     db: DB
 ) : AccessibilityAllowedRegionRepository {

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/SqlDelightAccessibilityAllowedRegionRepository.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/SqlDelightAccessibilityAllowedRegionRepository.kt
@@ -1,0 +1,34 @@
+package club.staircrusher.accessibility.infra.adapter.out.persistence
+
+import club.staircrusher.accessibility.application.port.out.persistence.AccessibilityAllowedRegionRepository
+import club.staircrusher.accessibility.domain.model.AccessibilityAllowedRegion
+import club.staircrusher.accessibility.infra.adapter.out.persistence.sqldelight.toDomainModel
+import club.staircrusher.accessibility.infra.adapter.out.persistence.sqldelight.toPersistenceModel
+import club.staircrusher.infra.persistence.sqldelight.DB
+
+class SqlDelightAccessibilityAllowedRegionRepository(
+    db: DB
+) : AccessibilityAllowedRegionRepository {
+    private val queries = db.accessibilityAllowedRegionQueries
+
+    override fun save(entity: AccessibilityAllowedRegion): AccessibilityAllowedRegion {
+        queries.save(entity.toPersistenceModel())
+        return entity
+    }
+
+    override fun saveAll(entities: Collection<AccessibilityAllowedRegion>) {
+        entities.forEach(::save)
+    }
+
+    override fun removeAll() {
+        queries.removeAll()
+    }
+
+    override fun findById(id: String): AccessibilityAllowedRegion {
+        return findByIdOrNull(id) ?: throw IllegalArgumentException("AccessibilityAllowedRegion of id $id does not exist.")
+    }
+
+    override fun findByIdOrNull(id: String): AccessibilityAllowedRegion? {
+        return queries.findById(id).executeAsOneOrNull()?.toDomainModel()
+    }
+}

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/SqlDelightAccessibilityAllowedRegionRepository.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/SqlDelightAccessibilityAllowedRegionRepository.kt
@@ -13,6 +13,10 @@ class SqlDelightAccessibilityAllowedRegionRepository(
 ) : AccessibilityAllowedRegionRepository {
     private val queries = db.accessibilityAllowedRegionQueries
 
+    override fun findAll(): List<AccessibilityAllowedRegion> {
+        return queries.findAll().executeAsList().map { it.toDomainModel() }
+    }
+
     override fun save(entity: AccessibilityAllowedRegion): AccessibilityAllowedRegion {
         queries.save(entity.toPersistenceModel())
         return entity

--- a/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/sqldelight/Converters.kt
+++ b/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/out/persistence/sqldelight/Converters.kt
@@ -2,6 +2,7 @@
 
 package club.staircrusher.accessibility.infra.adapter.out.persistence.sqldelight
 
+import club.staircrusher.accessibility.domain.model.AccessibilityAllowedRegion
 import club.staircrusher.accessibility.domain.model.AccessibilityRank
 import club.staircrusher.accessibility.domain.model.BuildingAccessibility
 import club.staircrusher.accessibility.domain.model.BuildingAccessibilityComment
@@ -9,6 +10,7 @@ import club.staircrusher.accessibility.domain.model.BuildingAccessibilityUpvote
 import club.staircrusher.accessibility.domain.model.PlaceAccessibility
 import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
 import club.staircrusher.accessibility.domain.model.StairInfo
+import club.staircrusher.infra.persistence.sqldelight.migration.Accessibility_allowed_region
 import club.staircrusher.infra.persistence.sqldelight.migration.Accessibility_rank
 import club.staircrusher.infra.persistence.sqldelight.migration.Building_accessibility
 import club.staircrusher.infra.persistence.sqldelight.migration.Building_accessibility_comment
@@ -178,6 +180,22 @@ fun Accessibility_rank.toDomainModel() = AccessibilityRank(
     userId = user_id,
     conqueredCount = conquered_count,
     rank = rank,
+    createdAt = created_at.toInstant(),
+    updatedAt = updated_at.toInstant(),
+)
+
+fun AccessibilityAllowedRegion.toPersistenceModel() = Accessibility_allowed_region(
+    id = id,
+    name = name,
+     boundary_vertices = boundaryVertices,
+     created_at = createdAt.toOffsetDateTime(),
+     updated_at = updatedAt.toOffsetDateTime(),
+)
+
+fun Accessibility_allowed_region.toDomainModel() = AccessibilityAllowedRegion(
+    id = id,
+    name = name,
+    boundaryVertices = boundary_vertices,
     createdAt = created_at.toInstant(),
     updatedAt = updated_at.toInstant(),
 )

--- a/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/DB.kt
+++ b/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/DB.kt
@@ -1,8 +1,10 @@
 package club.staircrusher.infra.persistence.sqldelight
 
 import club.staircrusher.infra.persistence.sqldelight.column_adapter.ListToTextColumnAdapter
+import club.staircrusher.infra.persistence.sqldelight.column_adapter.LocationListToTextColumnAdapter
 import club.staircrusher.infra.persistence.sqldelight.column_adapter.PlaceCategoryStringColumnAdapter
 import club.staircrusher.infra.persistence.sqldelight.column_adapter.StringListToTextColumnAdapter
+import club.staircrusher.infra.persistence.sqldelight.migration.Accessibility_allowed_region
 import club.staircrusher.infra.persistence.sqldelight.migration.Building_accessibility
 import club.staircrusher.infra.persistence.sqldelight.migration.Club_quest
 import club.staircrusher.infra.persistence.sqldelight.migration.Place
@@ -44,6 +46,9 @@ class DB(dataSource: DataSource) : TransactionManager {
                 }
 
             }
+        ),
+        accessibility_allowed_regionAdapter = Accessibility_allowed_region.Adapter(
+            boundary_verticesAdapter = LocationListToTextColumnAdapter,
         )
     )
 
@@ -57,6 +62,7 @@ class DB(dataSource: DataSource) : TransactionManager {
     val accessibilityRankQueries = scc.accessibilityRankQueries
     val userQueries = scc.userQueries
     val clubQuestQueries = scc.clubQuestQueries
+    val accessibilityAllowedRegionQueries = scc.accessibilityAllowedRegionQueries
 
     override fun <T> doInTransaction(block: Transaction<T>.() -> T): T {
         // FIXME: 다른 bounded context의 기능을 호출하기 때문에 nested transaction이 반드시 발생한다.

--- a/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/column_adapter/LocationListToTextColumnAdapter.kt
+++ b/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/column_adapter/LocationListToTextColumnAdapter.kt
@@ -1,0 +1,11 @@
+package club.staircrusher.infra.persistence.sqldelight.column_adapter
+
+import club.staircrusher.stdlib.geography.Location
+
+object LocationListToTextColumnAdapter : ListToTextColumnAdapter<Location>() {
+    override fun convertElementToTextColumn(element: Location) = with(element) { "$lng/$lat" }
+    override fun convertElementFromTextColumn(text: String): Location {
+        val (lngStr, latStr) = text.split("/")
+        return Location(lngStr.toDouble(), latStr.toDouble())
+    }
+}

--- a/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/migration/V8__accessibility_allowed_region.sqm
+++ b/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/migration/V8__accessibility_allowed_region.sqm
@@ -1,0 +1,13 @@
+import kotlin.collections.List;
+import club.staircrusher.stdlib.geography.Location;
+
+CREATE TABLE IF NOT EXISTS accessibility_allowed_region (
+    id VARCHAR(36) NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    boundary_vertices TEXT AS List<Location> NOT NULL,
+    created_at TIMESTAMP(6) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP(6) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_accessibility_allowed_region_1 ON accessibility_allowed_region(created_at);

--- a/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/accessibility/AccessibilityAllowedRegion.sq
+++ b/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/accessibility/AccessibilityAllowedRegion.sq
@@ -1,0 +1,21 @@
+save:
+INSERT INTO accessibility_allowed_region
+VALUES :accessibility_allowed_region
+ON CONFLICT(id) DO UPDATE SET
+    id = EXCLUDED.id,
+    name = EXCLUDED.name,
+    boundary_vertices = EXCLUDED.boundary_vertices,
+    created_at = EXCLUDED.created_at,
+    updated_at = EXCLUDED.updated_at;
+
+removeAll:
+DELETE FROM accessibility_allowed_region;
+
+remove:
+DELETE FROM accessibility_allowed_region
+WHERE id = :id;
+
+findById:
+SELECT *
+FROM accessibility_allowed_region
+WHERE id = :id;

--- a/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/accessibility/AccessibilityAllowedRegion.sq
+++ b/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/accessibility/AccessibilityAllowedRegion.sq
@@ -19,3 +19,7 @@ findById:
 SELECT *
 FROM accessibility_allowed_region
 WHERE id = :id;
+
+findAll:
+SELECT *
+FROM accessibility_allowed_region;

--- a/subprojects/stdlib/build.gradle.kts
+++ b/subprojects/stdlib/build.gradle.kts
@@ -11,6 +11,10 @@ dependencies {
 
     ksp("at.kopyk:kopykat-ksp:$kopyKatVersion")
     compileOnly("at.kopyk:kopykat-annotations:$kopyKatVersion")
+
+    val jUnitJupiterVersion: String by project
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$jUnitJupiterVersion")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jUnitJupiterVersion")
 }
 
 ksp {

--- a/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/LocationUtils.kt
+++ b/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/geography/LocationUtils.kt
@@ -9,4 +9,19 @@ object LocationUtils {
         calculator.setDestinationGeographicPoint(l2.lng, l2.lat)
         return Length(calculator.orthodromicDistance)
     }
+
+    /**
+     * https://stackoverflow.com/questions/217578/how-can-i-determine-whether-a-2d-point-is-within-a-polygon#answer-2922778
+     */
+    fun isInPolygon(polygonVertices: List<Location>, testLocation: Location): Boolean {
+        val edges = polygonVertices.zip(polygonVertices.subList(1, polygonVertices.size) + polygonVertices[0])
+        var result = false
+        edges.forEach { (v1, v2) ->
+            if ((v1.lat > testLocation.lat) != (v2.lat > testLocation.lat) &&
+                (testLocation.lng < (v2.lng - v1.lng) * (testLocation.lat - v1.lat) / (v2.lat - v1.lat) + v1.lng)) {
+                result = !result
+            }
+        }
+        return result
+    }
 }

--- a/subprojects/stdlib/src/unitTest/kotlin/club/staircrusher/stdlib/geography/LocationUtilsTest.kt
+++ b/subprojects/stdlib/src/unitTest/kotlin/club/staircrusher/stdlib/geography/LocationUtilsTest.kt
@@ -1,0 +1,73 @@
+package club.staircrusher.stdlib.geography
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LocationUtilsTest {
+    @Test
+    fun `isInPolygon - 정사각형 polygon`() {
+        val boundaryVertices = listOf(
+            Location(1.0, 1.0),
+            Location(1.0, 2.0),
+            Location(2.0, 2.0),
+            Location(2.0, 1.0),
+        )
+        val testLocation1 = Location(1.5, 1.5)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation1))
+        val testLocation2 = Location(1.05, 1.95)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation2))
+        val testLocation3 = Location(1.95, 1.95)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation3))
+
+        val testLocation4 = Location(-1.0, -1.0)
+        assertFalse(LocationUtils.isInPolygon(boundaryVertices, testLocation4))
+        val testLocation5 = Location(0.0, 1.5)
+        assertFalse(LocationUtils.isInPolygon(boundaryVertices, testLocation5))
+        val testLocation6 = Location(2.05, 1.05)
+        assertFalse(LocationUtils.isInPolygon(boundaryVertices, testLocation6))
+
+        // boundary에 거의 근접한 경우 테스트; 완전 boundary는 예외가 좀 있다고 해서 테스트하지 않는다.
+        val testLocation7 = Location(1.00001, 1.5)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation7))
+        val testLocation8 = Location(1.5, 1.99999)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation8))
+        val testLocation9 = Location(1.99999, 1.5)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation9))
+        val testLocation10 = Location(1.5, 1.00001)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation10))
+    }
+
+    @Test
+    fun `isInPolygon - 마름모 polygon`() {
+        val boundaryVertices = listOf(
+            Location(0.0, 1.0),
+            Location(1.0, 2.0),
+            Location(2.0, 1.0),
+            Location(1.0, 0.0),
+        )
+        val testLocation1 = Location(1.0, 1.0)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation1))
+        val testLocation2 = Location(1.0, 0.05)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation2))
+        val testLocation3 = Location(1.95, 1.0)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation3))
+
+        val testLocation4 = Location(0.0, 0.00)
+        assertFalse(LocationUtils.isInPolygon(boundaryVertices, testLocation4))
+        val testLocation5 = Location(0.0, 1.05)
+        assertFalse(LocationUtils.isInPolygon(boundaryVertices, testLocation5))
+        val testLocation6 = Location(1.55, 1.55)
+        assertFalse(LocationUtils.isInPolygon(boundaryVertices, testLocation6))
+
+        // boundary에 거의 근접한 경우 테스트; 완전 boundary는 예외가 좀 있다고 해서 테스트하지 않는다.
+        val testLocation7 = Location(0.50001, 0.50001)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation7))
+        val testLocation8 = Location(0.50001, 1.49999)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation8))
+        val testLocation9 = Location(1.49999, 1.49999)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation9))
+        val testLocation10 = Location(1.49999, 0.50001)
+        assertTrue(LocationUtils.isInPolygon(boundaryVertices, testLocation10))
+    }
+}


### PR DESCRIPTION
- 정보 등록 허용 지역을 도입하고, 어드민에서 생성 / 조회 / 삭제할 수 있도록 합니다.
- 어드민 쪽은 굳이 안 봐주셔도 될 것 같고, 정보 등록 허용 지역이 존재할 때 잘 동작해야 하는 로직 - e.g. 장소 검색 시 등록 가능 지역으로 잘 표시되고, 실제로 등록이 가능함 - 이나, 엔티티 구조 등 서버 쪽만 리뷰해주심 될 것 같습니다.