### PR TITLE
PROD build를 '-hotfix\d'와 같은 형태의 태그로도 트리거하도록 수정

### DIFF
--- a/.github/workflows/prod-ci-cd.yaml
+++ b/.github/workflows/prod-ci-cd.yaml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+' # Follow semantic versioning
+      - '[0-9]+.[0-9]+.[0-9]+-hotfix[0-9]' # For hotfix
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- #196 를 해결하다가 알게 됐는데, `0.1.5-hotfix1`과 같은 형태의 태그는 현재 prod CI / CD를 트리거하지 않아서 핫픽스가 되지 않습니다.
- 이를 지원하도록 수정합니다.