### PR TITLE
PROD 환경에 대한 CI/CD github action 추가

### DIFF
--- a/.github/workflows/prod-ci-cd.yaml
+++ b/.github/workflows/prod-ci-cd.yaml
@@ -1,0 +1,180 @@
+name: prod-ci-cd
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+' # Follow semantic versioning
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  backend-ci:
+    runs-on: ubuntu-latest
+    services:
+      postgresql:
+        image: postgres:14.5-alpine
+        ports:
+          - 15432:5432
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: scc_test
+
+    defaults:
+      run:
+        working-directory: app-server
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set RELEASE_VERSION
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: adopt
+          java-version: 19
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Gradle Check
+        run: ./gradlew check
+
+      - uses: actions/upload-artifact@v3
+        name: Upload Check Report If Failed
+        if: failure()
+        with:
+          name: test report
+          path: "**/build/reports"
+          retention-days: 1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::833004893731:role/github-action-ci-cd
+          aws-region: ap-northeast-2
+
+      - name: Build and Push Docker Image
+        run: ./gradlew jib -Pversion=$RELEASE_VERSION
+
+  frontend-ci:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: app-admin-frontend
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set RELEASE_VERSION
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install & Run openapi-generator
+        run: |
+          mkdir -p ~/bin/openapitools
+          curl https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/bin/utils/openapi-generator-cli.sh > ~/bin/openapitools/openapi-generator-cli
+          chmod u+x ~/bin/openapitools/openapi-generator-cli
+          export PATH=$PATH:~/bin/openapitools/
+
+          mv ~/bin/openapitools/openapi-generator-cli ~/bin/openapitools/openapi-generator
+
+          ./generate-api-spec.sh
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::833004893731:role/github-action-ci-cd
+          aws-region: ap-northeast-2
+
+      - name: Build and Push Image
+        run: ./docker-push.sh prod $RELEASE_VERSION
+
+  cd:
+    runs-on: ubuntu-latest
+    needs:
+      - backend-ci
+      - frontend-ci
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set RELEASE_VERSION
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Install kubeconfig
+        env:
+          SCC_K3S_KUBECONFIG: ${{ secrets.SCC_K3S_KUBECONFIG }}
+        run: |
+          mkdir -p ~/.kube && echo "$SCC_K3S_KUBECONFIG" > ~/.kube/config
+
+      - uses: azure/setup-helm@v1
+        with:
+          version: '3.8.2'
+        id: install-helm
+
+      - uses: azure/setup-kubectl@v3
+        with:
+           version: 'v1.24.1'
+        id: install-kubectl
+
+      - name: Update image tag for scc-server
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.image.tag = strenv(RELEASE_VERSION)' 'infra/helm/scc-server/values-prod.yaml'
+
+      - name: Upgrade scc-server helm chart
+        working-directory: infra/helm/scc-server
+        run: |
+          helm upgrade --install --namespace scc -f values-prod.yaml scc-server ./
+
+      - name: Update image tag for scc-admin-frontend
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.image.tag = strenv(RELEASE_VERSION)' 'infra/helm/scc-admin-frontend/values-prod.yaml'
+
+      - name: Upgrade scc-admin-frontend helm chart
+        working-directory: infra/helm/scc-admin-frontend
+        run: |
+          helm upgrade --install --namespace scc -f values-prod.yaml scc-admin-frontend ./
+
+  update-main-branch:
+    runs-on: ubuntu-latest
+    needs:
+      - cd
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set RELEASE_VERSION
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+        with:
+          ref: refs/heads/main
+          token: ${{ secrets.STAIRCRUSHERCLUB_ACCOUNT_GH_TOKEN }}
+
+      - name: Update image tag for scc-server
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.image.tag = strenv(RELEASE_VERSION)' 'infra/helm/scc-server/values-prod.yaml'
+
+      - name: Update image tag for scc-admin-frontend
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.image.tag = strenv(RELEASE_VERSION)' 'infra/helm/scc-admin-frontend/values-prod.yaml'
+
+      - name: Commit and push image tag for main branch
+        run: |
+          git config --global user.email "staircrusherclub.dev@gmail.com"
+          git config --global user.name "Stair-Crusher-Club"
+          git diff
+          git add .
+          git commit -m "Prod deploy: $RELEASE_VERSION"
+          git push

--- a/app-admin-frontend/docker-push.sh
+++ b/app-admin-frontend/docker-push.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if [[ $1 != "dev" && $1 != "prod" ]]; then
-  echo 'Usage: ./docker-push.sh (dev|prod)'
+  echo 'Usage: ./docker-push.sh (dev|prod) [<release-version>]; <release-version> is "latest" by default'
   exit 0
 fi;
 
-IMAGE_TAG=latest
+IMAGE_TAG="${2:-"latest"}"
 if [[ $1 = "dev" ]]; then
-  IMAGE_TAG="$IMAGE_TAG-rc"
+  IMAGE_TAG="IMAGE_TAG-rc"
 fi;
 
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q0g6g7m8


### PR DESCRIPTION
- DEV 환경에 이어서 PROD도 추가합니다.
- 순서는 대략 다음과 같이 하려고 합니다.
  1. **semantic versioning을 따른 git tag를 따서 푸시합니다. <- 개발자가 해야 하는 행동**
  2. tag를 딴 commit에서 빌드를 돌리고, tag 이름으로 이미지를 푸시합니다.
  3. 서버를 배포합니다.
  4. values-prod.yaml의 `image.tag` 값을 tag 이름으로 바꿔서 main 브랜치에 커밋 & 푸시합니다.
- 이렇게 할 경우,
  - 현재 실섭에 배포된 버전은 (롤백을 하지 않는 한) 최신 main 브랜치의 values-prod.yaml을 보고 빠르게 알 수 있습니다.
  - 현재 실섭에 배포된 버전의 코드는 `git checkout <버전>`을 통해 확인할 수 있습니다.
  - 롤백하는 경우에 현재 배포된 버전 확인이 좀 어렵긴 한데, 이건 그냥 감수하고 가려고 합니다.