### PR TITLE
[카카오 로그인] id token의 audience를 올바르게 검증하기

### DIFF
--- a/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/LoginWithKakaoTest.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/LoginWithKakaoTest.kt
@@ -44,7 +44,7 @@ class LoginWithKakaoTest : UserITBase() {
         Mockito.`when`(kakaoLoginService.parseIdToken("dummy")).thenReturn(
             KakaoIdToken(
                 issuer = "https://kauth.kakao.com",
-                audience = "appKey",
+                audience = "clientId",
                 expiresAtEpochSecond = SccClock.instant().epochSecond + 10,
                 kakaoSyncUserId = "kakaoSyncUserId",
             )

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/KakaoLoginProperties.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/KakaoLoginProperties.kt
@@ -4,5 +4,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("scc.kakao-login")
 data class KakaoLoginProperties(
-    val appKey: String,
+    val oauthClientId: String,
 )

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/KakaoLoginServiceImpl.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/KakaoLoginServiceImpl.kt
@@ -32,7 +32,7 @@ class KakaoLoginServiceImpl(
         if (kakaoIdToken.issuer != "https://kauth.kakao.com") {
             throw InvalidKakaoIdTokenException("issuer does not match: ${kakaoIdToken.issuer}")
         }
-        if (kakaoIdToken.audience != kakaoLoginProperties.appKey) {
+        if (kakaoIdToken.audience != kakaoLoginProperties.oauthClientId) {
             throw InvalidKakaoIdTokenException("audience does not match")
         }
         if (kakaoIdToken.expiresAt < SccClock.instant()) {

--- a/app-server/subprojects/testing/spring_it/src/main/resources/application.yaml
+++ b/app-server/subprojects/testing/spring_it/src/main/resources/application.yaml
@@ -26,4 +26,4 @@ scc:
     password: adminPassword
 
   kakao-login:
-    app-key: test
+    oauth-client-id: test

--- a/infra/helm/scc-server/files/dev/secret.yaml
+++ b/infra/helm/scc-server/files/dev/secret.yaml
@@ -7,7 +7,7 @@ scc:
     kakao:
         apiKey: ENC[AES256_GCM,data:3XULZW2dZmDj4ioPhjB22wVX9QyQb5ChtHuE4NowhGw=,iv:lB/3YKD7drfR20Hqpma+SLHZ21nl7dkX+wkfFfFAduA=,tag:6jpZL/Dm+/dwHHNAzeRvTw==,type:str]
     kakao-login:
-        app-key: ENC[AES256_GCM,data:oGgIrbkm3p5nbN5k+QrYNpTj/oZua2vkhrduVA1g1rE=,iv:6Um6a26lBoKHRLNzhR09G6t0O6bxM3zH00U0rhmqt0U=,tag:iEAJ7vhnMAZku+2hWQNAJA==,type:str]
+        oauth-client-id: ENC[AES256_GCM,data:JyQdF6YwxjssGLE+xFIXTBJRT8UrcneMz0uwzVUurjQ=,iv:CuzFVR28UBQzl1yEq23EnMt9tMHSPTvM8ini8P3gMmg=,tag:fTCAxQulDFSk7zwi/tuRIA==,type:str]
     admin:
         password: ENC[AES256_GCM,data:VyZvo4HRjZw6kQ==,iv:HqFCq6cMeWAb7dBxu9jNgIBOnd/+zWhNpSjCx//g2uk=,tag:cJ203Se2Er4i689pr/Eskw==,type:str]
 sops:
@@ -20,8 +20,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-08-27T12:21:24Z"
-    mac: ENC[AES256_GCM,data:X/hZFpPOH23zkSa5sFKYmsikI3I9UcpUoBFBeJKrDGzRGPS+1CCOABPtI5SOK7yg+VtTVUM+TcvWT8aOQL4h+DDxNu43dSRgBIwexiMD4czkxUtj46lP/OfmbH8tv9/eEhNNbYLapVg5tkV+CRJyNO0GyliA/sftPR4YCvs7p2A=,iv:hiPZNN0BDpMIKAmLTkzdDMAo9B0gUYxUSz1gD9SUZWU=,tag:aFbGB/lWEE8d3ib2zTBkuA==,type:str]
+    lastmodified: "2023-08-28T03:23:18Z"
+    mac: ENC[AES256_GCM,data:EcXofW3usvXSzFkGzGxCVFNeebJZzR+30k1P2f2EtnxUxd1eWNkxairpXBxws4c5rXgGc/+YnGqMClcd5KyE9xZMIBSCSZVLQg1goBtjVpbZCmuRb094nqHaIz5sMPB0z8ZmLG0jyMxm8uVT++5DouiDZKvXx+ixCa2lpYaTCrA=,iv:W15XrEnN7sKapv1t5j1Fano5PvD4aA6+cu6FN/nuK6Q=,tag:8kTw+++z6wYK1byCqRrvcg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/infra/helm/scc-server/files/prod/secret.yaml
+++ b/infra/helm/scc-server/files/prod/secret.yaml
@@ -7,7 +7,7 @@ scc:
     kakao:
         apiKey: ENC[AES256_GCM,data:AWS2hzoPX4WsMQUDC02qNT1k6+M3RMBiw1df/cOEBLs=,iv:y6v6IVIbFn80EzBOsW37ARUL0lrwhbbQfespxduJt54=,tag:ibxSBY2+Vuu2lypB8q4E4g==,type:str]
     kakao-login:
-        app-key: ENC[AES256_GCM,data:9Otrj18cka985mPdM5J2XYEaZn8RPJV9I3YdxoLVj3Q=,iv:ZRh+rBd+XAmHrpjRJxNU0qigP8OzbT/Q/iyXNyvu6Mo=,tag:unPStqwNGvXHuKmOGR3SGQ==,type:str]
+        oauth-client-id: ENC[AES256_GCM,data:IA3i5xloGUeZasjRvB5Za09eOeR5Z1Zq3AuyBCftYkU=,iv:1AvpV9G+JyenX4G5OZfP4J/jZzbD/0OnELDR2Ot2tyk=,tag:YqL2TtIrZ0HRD1BNetnnaw==,type:str]
     admin:
         password: ENC[AES256_GCM,data:nxQSfCYrS2dpHw==,iv:LYZe//z2/aYVUBqjPPLDEi9TlqlHGaJ8FfhLcYcv2Cs=,tag:g9D/3brOdBmoESFEDiQj6Q==,type:str]
 sops:
@@ -20,8 +20,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-08-27T04:08:51Z"
-    mac: ENC[AES256_GCM,data:MuqUWVOMVZbCZ0YIC1RpIy8OVg+VByrswbqBzo6sReunRa+8CBYM2FbAijMcjk9Hf12JP79QGRzfK+Aq2e9gSkru3/i2kbCf3mVEQdojCqx9lol6q/yiHRAnl2UVh6MWTomicwd3iRdQzGmLOc7yYWF8qysyXfycKpL46nQkRMI=,iv:dbdnHsjxSMXLYKoR++ukc1FiDO+CsRcLkFPNfNjPL0U=,tag:Gk2aoIhG0bap28DyFXSxKQ==,type:str]
+    lastmodified: "2023-08-28T03:23:51Z"
+    mac: ENC[AES256_GCM,data:+nwAvYUFV8qcoSdC+oY5+pAvZnnXEQG7cBnyMN/C47/4w1xp4nYvlmziEZKcM0+hDkU9w5mex29o8SJJ5XLmisBcMqSsnHkHBR4MXsML8rRVdN5nTgwPGto3PymFhCCIXGfThqm3roh7wXPd6Z77ccs3go/kfFJzOvauLPmC108=,iv:UDFtvxoyGXBwmtpFv5MZUrqj2t3HLu7D8duDUVwWE88=,tag:NJatABHw0g1m4zlqRYvXbg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- 이전에 audience 값을 체크할 때 rest api key를 쓰고 있었는데, 이게 아니라 카카오 로그인 페이지로 리다이렉트 시킬 때 client_id 값으로 전달하는 네이티브 앱 키를 사용해야 합니다.