### PR TITLE
[카카오 로그인] 유저 정보 입력 플로우를 위해 updateUserInfo API 수정

### DIFF
--- a/app-server/subprojects/api/scc-api/api-spec.yaml
+++ b/app-server/subprojects/api/scc-api/api-spec.yaml
@@ -475,9 +475,11 @@ paths:
                 instagramId:
                   type: string
                   description: 변경되지 않았으면 기존 값을 그대로 올려준다.
+                email:
+                  type: string
               required:
                 - nickname
-                - instagramId
+                - email
       responses:
         '200':
           content:

--- a/app-server/subprojects/api/scc-api/api-spec.yaml
+++ b/app-server/subprojects/api/scc-api/api-spec.yaml
@@ -496,6 +496,12 @@ paths:
                     $ref: '#/components/schemas/User'
                 required:
                   - user
+        '400':
+          $ref: '#/components/responses/ApiFailure'
+          description: |-
+            에러 코드 설명
+            - INVALID_NICKNAME : 닉네임이 유효하지 않을 때. e.g. 중복, 2글자 미만 등.
+            - INVALID_EMAIL : 이메일이 유효하지 않을 때. e.g. 중복, 이상한 형태 등.
 
   /deleteUser:
     post:
@@ -1052,9 +1058,13 @@ components:
           x-enum-varnames:
             - INTERNAL_FAILURE # -999999
             - INVALID_AUTHENTICATION # 1
+            - INVALID_NICKNAME # 2
+            - INVALID_EMAIL # 3
           enum:
             - -999999
             - 1
+            - 2
+            - 3
 
     GiveBuildingAccessibilityUpvoteRequestDto:
       type: object

--- a/app-server/subprojects/api/scc-api/api-spec.yaml
+++ b/app-server/subprojects/api/scc-api/api-spec.yaml
@@ -477,9 +477,14 @@ paths:
                   description: 변경되지 않았으면 기존 값을 그대로 올려준다.
                 email:
                   type: string
+                mobilityTools:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/UserMobilityToolDto'
               required:
                 - nickname
                 - email
+                - mobilityTools
       responses:
         '200':
           content:
@@ -686,10 +691,24 @@ components:
           type: string
         email:
           type: string
-        # TODO: TBD
+        mobilityTools:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserMobilityToolDto'
       required:
         - id
         - nickname
+        - mobilityTools
+
+    UserMobilityToolDto:
+      type: string
+      enum:
+        - MANUAL_WHEELCHAIR # 수동휠체어
+        - ELECTRIC_WHEELCHAIR # 전동휠체어
+        - MANUAL_AND_ELECTRIC_WHEELCHAIR # 수전동휠체어
+        - STROLLER # 유아차 이용자
+        - WALKING_ASSISTANCE_DEVICE # 보행보조기구
+        # TODO: TBD
 
     Place:
       description: 점포 정보.
@@ -773,7 +792,7 @@ components:
         placeId:
           type: string
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/AccessibilityRegistererDto'
           description: 익명으로 달린 댓글이면 null.
         comment:
           type: string
@@ -784,6 +803,19 @@ components:
         - placeId
         - comment
         - createdAt
+
+    AccessibilityRegistererDto:
+      type: object
+      properties:
+        id:
+          type: string
+        nickname:
+          type: string
+        instagramId:
+          type: string
+      required:
+        - id
+        - nickname
 
     BuildingAccessibility:
       description: 건물의 접근성 정보.
@@ -837,7 +869,7 @@ components:
         buildingId:
           type: string
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/AccessibilityRegistererDto'
           description: 익명으로 달린 댓글이면 null.
         comment:
           type: string
@@ -996,7 +1028,7 @@ components:
       type: object
       properties:
         user:
-          $ref: '#/components/schemas/User'
+          $ref: '#/components/schemas/AccessibilityRegistererDto'
         conqueredCount:
           type: integer
           description: 접근성 정보를 등록한 장소의 수.

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/AccessibilityRegisterer.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/AccessibilityRegisterer.kt
@@ -2,13 +2,13 @@ package club.staircrusher.accessibility.application
 
 import club.staircrusher.user.domain.model.User
 
-data class UserInfo(
+data class AccessibilityRegisterer(
     val userId: String,
     val nickname: String,
     val instagramId: String?,
 )
 
-fun User.toDomainModel() = UserInfo(
+fun User.toDomainModel() = AccessibilityRegisterer(
     userId = id,
     nickname = nickname,
     instagramId = instagramId,

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
@@ -1,6 +1,6 @@
 package club.staircrusher.accessibility.application.port.`in`
 
-import club.staircrusher.accessibility.application.UserInfo
+import club.staircrusher.accessibility.application.AccessibilityRegisterer
 import club.staircrusher.accessibility.application.port.`in`.result.GetAccessibilityResult
 import club.staircrusher.accessibility.application.port.`in`.result.RegisterBuildingAccessibilityResult
 import club.staircrusher.accessibility.application.port.`in`.result.RegisterPlaceAccessibilityResult
@@ -87,14 +87,14 @@ class AccessibilityApplicationService(
             buildingAccessibilityComments = buildingAccessibilityComments.map {
                 WithUserInfo(
                     value = it,
-                    userInfo = userInfoById[it.userId],
+                    accessibilityRegisterer = userInfoById[it.userId],
                 )
             },
             placeAccessibility = placeAccessibility?.let { WithUserInfo(it, userInfoById[it.userId]) },
             placeAccessibilityComments = placeAccessibilityComments.map {
                 WithUserInfo(
                     value = it,
-                    userInfo = userInfoById[it.userId],
+                    accessibilityRegisterer = userInfoById[it.userId],
                 )
             },
             hasOtherPlacesToRegisterInSameBuilding = placeAccessibilityRepository.hasAccessibilityNotRegisteredPlaceInBuilding(place.building.id),
@@ -122,7 +122,7 @@ class AccessibilityApplicationService(
         val placeAccessibilityComment: PlaceAccessibilityComment?,
         val buildingAccessibility: BuildingAccessibility?,
         val buildingAccessibilityComment: BuildingAccessibilityComment?,
-        val userInfo: UserInfo?,
+        val accessibilityRegisterer: AccessibilityRegisterer?,
         val registrationOrder: Int, // n번째 정복자를 표현하기 위한 값.
         val isLastPlaceAccessibilityInBuilding: Boolean,
     )
@@ -142,7 +142,7 @@ class AccessibilityApplicationService(
             placeAccessibilityComment = registerPlaceAccessibilityResult.placeAccessibilityComment,
             buildingAccessibility = registerBuildingAccessibilityResult?.buildingAccessibility,
             buildingAccessibilityComment = registerBuildingAccessibilityResult?.buildingAccessibilityComment,
-            userInfo = registerPlaceAccessibilityResult.userInfo,
+            accessibilityRegisterer = registerPlaceAccessibilityResult.accessibilityRegisterer,
             registrationOrder = registerPlaceAccessibilityResult.registrationOrder,
             isLastPlaceAccessibilityInBuilding = registerPlaceAccessibilityResult.isLastPlaceAccessibilityInBuilding,
         )
@@ -191,7 +191,7 @@ class AccessibilityApplicationService(
         return RegisterBuildingAccessibilityResult(
             buildingAccessibility = buildingAccessibility,
             buildingAccessibilityComment = buildingAccessibilityComment,
-            userInfo = userInfo,
+            accessibilityRegisterer = userInfo,
         )
     }
 
@@ -228,7 +228,7 @@ class AccessibilityApplicationService(
         return RegisterPlaceAccessibilityResult(
             placeAccessibility = result,
             placeAccessibilityComment = placeAccessibilityComment,
-            userInfo = userInfo,
+            accessibilityRegisterer = userInfo,
             registrationOrder = placeAccessibilityRepository.countAll(),
             isLastPlaceAccessibilityInBuilding = result.isLastPlaceAccessibilityInBuilding(buildingId) ?: false,
         )
@@ -240,7 +240,7 @@ class AccessibilityApplicationService(
         val comment = doRegisterBuildingAccessibilityComment(params)
         WithUserInfo(
             value = comment,
-            userInfo = params.userId?.let { userApplicationService.getUser(it) }?.toDomainModel(),
+            accessibilityRegisterer = params.userId?.let { userApplicationService.getUser(it) }?.toDomainModel(),
         )
     }
 
@@ -268,7 +268,7 @@ class AccessibilityApplicationService(
         val comment = doRegisterPlaceAccessibilityComment(params)
         WithUserInfo(
             value = comment,
-            userInfo = params.userId?.let { userApplicationService.getUser(it) }?.toDomainModel(),
+            accessibilityRegisterer = params.userId?.let { userApplicationService.getUser(it) }?.toDomainModel(),
         )
     }
 

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/RegisterBuildingAccessibilityResult.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/RegisterBuildingAccessibilityResult.kt
@@ -1,11 +1,11 @@
 package club.staircrusher.accessibility.application.port.`in`.result
 
-import club.staircrusher.accessibility.application.UserInfo
+import club.staircrusher.accessibility.application.AccessibilityRegisterer
 import club.staircrusher.accessibility.domain.model.BuildingAccessibility
 import club.staircrusher.accessibility.domain.model.BuildingAccessibilityComment
 
 data class RegisterBuildingAccessibilityResult(
     val buildingAccessibility: BuildingAccessibility?,
     val buildingAccessibilityComment: BuildingAccessibilityComment?,
-    val userInfo: UserInfo?,
+    val accessibilityRegisterer: AccessibilityRegisterer?,
 )

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/RegisterPlaceAccessibilityResult.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/RegisterPlaceAccessibilityResult.kt
@@ -1,13 +1,13 @@
 package club.staircrusher.accessibility.application.port.`in`.result
 
-import club.staircrusher.accessibility.application.UserInfo
+import club.staircrusher.accessibility.application.AccessibilityRegisterer
 import club.staircrusher.accessibility.domain.model.PlaceAccessibility
 import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
 
 data class RegisterPlaceAccessibilityResult(
     val placeAccessibility: PlaceAccessibility,
     val placeAccessibilityComment: PlaceAccessibilityComment?,
-    val userInfo: UserInfo?,
+    val accessibilityRegisterer: AccessibilityRegisterer?,
     val registrationOrder: Int, // n번째 정복자를 표현하기 위한 값.
     val isLastPlaceAccessibilityInBuilding: Boolean,
 )

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/WithUserInfo.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/result/WithUserInfo.kt
@@ -1,8 +1,8 @@
 package club.staircrusher.accessibility.application.port.`in`.result
 
-import club.staircrusher.accessibility.application.UserInfo
+import club.staircrusher.accessibility.application.AccessibilityRegisterer
 
 data class WithUserInfo<T>(
     val value: T,
-    val userInfo: UserInfo?
+    val accessibilityRegisterer: AccessibilityRegisterer?
 )

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityCommentController.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityCommentController.kt
@@ -29,7 +29,7 @@ class AccessibilityCommentController(
             )
         )
         return RegisterBuildingAccessibilityCommentPost200Response(
-            buildingAccessibilityComment = result.value.toDTO(userInfo = result.userInfo)
+            buildingAccessibilityComment = result.value.toDTO(accessibilityRegisterer = result.accessibilityRegisterer)
         )
     }
 
@@ -46,7 +46,7 @@ class AccessibilityCommentController(
             )
         )
         return RegisterPlaceAccessibilityCommentPost200Response(
-            placeAccessibilityComment = result.value.toDTO(userInfo = result.userInfo)
+            placeAccessibilityComment = result.value.toDTO(accessibilityRegisterer = result.accessibilityRegisterer)
         )
     }
 }

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityController.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityController.kt
@@ -78,18 +78,18 @@ class AccessibilityController(
             buildingAccessibility = result.buildingAccessibility?.toDTO(
                 isUpvoted = false,
                 totalUpvoteCount = 0,
-                registeredUserName = result.userInfo?.nickname,
+                registeredUserName = result.accessibilityRegisterer?.nickname,
             ),
             buildingAccessibilityComments = listOfNotNull(result.buildingAccessibilityComment).map {
-                it.toDTO(userInfo = result.userInfo)
+                it.toDTO(accessibilityRegisterer = result.accessibilityRegisterer)
             },
             placeAccessibility = result.placeAccessibility.toDTO(
-                registeredUserInfo = result.userInfo,
+                registeredAccessibilityRegisterer = result.accessibilityRegisterer,
                 authUser = authentication.details,
                 isLastInBuilding = result.isLastPlaceAccessibilityInBuilding,
             ),
             placeAccessibilityComments = listOfNotNull(result.placeAccessibilityComment).map {
-                it.toDTO(userInfo = result.userInfo)
+                it.toDTO(accessibilityRegisterer = result.accessibilityRegisterer)
             },
             registeredUserOrder = result.registrationOrder,
         )

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
@@ -2,7 +2,7 @@
 
 package club.staircrusher.accessibility.infra.adapter.`in`.controller
 
-import club.staircrusher.accessibility.application.UserInfo
+import club.staircrusher.accessibility.application.AccessibilityRegisterer
 import club.staircrusher.accessibility.application.port.`in`.result.GetAccessibilityResult
 import club.staircrusher.accessibility.application.port.out.persistence.BuildingAccessibilityRepository
 import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityRepository
@@ -14,18 +14,18 @@ import club.staircrusher.accessibility.domain.model.PlaceAccessibilityComment
 import club.staircrusher.accessibility.domain.model.StairInfo
 import club.staircrusher.api.converter.toDTO
 import club.staircrusher.api.spec.dto.AccessibilityInfoDto
+import club.staircrusher.api.spec.dto.AccessibilityRegistererDto
 import club.staircrusher.api.spec.dto.PlaceAccessibilityDeletionInfo
 import club.staircrusher.api.spec.dto.RegisterBuildingAccessibilityRequestDto
 import club.staircrusher.api.spec.dto.RegisterPlaceAccessibilityRequestDto
-import club.staircrusher.api.spec.dto.User
 import club.staircrusher.stdlib.auth.AuthUser
 
-fun BuildingAccessibilityComment.toDTO(userInfo: UserInfo?) = club.staircrusher.api.spec.dto.BuildingAccessibilityComment(
+fun BuildingAccessibilityComment.toDTO(accessibilityRegisterer: AccessibilityRegisterer?) = club.staircrusher.api.spec.dto.BuildingAccessibilityComment(
     id = id,
     buildingId = buildingId,
     comment = comment,
     createdAt = createdAt.toDTO(),
-    user = userInfo?.toDTO(),
+    user = accessibilityRegisterer?.toDTO(),
 )
 
 fun BuildingAccessibility.toDTO(
@@ -51,21 +51,21 @@ fun GetAccessibilityResult.toDTO(authUser: AuthUser?) = AccessibilityInfoDto(
         it.value.toDTO(
             isUpvoted = buildingAccessibilityUpvoteInfo?.isUpvoted ?: false,
             totalUpvoteCount = buildingAccessibilityUpvoteInfo?.totalUpvoteCount ?: 0,
-            registeredUserName = it.userInfo?.nickname,
+            registeredUserName = it.accessibilityRegisterer?.nickname,
         )
     },
     placeAccessibility = placeAccessibility?.let {
         it.value.toDTO(
-            registeredUserInfo = it.userInfo,
+            registeredAccessibilityRegisterer = it.accessibilityRegisterer,
             authUser = authUser,
             isLastInBuilding = isLastPlaceAccessibilityInBuilding,
         )
     },
     buildingAccessibilityComments = buildingAccessibilityComments.map {
-        it.value.toDTO(userInfo = it.userInfo)
+        it.value.toDTO(accessibilityRegisterer = it.accessibilityRegisterer)
     },
     placeAccessibilityComments = placeAccessibilityComments.map {
-        it.value.toDTO(userInfo = it.userInfo)
+        it.value.toDTO(accessibilityRegisterer = it.accessibilityRegisterer)
     },
     hasOtherPlacesToRegisterInBuilding = hasOtherPlacesToRegisterInSameBuilding,
 )
@@ -82,16 +82,16 @@ fun RegisterBuildingAccessibilityRequestDto.toModel(userId: String?) =
         userId = userId,
     )
 
-fun PlaceAccessibilityComment.toDTO(userInfo: UserInfo?) = club.staircrusher.api.spec.dto.PlaceAccessibilityComment(
+fun PlaceAccessibilityComment.toDTO(accessibilityRegisterer: AccessibilityRegisterer?) = club.staircrusher.api.spec.dto.PlaceAccessibilityComment(
     id = id,
     placeId = placeId,
     comment = comment,
     createdAt = createdAt.toDTO(),
-    user = userInfo?.toDTO(),
+    user = accessibilityRegisterer?.toDTO(),
 )
 
 fun PlaceAccessibility.toDTO(
-    registeredUserInfo: UserInfo?,
+    registeredAccessibilityRegisterer: AccessibilityRegisterer?,
     authUser: AuthUser?,
     isLastInBuilding: Boolean,
 ) = club.staircrusher.api.spec.dto.PlaceAccessibility(
@@ -101,7 +101,7 @@ fun PlaceAccessibility.toDTO(
     hasSlope = hasSlope,
     imageUrls = imageUrls,
     placeId = placeId,
-    registeredUserName = registeredUserInfo?.nickname,
+    registeredUserName = registeredAccessibilityRegisterer?.nickname,
     deletionInfo = if (isDeletable(authUser?.id)) {
         PlaceAccessibilityDeletionInfo(
             isLastInBuilding = isLastInBuilding,
@@ -137,14 +137,14 @@ fun RegisterPlaceAccessibilityRequestDto.toModel(userId: String?) =
         userId = userId,
     )
 
-fun UserInfo.toDTO() = User(
+fun AccessibilityRegisterer.toDTO() = AccessibilityRegistererDto(
     id = userId,
     nickname = nickname,
     instagramId = instagramId,
 )
 
-fun AccessibilityRank.toDTO(userInfo: UserInfo) = club.staircrusher.api.spec.dto.AccessibilityRankDto(
-    user = userInfo.toDTO(),
+fun AccessibilityRank.toDTO(accessibilityRegisterer: AccessibilityRegisterer) = club.staircrusher.api.spec.dto.AccessibilityRankDto(
+    user = accessibilityRegisterer.toDTO(),
     rank = rank,
     conqueredCount = conqueredCount,
 )

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/InitialNicknameGenerator.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/InitialNicknameGenerator.kt
@@ -3,6 +3,7 @@ package club.staircrusher.user.application.port.`in`
 import java.util.UUID
 
 object InitialNicknameGenerator {
+    @Suppress("MagicNumber")
     fun generate(): String {
         // TODO: human-readable하게 수정
         return UUID.randomUUID().toString().take(16)

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
@@ -80,7 +80,8 @@ class UserApplicationService(
     fun updateUserInfo(
         userId: String,
         nickname: String,
-        instagramId: String?
+        instagramId: String?,
+        email: String,
     ): User = transactionManager.doInTransaction(TransactionIsolationLevel.REPEATABLE_READ) {
         val user = userRepository.findById(userId)
         user.nickname = run {
@@ -92,6 +93,13 @@ class UserApplicationService(
                 throw SccDomainException("${normalizedNickname}은 이미 사용 중인 닉네임입니다.")
             }
             normalizedNickname
+        }
+        user.email = run {
+            val normalizedEmail = email.trim()
+            if (userRepository.findByEmail(normalizedEmail)?.takeIf { it.id != user.id } != null) {
+                throw SccDomainException("${normalizedEmail}은 이미 사용 중인 이메일입니다.")
+            }
+            normalizedEmail
         }
         user.instagramId = instagramId?.trim()?.takeIf { it.isNotEmpty() }
         userRepository.save(user)

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
@@ -91,20 +91,32 @@ class UserApplicationService(
         user.nickname = run {
             val normalizedNickname = nickname.trim()
             if (normalizedNickname.length < 2) {
-                throw SccDomainException("최소 2자 이상의 닉네임을 설정해주세요.")
+                throw SccDomainException(
+                    "최소 2자 이상의 닉네임을 설정해주세요.",
+                    SccDomainException.ErrorCode.INVALID_NICKNAME,
+                )
             }
             if (userRepository.findByNickname(normalizedNickname)?.takeIf { it.id != user.id } != null) {
-                throw SccDomainException("${normalizedNickname}은 이미 사용 중인 닉네임입니다.")
+                throw SccDomainException(
+                    "${normalizedNickname}은 이미 사용 중인 닉네임입니다.",
+                    SccDomainException.ErrorCode.INVALID_NICKNAME,
+                )
             }
             normalizedNickname
         }
         user.email = run {
             val normalizedEmail = email.trim()
             if (!EmailValidator.isValid(normalizedEmail)) {
-                throw SccDomainException("${normalizedEmail}은 유효한 형태의 이메일이 아닙니다.")
+                throw SccDomainException(
+                    "${normalizedEmail}은 유효한 형태의 이메일이 아닙니다.",
+                    SccDomainException.ErrorCode.INVALID_EMAIL,
+                )
             }
             if (userRepository.findByEmail(normalizedEmail)?.takeIf { it.id != user.id } != null) {
-                throw SccDomainException("${normalizedEmail}은 이미 사용 중인 이메일입니다.")
+                throw SccDomainException(
+                    "${normalizedEmail}은 이미 사용 중인 이메일입니다.",
+                    SccDomainException.ErrorCode.INVALID_EMAIL,
+                )
             }
             normalizedEmail
         }

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
@@ -5,6 +5,7 @@ import club.staircrusher.stdlib.domain.SccDomainException
 import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
 import club.staircrusher.stdlib.persistence.TransactionManager
+import club.staircrusher.stdlib.validation.email.EmailValidator
 import club.staircrusher.user.domain.model.AuthTokens
 import club.staircrusher.user.application.port.out.persistence.UserRepository
 import club.staircrusher.user.domain.model.User
@@ -98,8 +99,10 @@ class UserApplicationService(
             normalizedNickname
         }
         user.email = run {
-            // TODO: 이메일이 valid한 format인지 검증하기
             val normalizedEmail = email.trim()
+            if (!EmailValidator.isValid(normalizedEmail)) {
+                throw SccDomainException("${normalizedEmail}은 유효한 형태의 이메일이 아닙니다.")
+            }
             if (userRepository.findByEmail(normalizedEmail)?.takeIf { it.id != user.id } != null) {
                 throw SccDomainException("${normalizedEmail}은 이미 사용 중인 이메일입니다.")
             }

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/LoginWithKakaoUseCase.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/LoginWithKakaoUseCase.kt
@@ -6,7 +6,6 @@ import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.stdlib.persistence.TransactionManager
 import club.staircrusher.user.application.port.`in`.InitialNicknameGenerator
 import club.staircrusher.user.application.port.`in`.UserApplicationService
-import club.staircrusher.user.domain.model.AuthTokens
 import club.staircrusher.user.application.port.out.persistence.UserAuthInfoRepository
 import club.staircrusher.user.application.port.out.persistence.UserRepository
 import club.staircrusher.user.application.port.out.web.KakaoLoginService

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/out/persistence/UserRepository.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/out/persistence/UserRepository.kt
@@ -5,6 +5,7 @@ import club.staircrusher.user.domain.model.User
 
 interface UserRepository : EntityRepository<User, String> {
     fun findByNickname(nickname: String): User?
+    fun findByEmail(email: String): User?
     fun findByIdIn(ids: Collection<String>): List<User>
     fun findAll(): List<User>
     data class CreateUserParams(

--- a/app-server/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/model/User.kt
+++ b/app-server/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/model/User.kt
@@ -8,6 +8,7 @@ data class User(
     @Deprecated("닉네임 로그인은 사라질 예정") var encryptedPassword: String?,
     var instagramId: String?,
     var email: String?, // FIXME: 레거시 계정이 모두 사라지면 non-nullable로 변경
+    val mobilityTools: MutableList<UserMobilityTool>,
     val createdAt: Instant,
 ) {
     var deletedAt: Instant? = null // private으로 둘 방법이 없을까? 지금은 persistence_model 모듈에서 써야 해서 안 된다.

--- a/app-server/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/model/User.kt
+++ b/app-server/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/model/User.kt
@@ -7,7 +7,7 @@ data class User(
     var nickname: String,
     @Deprecated("닉네임 로그인은 사라질 예정") var encryptedPassword: String?,
     var instagramId: String?,
-    val email: String?, // FIXME: 레거시 계정이 모두 사라지면 non-nullable로 변경
+    var email: String?, // FIXME: 레거시 계정이 모두 사라지면 non-nullable로 변경
     val createdAt: Instant,
 ) {
     var deletedAt: Instant? = null // private으로 둘 방법이 없을까? 지금은 persistence_model 모듈에서 써야 해서 안 된다.

--- a/app-server/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/model/UserMobilityTool.kt
+++ b/app-server/subprojects/bounded_context/user/domain/src/main/kotlin/club/staircrusher/user/domain/model/UserMobilityTool.kt
@@ -1,0 +1,10 @@
+package club.staircrusher.user.domain.model
+
+enum class UserMobilityTool {
+    MANUAL_WHEELCHAIR,
+    ELECTRIC_WHEELCHAIR,
+    MANUAL_AND_ELECTRIC_WHEELCHAIR,
+    STROLLER,
+    WALKING_ASSISTANCE_DEVICE,
+    ;
+}

--- a/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/UpdateUserInfoTest.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/UpdateUserInfoTest.kt
@@ -1,5 +1,6 @@
 package club.staircrusher.user.infra.adapter.`in`.controller
 
+import club.staircrusher.api.spec.dto.ApiErrorResponse
 import club.staircrusher.api.spec.dto.UpdateUserInfoPost200Response
 import club.staircrusher.api.spec.dto.UpdateUserInfoPostRequest
 import club.staircrusher.stdlib.testing.SccRandom
@@ -95,6 +96,10 @@ class UpdateUserInfoTest : UserITBase() {
                     isBadRequest()
                 }
             }
+            .apply {
+                val result = getResult(ApiErrorResponse::class)
+                assertEquals(ApiErrorResponse.Code.INVALID_NICKNAME, result.code)
+            }
     }
 
     @Test
@@ -120,6 +125,10 @@ class UpdateUserInfoTest : UserITBase() {
                     isBadRequest()
                 }
             }
+            .apply {
+                val result = getResult(ApiErrorResponse::class)
+                assertEquals(ApiErrorResponse.Code.INVALID_EMAIL, result.code)
+            }
     }
 
     @Test
@@ -140,6 +149,10 @@ class UpdateUserInfoTest : UserITBase() {
                 status {
                     isBadRequest()
                 }
+            }
+            .apply {
+                val result = getResult(ApiErrorResponse::class)
+                assertEquals(ApiErrorResponse.Code.INVALID_EMAIL, result.code)
             }
     }
 }

--- a/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/UpdateUserInfoTest.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/UpdateUserInfoTest.kt
@@ -2,7 +2,10 @@ package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.UpdateUserInfoPost200Response
 import club.staircrusher.api.spec.dto.UpdateUserInfoPostRequest
+import club.staircrusher.user.domain.model.UserMobilityTool
 import club.staircrusher.user.infra.adapter.`in`.controller.base.UserITBase
+import club.staircrusher.user.infra.adapter.`in`.converter.toDTO
+import club.staircrusher.user.infra.adapter.`in`.converter.toModel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
@@ -18,14 +21,20 @@ class UpdateUserInfoTest : UserITBase() {
         val changedNickname = UUID.randomUUID().toString().take(32)
         val changedInstagramId = UUID.randomUUID().toString().take(32)
         val changedEmail = UUID.randomUUID().toString().take(32)
+        val changedMobilityTools = listOf(
+            UserMobilityTool.ELECTRIC_WHEELCHAIR,
+            UserMobilityTool.WALKING_ASSISTANCE_DEVICE,
+        )
         assertNotEquals(user.nickname, changedNickname)
         assertNotEquals(user.instagramId, changedInstagramId)
         assertNotEquals(user.email, changedEmail)
+        assertNotEquals(user.mobilityTools, changedMobilityTools)
 
         val params = UpdateUserInfoPostRequest(
             nickname = changedNickname,
             instagramId = changedInstagramId,
-            email = changedEmail
+            email = changedEmail,
+            mobilityTools = changedMobilityTools.map { it.toDTO() },
         )
         mvc
             .sccRequest("/updateUserInfo", params, user = user)
@@ -35,6 +44,7 @@ class UpdateUserInfoTest : UserITBase() {
                 assertEquals(changedNickname, result.user.nickname)
                 assertEquals(changedInstagramId, result.user.instagramId)
                 assertEquals(changedEmail, result.user.email)
+                assertEquals(changedMobilityTools.sorted(), result.user.mobilityTools.map { it.toModel() }.sorted())
             }
     }
 
@@ -48,6 +58,7 @@ class UpdateUserInfoTest : UserITBase() {
             nickname = user.nickname,
             instagramId = user.instagramId,
             email = user.email!!,
+            mobilityTools = user.mobilityTools.map { it.toDTO() },
         )
         mvc
             .sccRequest("/updateUserInfo", params, user = user)
@@ -73,7 +84,8 @@ class UpdateUserInfoTest : UserITBase() {
         val params = UpdateUserInfoPostRequest(
             nickname = user2.nickname,
             instagramId = user.instagramId,
-            email = user.email!!
+            email = user.email!!,
+            mobilityTools = user.mobilityTools.map { it.toDTO() },
         )
         mvc
             .sccRequest("/updateUserInfo", params, user = user)
@@ -98,6 +110,7 @@ class UpdateUserInfoTest : UserITBase() {
             nickname = user.nickname,
             instagramId = user.instagramId,
             email = user2.email!!,
+            mobilityTools = user.mobilityTools.map { it.toDTO() },
         )
         mvc
             .sccRequest("/updateUserInfo", params, user = user)

--- a/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/UpdateUserInfoTest.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/UpdateUserInfoTest.kt
@@ -2,6 +2,7 @@ package club.staircrusher.user.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.UpdateUserInfoPost200Response
 import club.staircrusher.api.spec.dto.UpdateUserInfoPostRequest
+import club.staircrusher.stdlib.testing.SccRandom
 import club.staircrusher.user.domain.model.UserMobilityTool
 import club.staircrusher.user.infra.adapter.`in`.controller.base.UserITBase
 import club.staircrusher.user.infra.adapter.`in`.converter.toDTO
@@ -18,9 +19,9 @@ class UpdateUserInfoTest : UserITBase() {
             testDataGenerator.createUser()
         }
 
-        val changedNickname = UUID.randomUUID().toString().take(32)
-        val changedInstagramId = UUID.randomUUID().toString().take(32)
-        val changedEmail = UUID.randomUUID().toString().take(32)
+        val changedNickname = SccRandom.string(32)
+        val changedInstagramId = SccRandom.string(32)
+        val changedEmail = "${SccRandom.string(32)}@staircrusher.club"
         val changedMobilityTools = listOf(
             UserMobilityTool.ELECTRIC_WHEELCHAIR,
             UserMobilityTool.WALKING_ASSISTANCE_DEVICE,
@@ -110,6 +111,27 @@ class UpdateUserInfoTest : UserITBase() {
             nickname = user.nickname,
             instagramId = user.instagramId,
             email = user2.email!!,
+            mobilityTools = user.mobilityTools.map { it.toDTO() },
+        )
+        mvc
+            .sccRequest("/updateUserInfo", params, user = user)
+            .andExpect {
+                status {
+                    isBadRequest()
+                }
+            }
+    }
+
+    @Test
+    fun `유효하지 않은 포맷의 이메일로는 변경이 불가능하다`() {
+        val user = transactionManager.doInTransaction {
+            testDataGenerator.createUser()
+        }
+
+        val params = UpdateUserInfoPostRequest(
+            nickname = user.nickname,
+            instagramId = user.instagramId,
+            email = "strange",
             mobilityTools = user.mobilityTools.map { it.toDTO() },
         )
         mvc

--- a/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/UpdateUserInfoTest.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/UpdateUserInfoTest.kt
@@ -17,12 +17,15 @@ class UpdateUserInfoTest : UserITBase() {
 
         val changedNickname = UUID.randomUUID().toString().take(32)
         val changedInstagramId = UUID.randomUUID().toString().take(32)
+        val changedEmail = UUID.randomUUID().toString().take(32)
         assertNotEquals(user.nickname, changedNickname)
         assertNotEquals(user.instagramId, changedInstagramId)
+        assertNotEquals(user.email, changedEmail)
 
         val params = UpdateUserInfoPostRequest(
             nickname = changedNickname,
             instagramId = changedInstagramId,
+            email = changedEmail
         )
         mvc
             .sccRequest("/updateUserInfo", params, user = user)
@@ -31,6 +34,77 @@ class UpdateUserInfoTest : UserITBase() {
                 assertEquals(user.id, result.user.id)
                 assertEquals(changedNickname, result.user.nickname)
                 assertEquals(changedInstagramId, result.user.instagramId)
+                assertEquals(changedEmail, result.user.email)
+            }
+    }
+
+    @Test
+    fun `현재와 같은 데이터로 업데이트가 가능하다`() {
+        val user = transactionManager.doInTransaction {
+            testDataGenerator.createUser()
+        }
+
+        val params = UpdateUserInfoPostRequest(
+            nickname = user.nickname,
+            instagramId = user.instagramId,
+            email = user.email!!,
+        )
+        mvc
+            .sccRequest("/updateUserInfo", params, user = user)
+            .apply {
+                val result = getResult(UpdateUserInfoPost200Response::class)
+                assertEquals(user.id, result.user.id)
+                assertEquals(user.nickname, result.user.nickname)
+                assertEquals(user.instagramId, result.user.instagramId)
+                assertEquals(user.email, result.user.email)
+            }
+    }
+
+    @Test
+    fun `중복된 닉네임으로는 변경이 불가능하다`() {
+        val user = transactionManager.doInTransaction {
+            testDataGenerator.createUser()
+        }
+
+        val user2 = transactionManager.doInTransaction {
+            testDataGenerator.createUser()
+        }
+
+        val params = UpdateUserInfoPostRequest(
+            nickname = user2.nickname,
+            instagramId = user.instagramId,
+            email = user.email!!
+        )
+        mvc
+            .sccRequest("/updateUserInfo", params, user = user)
+            .andExpect {
+                status {
+                    isBadRequest()
+                }
+            }
+    }
+
+    @Test
+    fun `중복된 이메일로는 변경이 불가능하다`() {
+        val user = transactionManager.doInTransaction {
+            testDataGenerator.createUser()
+        }
+
+        val user2 = transactionManager.doInTransaction {
+            testDataGenerator.createUser()
+        }
+
+        val params = UpdateUserInfoPostRequest(
+            nickname = user.nickname,
+            instagramId = user.instagramId,
+            email = user2.email!!,
+        )
+        mvc
+            .sccRequest("/updateUserInfo", params, user = user)
+            .andExpect {
+                status {
+                    isBadRequest()
+                }
             }
     }
 }

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
@@ -23,6 +23,7 @@ class UserController(
             userId = authentication.principal,
             nickname = request.nickname,
             instagramId = request.instagramId,
+            email = request.email,
         )
         return UpdateUserInfoPost200Response(
             user = updatedUser.toDTO(),

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
@@ -5,6 +5,7 @@ import club.staircrusher.api.spec.dto.UpdateUserInfoPostRequest
 import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import club.staircrusher.user.application.port.`in`.UserApplicationService
 import club.staircrusher.user.infra.adapter.`in`.converter.toDTO
+import club.staircrusher.user.infra.adapter.`in`.converter.toModel
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,6 +25,7 @@ class UserController(
             nickname = request.nickname,
             instagramId = request.instagramId,
             email = request.email,
+            mobilityTools = request.mobilityTools.map { it.toModel() },
         )
         return UpdateUserInfoPost200Response(
             user = updatedUser.toDTO(),

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/converter/UserConverter.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/converter/UserConverter.kt
@@ -6,4 +6,5 @@ fun User.toDTO() = club.staircrusher.api.spec.dto.User(
     id = id,
     nickname = nickname,
     instagramId = instagramId,
+    email = email,
 )

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/converter/UserConverter.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/converter/UserConverter.kt
@@ -7,4 +7,5 @@ fun User.toDTO() = club.staircrusher.api.spec.dto.User(
     nickname = nickname,
     instagramId = instagramId,
     email = email,
+    mobilityTools = mobilityTools.map { it.toDTO() }
 )

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/converter/UserMobilityToolConverter.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/converter/UserMobilityToolConverter.kt
@@ -1,0 +1,20 @@
+package club.staircrusher.user.infra.adapter.`in`.converter
+
+import club.staircrusher.api.spec.dto.UserMobilityToolDto
+import club.staircrusher.user.domain.model.UserMobilityTool
+
+fun UserMobilityToolDto.toModel() = when (this) {
+    UserMobilityToolDto.mANUALWHEELCHAIR -> UserMobilityTool.MANUAL_WHEELCHAIR
+    UserMobilityToolDto.eLECTRICWHEELCHAIR -> UserMobilityTool.ELECTRIC_WHEELCHAIR
+    UserMobilityToolDto.mANUALANDELECTRICWHEELCHAIR -> UserMobilityTool.MANUAL_AND_ELECTRIC_WHEELCHAIR
+    UserMobilityToolDto.sTROLLER -> UserMobilityTool.STROLLER
+    UserMobilityToolDto.wALKINGASSISTANCEDEVICE -> UserMobilityTool.WALKING_ASSISTANCE_DEVICE
+}
+
+fun UserMobilityTool.toDTO() = when (this) {
+    UserMobilityTool.MANUAL_WHEELCHAIR -> UserMobilityToolDto.mANUALWHEELCHAIR
+    UserMobilityTool.ELECTRIC_WHEELCHAIR -> UserMobilityToolDto.eLECTRICWHEELCHAIR
+    UserMobilityTool.MANUAL_AND_ELECTRIC_WHEELCHAIR -> UserMobilityToolDto.mANUALANDELECTRICWHEELCHAIR
+    UserMobilityTool.STROLLER -> UserMobilityToolDto.sTROLLER
+    UserMobilityTool.WALKING_ASSISTANCE_DEVICE -> UserMobilityToolDto.wALKINGASSISTANCEDEVICE
+}

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/Converters.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/Converters.kt
@@ -12,6 +12,7 @@ fun Scc_user.toDomainModel() = club.staircrusher.user.domain.model.User(
     instagramId = instagram_id,
     createdAt = created_at.toInstant(),
     email = email,
+    mobilityTools = mobility_tools?.toMutableList() ?: mutableListOf()
 ).apply {
     deletedAt = deleted_at?.toInstant()
 }
@@ -22,6 +23,7 @@ fun club.staircrusher.user.domain.model.User.toPersistenceModel() = Scc_user(
     encrypted_password = encryptedPassword ?: "", // SqlDelight 버그로 인해 DROP NOT NULL DDL을 제대로 인식하지 못한다. 어차피 encryptedPassword 필드는 곧 삭제될 것이므로, 그냥 empty string을 넣어준다.
     instagram_id = instagramId,
     email = email,
+    mobility_tools = mobilityTools,
     created_at = createdAt.toOffsetDateTime(),
     updated_at = createdAt.toOffsetDateTime(),
     deleted_at = deletedAt?.toOffsetDateTime(),

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/UserRepository.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/UserRepository.kt
@@ -40,6 +40,12 @@ class UserRepository(
             ?.toDomainModel()
     }
 
+    override fun findByEmail(email: String): User? {
+        return queries.findByEmail(email = email)
+            .executeAsOneOrNull()
+            ?.toDomainModel()
+    }
+
     override fun findByIdIn(ids: Collection<String>): List<User> {
         if (ids.isEmpty()) {
             // empty list로 쿼리를 할 경우 sqldelight가 제대로 처리하지 못하는 문제가 있다.

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/KakaoLoginServiceImpl.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/KakaoLoginServiceImpl.kt
@@ -27,6 +27,7 @@ class KakaoLoginServiceImpl(
 
 
     // 검증 로직은 https://developers.kakao.com/docs/latest/ko/kakaologin/common#oidc 를 참고.
+    @Suppress("ThrowsCount")
     private fun validateKakaoIdToken(kakaoIdToken: KakaoIdToken) {
         if (kakaoIdToken.issuer != "https://kauth.kakao.com") {
             throw InvalidKakaoIdTokenException("issuer does not match: ${kakaoIdToken.issuer}")

--- a/app-server/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/DB.kt
+++ b/app-server/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/DB.kt
@@ -5,11 +5,13 @@ import club.staircrusher.infra.persistence.sqldelight.column_adapter.LocationLis
 import club.staircrusher.infra.persistence.sqldelight.column_adapter.PlaceCategoryStringColumnAdapter
 import club.staircrusher.infra.persistence.sqldelight.column_adapter.StringListToTextColumnAdapter
 import club.staircrusher.infra.persistence.sqldelight.column_adapter.UserAuthProviderTypeStringColumnAdapter
+import club.staircrusher.infra.persistence.sqldelight.column_adapter.UserMobilityToolStringColumnAdapter
 import club.staircrusher.infra.persistence.sqldelight.migration.Accessibility_allowed_region
 import club.staircrusher.infra.persistence.sqldelight.migration.Building_accessibility
 import club.staircrusher.infra.persistence.sqldelight.migration.Club_quest
 import club.staircrusher.infra.persistence.sqldelight.migration.Place
 import club.staircrusher.infra.persistence.sqldelight.migration.Place_accessibility
+import club.staircrusher.infra.persistence.sqldelight.migration.Scc_user
 import club.staircrusher.infra.persistence.sqldelight.migration.User_auth_info
 import club.staircrusher.quest.domain.model.ClubQuestTargetBuilding
 import club.staircrusher.stdlib.di.annotation.Component
@@ -54,6 +56,9 @@ class DB(dataSource: DataSource) : TransactionManager {
         ),
         user_auth_infoAdapter = User_auth_info.Adapter(
             auth_provider_typeAdapter = UserAuthProviderTypeStringColumnAdapter,
+        ),
+        scc_userAdapter = Scc_user.Adapter(
+            mobility_toolsAdapter = UserMobilityToolStringColumnAdapter,
         )
     )
 

--- a/app-server/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/column_adapter/UserMobilityToolStringColumnAdapter.kt
+++ b/app-server/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/column_adapter/UserMobilityToolStringColumnAdapter.kt
@@ -1,0 +1,14 @@
+package club.staircrusher.infra.persistence.sqldelight.column_adapter
+
+import app.cash.sqldelight.ColumnAdapter
+import club.staircrusher.user.domain.model.UserMobilityTool
+
+object UserMobilityToolStringColumnAdapter : ColumnAdapter<List<UserMobilityTool>, String> {
+    override fun decode(databaseValue: String): List<UserMobilityTool> {
+        return databaseValue.split(delimiter).filter { it.isNotBlank() }.map { UserMobilityTool.valueOf(it) }
+    }
+
+    override fun encode(value: List<UserMobilityTool>): String = value.joinToString(delimiter)
+
+    private const val delimiter = ",,"
+}

--- a/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/migration/V10__support_kakao_login.sqm
+++ b/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/migration/V10__support_kakao_login.sqm
@@ -1,3 +1,5 @@
 ALTER TABLE scc_user
     ADD COLUMN email VARCHAR(64) NULL,
     ALTER COLUMN encrypted_password DROP NOT NULL;
+
+CREATE UNIQUE INDEX idx_user_table_2 ON scc_user(email);

--- a/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/migration/V10__support_kakao_login.sqm
+++ b/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/migration/V10__support_kakao_login.sqm
@@ -1,5 +1,9 @@
+import club.staircrusher.user.domain.model.UserMobilityTool;
+import kotlin.collections.List;
+
 ALTER TABLE scc_user
     ADD COLUMN email VARCHAR(64) NULL,
+    ADD COLUMN mobility_tools TEXT AS List<UserMobilityTool> NULL,
     ALTER COLUMN encrypted_password DROP NOT NULL;
 
 CREATE UNIQUE INDEX idx_user_table_2 ON scc_user(email);

--- a/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/user/User.sq
+++ b/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/user/User.sq
@@ -8,7 +8,8 @@ ON CONFLICT(id) DO UPDATE SET
     instagram_id = EXCLUDED.instagram_id,
     created_at = EXCLUDED.created_at,
     deleted_at = EXCLUDED.deleted_at,
-    email = EXCLUDED.email;
+    email = EXCLUDED.email,
+    mobility_tools = EXCLUDED.mobility_tools;
 
 removeAll:
 DELETE FROM scc_user;

--- a/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/user/User.sq
+++ b/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/user/User.sq
@@ -7,7 +7,8 @@ ON CONFLICT(id) DO UPDATE SET
     encrypted_password = EXCLUDED.encrypted_password,
     instagram_id = EXCLUDED.instagram_id,
     created_at = EXCLUDED.created_at,
-    deleted_at = EXCLUDED.deleted_at;
+    deleted_at = EXCLUDED.deleted_at,
+    email = EXCLUDED.email;
 
 removeAll:
 DELETE FROM scc_user;
@@ -21,6 +22,11 @@ findByNickname:
 SELECT *
 FROM scc_user
 WHERE scc_user.nickname = :nickname;
+
+findByEmail:
+SELECT *
+FROM scc_user
+WHERE scc_user.email = :email;
 
 findByIdIn:
 SELECT *

--- a/app-server/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/InMemoryUserRepository.kt
+++ b/app-server/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/InMemoryUserRepository.kt
@@ -14,6 +14,10 @@ class InMemoryUserRepository : UserRepository {
         return userById.values.find { it.nickname == nickname }
     }
 
+    override fun findByEmail(email: String): User? {
+        return userById.values.find { it.email == email }
+    }
+
     override fun findByIdIn(ids: Collection<String>): List<User> {
         return userById.values.filter { it.id in ids }
     }

--- a/app-server/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccSecurityConfigTest.kt
+++ b/app-server/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccSecurityConfigTest.kt
@@ -72,6 +72,7 @@ class SccSecurityConfigTest {
             encryptedPassword = "",
             instagramId = null,
             email = "",
+            mobilityTools = mutableListOf(),
             createdAt = Instant.now()
         ))
     }

--- a/app-server/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
+++ b/app-server/subprojects/spring_web/src/main/kotlin/club/staircrusher/spring_web/web/SccExceptionHandler.kt
@@ -59,6 +59,8 @@ class SccExceptionHandler {
             msg = msg,
             code = when (errorCode) {
                 SccDomainException.ErrorCode.INVALID_AUTHENTICATION -> ApiErrorResponse.Code.INVALID_AUTHENTICATION
+                SccDomainException.ErrorCode.INVALID_NICKNAME -> ApiErrorResponse.Code.INVALID_NICKNAME
+                SccDomainException.ErrorCode.INVALID_EMAIL -> ApiErrorResponse.Code.INVALID_EMAIL
                 null -> null
             }
         )

--- a/app-server/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/SccDomainException.kt
+++ b/app-server/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/domain/SccDomainException.kt
@@ -3,6 +3,8 @@ package club.staircrusher.stdlib.domain
 open class SccDomainException(val msg: String, val errorCode: ErrorCode? = null) : RuntimeException(msg) {
     enum class ErrorCode {
         INVALID_AUTHENTICATION,
+        INVALID_NICKNAME,
+        INVALID_EMAIL,
         ;
     }
 

--- a/app-server/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/validation/email/EmailValidator.kt
+++ b/app-server/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/validation/email/EmailValidator.kt
@@ -1,0 +1,13 @@
+package club.staircrusher.stdlib.validation.email
+
+/**
+ * RFC 5322 기반 validation을 진행한다.
+ * refs: https://www.baeldung.com/java-email-validation-regex#regular-expression-by-rfc-5322-for-email-validation
+ */
+object EmailValidator {
+    private val regex = Regex("^[a-zA-Z\\d_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z\\d.-]+$")
+
+    fun isValid(email: String): Boolean {
+        return regex.matches(email)
+    }
+}

--- a/app-server/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
+++ b/app-server/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
@@ -65,7 +65,7 @@ class ITDataGenerator {
     fun createUser(
         nickname: String = SccRandom.string(12),
         password: String = "password",
-        email: String = "official@staircrusher.club",
+        email: String = SccRandom.string(24),
         instagramId: String? = null
     ): User {
         return userRepository.save(

--- a/app-server/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
+++ b/app-server/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
@@ -24,6 +24,7 @@ import club.staircrusher.stdlib.geography.siGunGuById
 import club.staircrusher.stdlib.testing.SccRandom
 import club.staircrusher.user.application.port.out.persistence.UserRepository
 import club.staircrusher.user.domain.model.User
+import club.staircrusher.user.domain.model.UserMobilityTool
 import club.staircrusher.user.domain.service.PasswordEncryptor
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Clock
@@ -66,7 +67,8 @@ class ITDataGenerator {
         nickname: String = SccRandom.string(12),
         password: String = "password",
         email: String = SccRandom.string(24),
-        instagramId: String? = null
+        instagramId: String? = null,
+        mobilityTools: List<UserMobilityTool> = emptyList(),
     ): User {
         return userRepository.save(
             User(
@@ -75,6 +77,7 @@ class ITDataGenerator {
                 encryptedPassword = passwordEncryptor.encrypt(password.trim()),
                 instagramId = instagramId?.trim()?.takeIf { it.isNotEmpty() },
                 email = email,
+                mobilityTools = mobilityTools.toMutableList(),
                 createdAt = clock.instant(),
             )
         )

--- a/app-server/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
+++ b/app-server/subprojects/testing/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
@@ -66,7 +66,7 @@ class ITDataGenerator {
     fun createUser(
         nickname: String = SccRandom.string(12),
         password: String = "password",
-        email: String = SccRandom.string(24),
+        email: String = "${SccRandom.string(12)}@staircrusher.club",
         instagramId: String? = null,
         mobilityTools: List<UserMobilityTool> = emptyList(),
     ): User {


### PR DESCRIPTION
## Checklist
- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- [기획서](https://www.notion.so/agnica/a8418381554948459dc1e43bbb6d929b)
- 아마 현재 마이페이지를 보면 updateUserInfo API가 안 쓰이고 있던데, 이걸 재활용해서 아래 사진의 [정복자 정보를 알려주세요.] 페이지를 위한 API를 구현합니다.
![image](https://github.com/Stair-Crusher-Club/scc-server/assets/24506624/303ebc5d-0164-4839-80de-19bd995174e8)
- 구현하는 과정에서 User라는 엔티티가 가진 정보가 늘어났는데, api spec 상 accessibility domain 관련 API response에서도 UserDto가 재사용되고 있어서 불필요한 정보가 내려가게 되었습니다. 따라서 이를 막기 위해 accessiblity domain 관련 API response에서는 UserDto 대신 `AccessibilityRegistererDto`라는 새로운 dto를 내려주도록 수정합니다.