### PR TITLE
정보 삭제 시 contribution도 삭제하기

### DIFF
--- a/app-server/subprojects/bounded_context/accessibility/application/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/accessibility/application/build.gradle.kts
@@ -2,4 +2,6 @@ dependencies {
     implementation(projects.boundedContext.user.application)
     implementation(projects.boundedContext.place.application)
     implementation(projects.boundedContext.challenge.application)
+
+    implementation(projects.domainEvent)
 }

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/DeleteAccessibilityUseCase.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/DeleteAccessibilityUseCase.kt
@@ -4,11 +4,25 @@ import club.staircrusher.accessibility.application.port.out.persistence.Building
 import club.staircrusher.accessibility.application.port.out.persistence.BuildingAccessibilityRepository
 import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityCommentRepository
 import club.staircrusher.accessibility.application.port.out.persistence.PlaceAccessibilityRepository
+import club.staircrusher.accessibility.domain.model.BuildingAccessibility
+import club.staircrusher.accessibility.domain.model.PlaceAccessibility
+import club.staircrusher.domain_event.BuildingAccessibilityCommentDeletedEvent
+import club.staircrusher.domain_event.BuildingAccessibilityDeletedEvent
+import club.staircrusher.domain_event.PlaceAccessibilityCommentDeletedEvent
+import club.staircrusher.domain_event.PlaceAccessibilityDeletedEvent
+import club.staircrusher.domain_event.dto.AccessibilityCommentRegistererDTO
+import club.staircrusher.domain_event.dto.AccessibilityRegistererDTO
 import club.staircrusher.place.application.port.`in`.PlaceService
+import club.staircrusher.place.application.port.`in`.toBuildingDTO
+import club.staircrusher.place.application.port.`in`.toPlaceDTO
+import club.staircrusher.place.domain.model.Building
+import club.staircrusher.place.domain.model.Place
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.domain.SccDomainException
+import club.staircrusher.stdlib.domain.event.DomainEventPublisher
 import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
 import club.staircrusher.stdlib.persistence.TransactionManager
+import kotlinx.coroutines.runBlocking
 
 @Component
 class DeleteAccessibilityUseCase(
@@ -18,6 +32,7 @@ class DeleteAccessibilityUseCase(
     private val buildingAccessibilityRepository: BuildingAccessibilityRepository,
     private val buildingAccessibilityCommentRepository: BuildingAccessibilityCommentRepository,
     private val placeService: PlaceService,
+    private val domainEventPublisher: DomainEventPublisher,
 ) {
     fun handle(
         userId: String,
@@ -27,14 +42,89 @@ class DeleteAccessibilityUseCase(
         if (!placeAccessibility.isDeletable(userId)) {
             throw SccDomainException("삭제 가능한 장소 정보가 아닙니다.")
         }
-        placeAccessibilityRepository.remove(placeAccessibilityId)
-        placeAccessibilityCommentRepository.removeByPlaceId(placeAccessibility.placeId)
 
-        val buildingId = placeService.findPlace(placeAccessibility.placeId)!!.building.id
-        if (placeAccessibilityRepository.findByBuildingId(buildingId).isEmpty()) {
-            val buildingAccessibility = buildingAccessibilityRepository.findByBuildingId(buildingId) ?: return@doInTransaction
-            buildingAccessibilityRepository.remove(buildingAccessibility.id)
-            buildingAccessibilityCommentRepository.removeByBuildingId(buildingAccessibility.buildingId)
+        val place = placeService.findPlace(placeAccessibility.placeId)!!
+        deletePlaceAccessibility(userId, placeAccessibility, place)
+        deletePlaceAccessibilityComments(place)
+
+        val building = place.building
+        if (placeAccessibilityRepository.findByBuildingId(building.id).isEmpty()) {
+            val buildingAccessibility = buildingAccessibilityRepository.findByBuildingId(building.id) ?: return@doInTransaction
+            deleteBuildingAccessibility(buildingAccessibility, building)
+            deleteBuildingAccessibilityComments(building)
+        }
+    }
+
+    private fun deletePlaceAccessibility(
+        userId: String,
+        placeAccessibility: PlaceAccessibility,
+        place: Place,
+    ) {
+        placeAccessibilityRepository.remove(placeAccessibility.id)
+        transactionManager.doAfterCommit {
+            runBlocking {
+                domainEventPublisher.publishEvent(PlaceAccessibilityDeletedEvent(
+                    id = placeAccessibility.id,
+                    accessibilityRegisterer = AccessibilityRegistererDTO(
+                        id = userId,
+                    ),
+                    place = place.toPlaceDTO(),
+                ))
+            }
+        }
+    }
+
+    private fun deletePlaceAccessibilityComments(place: Place) {
+        val placeAccessibilityComments = placeAccessibilityCommentRepository.findByPlaceId(place.id)
+        placeAccessibilityCommentRepository.removeByPlaceId(place.id)
+        transactionManager.doAfterCommit {
+            runBlocking {
+                placeAccessibilityComments.forEach { comment ->
+                    domainEventPublisher.publishEvent(PlaceAccessibilityCommentDeletedEvent(
+                        id = comment.id,
+                        commentRegisterer = AccessibilityCommentRegistererDTO(
+                            id = comment.userId,
+                        ),
+                        place = place.toPlaceDTO(),
+                    ))
+                }
+            }
+        }
+    }
+
+    private fun deleteBuildingAccessibility(
+        buildingAccessibility: BuildingAccessibility,
+        building: Building,
+    ) {
+        buildingAccessibilityRepository.remove(buildingAccessibility.id)
+        transactionManager.doAfterCommit {
+            runBlocking {
+                domainEventPublisher.publishEvent(BuildingAccessibilityDeletedEvent(
+                    id = buildingAccessibility.id,
+                    accessibilityRegisterer = AccessibilityRegistererDTO(
+                        id = buildingAccessibility.userId,
+                    ),
+                    building = building.toBuildingDTO(),
+                ))
+            }
+        }
+    }
+
+    private fun deleteBuildingAccessibilityComments(building: Building) {
+        val buildingAccessibilityComments = buildingAccessibilityCommentRepository.findByBuildingId(building.id)
+        buildingAccessibilityCommentRepository.removeByBuildingId(building.id)
+        transactionManager.doAfterCommit {
+            runBlocking {
+                buildingAccessibilityComments.forEach { comment ->
+                    domainEventPublisher.publishEvent(BuildingAccessibilityCommentDeletedEvent(
+                        id = comment.id,
+                        commentRegisterer = AccessibilityCommentRegistererDTO(
+                            id = comment.userId,
+                        ),
+                        building = building.toBuildingDTO(),
+                    ))
+                }
+            }
         }
     }
 }

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/RegisterBuildingAccessibilityUseCase.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/RegisterBuildingAccessibilityUseCase.kt
@@ -34,15 +34,7 @@ class RegisterBuildingAccessibilityUseCase(
                 userId = userId,
                 contribution = ChallengeService.Contribution.BuildingAccessibility(
                     buildingAccessibilityId = registerResult.buildingAccessibility.id,
-                    buildingAccessibilityAddress = registerResult.building.address.let {
-                        ChallengeAddress(
-                            siDo = it.siDo,
-                            siGunGu = it.siGunGu,
-                            eupMyeonDong = it.eupMyeonDong,
-                            li = it.li,
-                            roadName = it.roadName
-                        )
-                    }
+                    buildingAccessibilityAddress = ChallengeAddress(registerResult.building),
                 )
             )
         return@doInTransaction RegisterBuildingAccessibilityUseCaseResult(

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/RegisterPlaceAccessibilityUseCase.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/RegisterPlaceAccessibilityUseCase.kt
@@ -14,7 +14,7 @@ import club.staircrusher.stdlib.persistence.TransactionManager
 class RegisterPlaceAccessibilityUseCase(
     private val transactionManager: TransactionManager,
     private val accessibilityApplicationService: AccessibilityApplicationService,
-    private val challengeService: ChallengeService
+    private val challengeService: ChallengeService,
 ) {
     data class RegisterPlaceAccessibilityUseCaseResult(
         val registerPlaceAccessibilityResult: RegisterPlaceAccessibilityResult,
@@ -23,7 +23,7 @@ class RegisterPlaceAccessibilityUseCase(
     )
 
     fun handle(
-        userId: String?,
+        userId: String,
         createPlaceAccessibilityParams: PlaceAccessibilityRepository.CreateParams,
         createPlaceAccessibilityCommentParams: PlaceAccessibilityCommentRepository.CreateParams?,
     ): RegisterPlaceAccessibilityUseCaseResult = transactionManager.doInTransaction {
@@ -33,23 +33,14 @@ class RegisterPlaceAccessibilityUseCase(
         )
         val getAccessibilityResult =
             accessibilityApplicationService.doGetAccessibility(createPlaceAccessibilityParams.placeId, userId)
-        val challengeContributions = userId?.let { userId ->
-            challengeService.contributeToSatisfiedChallenges(
-                userId = userId,
-                contribution = ChallengeService.Contribution.PlaceAccessibility(
-                    placeAccessibilityId = registerResult.placeAccessibility.id,
-                    placeAccessibilityAddress = registerResult.place.address.let {
-                        ChallengeAddress(
-                            siDo = it.siDo,
-                            siGunGu = it.siGunGu,
-                            eupMyeonDong = it.eupMyeonDong,
-                            li = it.li,
-                            roadName = it.roadName
-                        )
-                    }
-                )
+        val challengeContributions = challengeService.contributeToSatisfiedChallenges(
+            userId = userId,
+            contribution = ChallengeService.Contribution.PlaceAccessibility(
+                placeAccessibilityId = registerResult.placeAccessibility.id,
+                placeAccessibilityAddress = ChallengeAddress(registerResult.place),
             )
-        } ?: listOf()
+        )
+
         return@doInTransaction RegisterPlaceAccessibilityUseCaseResult(
             registerPlaceAccessibilityResult = registerResult,
             getAccessibilityResult = getAccessibilityResult,

--- a/app-server/subprojects/bounded_context/accessibility/infra/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/accessibility/infra/build.gradle.kts
@@ -16,4 +16,6 @@ dependencies {
     val awsSdkVersion: String by project
     implementation("software.amazon.awssdk:s3:$awsSdkVersion")
     runtimeOnly("software.amazon.awssdk:sts:$awsSdkVersion") // IRSA를 사용하기 위해서 필요함
+    testImplementation(projects.domainEvent)
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
 }

--- a/app-server/subprojects/bounded_context/challenge/application/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/challenge/application/build.gradle.kts
@@ -1,3 +1,5 @@
 dependencies {
     implementation(projects.boundedContext.user.application)
+    implementation(projects.boundedContext.place.application)
+    implementation(projects.domainEvent)
 }

--- a/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/HandleBuildingAccessibilityCommentDeletedEventUseCase.kt
+++ b/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/HandleBuildingAccessibilityCommentDeletedEventUseCase.kt
@@ -1,0 +1,27 @@
+package club.staircrusher.challenge.application.port.`in`.use_case
+
+import club.staircrusher.challenge.application.port.`in`.ChallengeService
+import club.staircrusher.challenge.domain.model.ChallengeAddress
+import club.staircrusher.domain_event.BuildingAccessibilityCommentDeletedEvent
+import club.staircrusher.place.application.port.`in`.toBuilding
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+@Component
+class HandleBuildingAccessibilityCommentDeletedEventUseCase(
+    private val transactionManager: TransactionManager,
+    private val challengeService: ChallengeService,
+) {
+    fun handle(event: BuildingAccessibilityCommentDeletedEvent) = transactionManager.doInTransaction {
+        if (event.commentRegisterer.id == null) {
+            return@doInTransaction
+        }
+        challengeService.deleteContributions(
+            userId = event.commentRegisterer.id!!,
+            contribution = ChallengeService.Contribution.BuildingAccessibility(
+                buildingAccessibilityId = event.id,
+                buildingAccessibilityAddress = ChallengeAddress(event.building.toBuilding()),
+            ),
+        )
+    }
+}

--- a/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/HandleBuildingAccessibilityDeletedEventUseCase.kt
+++ b/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/HandleBuildingAccessibilityDeletedEventUseCase.kt
@@ -1,0 +1,27 @@
+package club.staircrusher.challenge.application.port.`in`.use_case
+
+import club.staircrusher.challenge.application.port.`in`.ChallengeService
+import club.staircrusher.challenge.domain.model.ChallengeAddress
+import club.staircrusher.domain_event.BuildingAccessibilityDeletedEvent
+import club.staircrusher.place.application.port.`in`.toBuilding
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+@Component
+class HandleBuildingAccessibilityDeletedEventUseCase(
+    private val transactionManager: TransactionManager,
+    private val challengeService: ChallengeService,
+) {
+    fun handle(event: BuildingAccessibilityDeletedEvent) = transactionManager.doInTransaction {
+        if (event.accessibilityRegisterer.id == null) {
+            return@doInTransaction
+        }
+        challengeService.deleteContributions(
+            userId = event.accessibilityRegisterer.id!!,
+            contribution = ChallengeService.Contribution.BuildingAccessibilityComment(
+                buildingAccessibilityCommentId = event.id,
+                buildingAccessibilityAddress = ChallengeAddress(event.building.toBuilding()),
+            ),
+        )
+    }
+}

--- a/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/HandlePlaceAccessibilityCommentDeletedEventUseCase.kt
+++ b/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/HandlePlaceAccessibilityCommentDeletedEventUseCase.kt
@@ -1,0 +1,27 @@
+package club.staircrusher.challenge.application.port.`in`.use_case
+
+import club.staircrusher.challenge.application.port.`in`.ChallengeService
+import club.staircrusher.challenge.domain.model.ChallengeAddress
+import club.staircrusher.domain_event.PlaceAccessibilityCommentDeletedEvent
+import club.staircrusher.place.application.port.`in`.toPlace
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+@Component
+class HandlePlaceAccessibilityCommentDeletedEventUseCase(
+    private val transactionManager: TransactionManager,
+    private val challengeService: ChallengeService,
+) {
+    fun handle(event: PlaceAccessibilityCommentDeletedEvent) = transactionManager.doInTransaction {
+        if (event.commentRegisterer.id == null) {
+            return@doInTransaction
+        }
+        challengeService.deleteContributions(
+            userId = event.commentRegisterer.id!!,
+            contribution = ChallengeService.Contribution.PlaceAccessibilityComment(
+                placeAccessibilityCommentId = event.id,
+                placeAccessibilityAddress = ChallengeAddress(event.place.toPlace()),
+            ),
+        )
+    }
+}

--- a/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/HandlePlaceAccessibilityDeletedEventUseCase.kt
+++ b/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/HandlePlaceAccessibilityDeletedEventUseCase.kt
@@ -1,0 +1,27 @@
+package club.staircrusher.challenge.application.port.`in`.use_case
+
+import club.staircrusher.challenge.application.port.`in`.ChallengeService
+import club.staircrusher.challenge.domain.model.ChallengeAddress
+import club.staircrusher.domain_event.PlaceAccessibilityDeletedEvent
+import club.staircrusher.place.application.port.`in`.toPlace
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+@Component
+class HandlePlaceAccessibilityDeletedEventUseCase(
+    private val transactionManager: TransactionManager,
+    private val challengeService: ChallengeService,
+) {
+    fun handle(event: PlaceAccessibilityDeletedEvent) = transactionManager.doInTransaction {
+        if (event.accessibilityRegisterer.id == null) {
+            return@doInTransaction
+        }
+        challengeService.deleteContributions(
+            userId = event.accessibilityRegisterer.id!!,
+            contribution = ChallengeService.Contribution.PlaceAccessibility(
+                placeAccessibilityId = event.id,
+                placeAccessibilityAddress = ChallengeAddress(event.place.toPlace()),
+            ),
+        )
+    }
+}

--- a/app-server/subprojects/bounded_context/challenge/domain/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/challenge/domain/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    implementation(projects.boundedContext.place.domain)
+}

--- a/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/ChallengeAddress.kt
+++ b/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/ChallengeAddress.kt
@@ -1,5 +1,9 @@
 package club.staircrusher.challenge.domain.model
 
+import club.staircrusher.place.domain.model.Building
+import club.staircrusher.place.domain.model.BuildingAddress
+import club.staircrusher.place.domain.model.Place
+
 data class ChallengeAddress(
     val siDo: String,
     val siGunGu: String,
@@ -14,4 +18,16 @@ data class ChallengeAddress(
             li.contains(keyword) ||
             roadName.contains(keyword)
     }
+
+    constructor(place: Place) : this(place.address)
+
+    constructor(building: Building) : this(building.address)
+
+    constructor(buildingAddress: BuildingAddress) : this(
+        siDo = buildingAddress.siDo,
+        siGunGu = buildingAddress.siGunGu,
+        eupMyeonDong = buildingAddress.eupMyeonDong,
+        li = buildingAddress.li,
+        roadName = buildingAddress.roadName,
+    )
 }

--- a/app-server/subprojects/bounded_context/challenge/infra/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/challenge/infra/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     api(project(":api"))
+    api(projects.domainEvent)
     implementation(projects.persistenceModel)
     implementation("org.springframework.boot:spring-boot-starter-web")
 

--- a/app-server/subprojects/bounded_context/challenge/infra/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/challenge/infra/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
     val awsSdkVersion: String by project
     implementation("software.amazon.awssdk:s3:$awsSdkVersion")
     runtimeOnly("software.amazon.awssdk:sts:$awsSdkVersion") // IRSA를 사용하기 위해서 필요함
+
+    testImplementation(projects.boundedContext.place.application)
 }

--- a/app-server/subprojects/bounded_context/challenge/infra/src/integrationTest/kotlin/club/staircrusher/challenge/infra/adapter/in/controller/ChallengeContributionDeletionTest.kt
+++ b/app-server/subprojects/bounded_context/challenge/infra/src/integrationTest/kotlin/club/staircrusher/challenge/infra/adapter/in/controller/ChallengeContributionDeletionTest.kt
@@ -1,0 +1,103 @@
+package club.staircrusher.challenge.infra.adapter.`in`.controller
+
+import club.staircrusher.api.spec.dto.GetChallengeRequestDto
+import club.staircrusher.api.spec.dto.GetChallengeResponseDto
+import club.staircrusher.challenge.application.port.`in`.use_case.HandlePlaceAccessibilityDeletedEventUseCase
+import club.staircrusher.challenge.application.port.out.persistence.ChallengeContributionRepository
+import club.staircrusher.challenge.application.port.out.persistence.ChallengeParticipationRepository
+import club.staircrusher.challenge.application.port.out.persistence.ChallengeRepository
+import club.staircrusher.challenge.infra.adapter.`in`.controller.base.ChallengeITBase
+import club.staircrusher.domain_event.PlaceAccessibilityDeletedEvent
+import club.staircrusher.domain_event.dto.AccessibilityRegistererDTO
+import club.staircrusher.place.application.port.`in`.toPlaceDTO
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class ChallengeContributionDeletionTest : ChallengeITBase() {
+    @Autowired
+    private lateinit var challengeRepository: ChallengeRepository
+
+    @Autowired
+    private lateinit var challengeContributionRepository: ChallengeContributionRepository
+
+    @Autowired
+    private lateinit var challengeParticipationRepository: ChallengeParticipationRepository
+
+    @Autowired
+    private lateinit var handlePlaceAccessibilityDeletedEventUseCase: HandlePlaceAccessibilityDeletedEventUseCase
+
+    @BeforeEach
+    fun setUp() {
+        transactionManager.doInTransaction {
+            challengeRepository.removeAll()
+            challengeParticipationRepository.removeAll()
+            challengeContributionRepository.removeAll()
+
+            registerChallenges()
+        }
+    }
+
+    @Test
+    fun `장소 정보 삭제 시 contribution이 삭제된다`() {
+        // given
+        val challenge = registerInProgressChallenge()
+        val user = transactionManager.doInTransaction {
+            val user = testDataGenerator.createUser()
+            participate(user, challenge)
+            user
+        }
+        val place = transactionManager.doInTransaction {
+            testDataGenerator.createBuildingAndPlace(placeName = "장소장소", building = null)
+        }
+        val contributions = (0 until 5).map {
+            contributePlaceAccessibility(
+                user = user,
+                overridingPlace = place,
+                challenge = challenge,
+            )
+        }
+        val getChallengeResponse = mvc.sccRequest(
+            "/getChallenge",
+            GetChallengeRequestDto(
+                challengeId = challenge.id,
+            ),
+            user = user,
+        )
+            .getResult(GetChallengeResponseDto::class)
+        assertEquals(challenge.id, getChallengeResponse.challenge.id)
+        assertEquals(contributions.count(), getChallengeResponse.challenge.contributionsCount)
+
+        // when
+        val contributionToDelete = contributions[0]
+        handlePlaceAccessibilityDeletedEventUseCase.handle(
+            event = PlaceAccessibilityDeletedEvent(
+                id = contributionToDelete.placeAccessibilityId!!,
+                accessibilityRegisterer = AccessibilityRegistererDTO(
+                    id = contributionToDelete.userId,
+                ),
+                place = place.toPlaceDTO(),
+            ),
+        )
+
+        // then
+        val getChallengeResponse2 = mvc.sccRequest(
+            "/getChallenge",
+            GetChallengeRequestDto(
+                challengeId = challenge.id,
+            ),
+            user = user,
+        )
+            .getResult(GetChallengeResponseDto::class)
+        assertEquals(challenge.id, getChallengeResponse2.challenge.id)
+        assertEquals(contributions.count() - 1, getChallengeResponse2.challenge.contributionsCount)
+
+        val remainingContributions = transactionManager.doInTransaction {
+            challengeContributionRepository.findByChallengeId(challengeId = challenge.id)
+        }
+        assertEquals(contributions.count() - 1, remainingContributions.size)
+        assertTrue(contributionToDelete.id !in remainingContributions.map { it.id })
+    }
+}

--- a/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/domain_event/BuildingAccessibilityCommentDeletedEventSubscriber.kt
+++ b/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/domain_event/BuildingAccessibilityCommentDeletedEventSubscriber.kt
@@ -1,0 +1,20 @@
+package club.staircrusher.challenge.infra.adapter.`in`.domain_event
+
+import club.staircrusher.challenge.application.port.`in`.use_case.HandleBuildingAccessibilityCommentDeletedEventUseCase
+import club.staircrusher.domain_event.BuildingAccessibilityCommentDeletedEvent
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.domain.event.DomainEvent
+import club.staircrusher.stdlib.domain.event.DomainEventSubscriber
+
+@Component
+class BuildingAccessibilityCommentDeletedEventSubscriber(
+    private val buildingAccessibilityCommentDeletedEventUseCase: HandleBuildingAccessibilityCommentDeletedEventUseCase,
+) : DomainEventSubscriber<BuildingAccessibilityCommentDeletedEvent>() {
+    override fun onDomainEvent(event: BuildingAccessibilityCommentDeletedEvent) {
+        buildingAccessibilityCommentDeletedEventUseCase.handle(event)
+    }
+
+    override fun canConsume(event: DomainEvent): Boolean {
+        return event is BuildingAccessibilityCommentDeletedEvent
+    }
+}

--- a/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/domain_event/BuildingAccessibilityDeletedEventSubscriber.kt
+++ b/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/domain_event/BuildingAccessibilityDeletedEventSubscriber.kt
@@ -1,0 +1,20 @@
+package club.staircrusher.challenge.infra.adapter.`in`.domain_event
+
+import club.staircrusher.challenge.application.port.`in`.use_case.HandleBuildingAccessibilityDeletedEventUseCase
+import club.staircrusher.domain_event.BuildingAccessibilityDeletedEvent
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.domain.event.DomainEvent
+import club.staircrusher.stdlib.domain.event.DomainEventSubscriber
+
+@Component
+class BuildingAccessibilityDeletedEventSubscriber(
+    private val buildingAccessibilityDeletedEventUseCase: HandleBuildingAccessibilityDeletedEventUseCase,
+) : DomainEventSubscriber<BuildingAccessibilityDeletedEvent>() {
+    override fun onDomainEvent(event: BuildingAccessibilityDeletedEvent) {
+        buildingAccessibilityDeletedEventUseCase.handle(event)
+    }
+
+    override fun canConsume(event: DomainEvent): Boolean {
+        return event is BuildingAccessibilityDeletedEvent
+    }
+}

--- a/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/domain_event/PlaceAccessibilityCommentDeletedEventSubscriber.kt
+++ b/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/domain_event/PlaceAccessibilityCommentDeletedEventSubscriber.kt
@@ -1,0 +1,20 @@
+package club.staircrusher.challenge.infra.adapter.`in`.domain_event
+
+import club.staircrusher.challenge.application.port.`in`.use_case.HandlePlaceAccessibilityCommentDeletedEventUseCase
+import club.staircrusher.domain_event.PlaceAccessibilityCommentDeletedEvent
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.domain.event.DomainEvent
+import club.staircrusher.stdlib.domain.event.DomainEventSubscriber
+
+@Component
+class PlaceAccessibilityCommentDeletedEventSubscriber(
+    private val placeAccessibilityCommentDeletedEventUseCase: HandlePlaceAccessibilityCommentDeletedEventUseCase,
+) : DomainEventSubscriber<PlaceAccessibilityCommentDeletedEvent>() {
+    override fun onDomainEvent(event: PlaceAccessibilityCommentDeletedEvent) {
+        placeAccessibilityCommentDeletedEventUseCase.handle(event)
+    }
+
+    override fun canConsume(event: DomainEvent): Boolean {
+        return event is PlaceAccessibilityCommentDeletedEvent
+    }
+}

--- a/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/domain_event/PlaceAccessibilityDeletedEventSubscriber.kt
+++ b/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/domain_event/PlaceAccessibilityDeletedEventSubscriber.kt
@@ -1,0 +1,20 @@
+package club.staircrusher.challenge.infra.adapter.`in`.domain_event
+
+import club.staircrusher.challenge.application.port.`in`.use_case.HandlePlaceAccessibilityDeletedEventUseCase
+import club.staircrusher.domain_event.PlaceAccessibilityDeletedEvent
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.domain.event.DomainEvent
+import club.staircrusher.stdlib.domain.event.DomainEventSubscriber
+
+@Component
+class PlaceAccessibilityDeletedEventSubscriber(
+    private val placeAccessibilityDeletedEventUseCase: HandlePlaceAccessibilityDeletedEventUseCase,
+) : DomainEventSubscriber<PlaceAccessibilityDeletedEvent>() {
+    override fun onDomainEvent(event: PlaceAccessibilityDeletedEvent) {
+        placeAccessibilityDeletedEventUseCase.handle(event)
+    }
+
+    override fun canConsume(event: DomainEvent): Boolean {
+        return event is PlaceAccessibilityDeletedEvent
+    }
+}

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/DomainEventConverters.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/DomainEventConverters.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.place.infra.adapter.`in`
+package club.staircrusher.place.application.port.`in`
 
 import club.staircrusher.domain_event.dto.BuildingAddressDTO
 import club.staircrusher.domain_event.dto.BuildingDTO

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/PlaceSearchEventSubscriber.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/PlaceSearchEventSubscriber.kt
@@ -3,6 +3,8 @@ package club.staircrusher.place.infra.adapter.`in`
 import club.staircrusher.domain_event.PlaceSearchEvent
 import club.staircrusher.domain_event.dto.PlaceDTO
 import club.staircrusher.place.application.port.`in`.CacheAllBuildingsAndPlacesUseCase
+import club.staircrusher.place.application.port.`in`.toBuilding
+import club.staircrusher.place.application.port.`in`.toPlace
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.domain.event.DomainEvent
 import club.staircrusher.stdlib.domain.event.DomainEventSubscriber

--- a/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/BuildingAccessibilityCommentDeletedEvent.kt
+++ b/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/BuildingAccessibilityCommentDeletedEvent.kt
@@ -1,0 +1,12 @@
+package club.staircrusher.domain_event
+
+import club.staircrusher.domain_event.dto.AccessibilityCommentRegistererDTO
+import club.staircrusher.domain_event.dto.BuildingDTO
+import club.staircrusher.stdlib.domain.event.DomainEvent
+
+
+data class BuildingAccessibilityCommentDeletedEvent(
+    val id: String,
+    val commentRegisterer: AccessibilityCommentRegistererDTO,
+    val building: BuildingDTO,
+) : DomainEvent

--- a/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/BuildingAccessibilityDeletedEvent.kt
+++ b/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/BuildingAccessibilityDeletedEvent.kt
@@ -1,0 +1,12 @@
+package club.staircrusher.domain_event
+
+import club.staircrusher.domain_event.dto.AccessibilityRegistererDTO
+import club.staircrusher.domain_event.dto.BuildingDTO
+import club.staircrusher.stdlib.domain.event.DomainEvent
+
+
+data class BuildingAccessibilityDeletedEvent(
+    val id: String,
+    val accessibilityRegisterer: AccessibilityRegistererDTO,
+    val building: BuildingDTO,
+) : DomainEvent

--- a/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/PlaceAccessibilityCommentDeletedEvent.kt
+++ b/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/PlaceAccessibilityCommentDeletedEvent.kt
@@ -1,0 +1,12 @@
+package club.staircrusher.domain_event
+
+import club.staircrusher.domain_event.dto.AccessibilityCommentRegistererDTO
+import club.staircrusher.domain_event.dto.PlaceDTO
+import club.staircrusher.stdlib.domain.event.DomainEvent
+
+
+data class PlaceAccessibilityCommentDeletedEvent(
+    val id: String,
+    val commentRegisterer: AccessibilityCommentRegistererDTO,
+    val place: PlaceDTO,
+) : DomainEvent

--- a/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/PlaceAccessibilityDeletedEvent.kt
+++ b/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/PlaceAccessibilityDeletedEvent.kt
@@ -1,0 +1,12 @@
+package club.staircrusher.domain_event
+
+import club.staircrusher.domain_event.dto.AccessibilityRegistererDTO
+import club.staircrusher.domain_event.dto.PlaceDTO
+import club.staircrusher.stdlib.domain.event.DomainEvent
+
+
+data class PlaceAccessibilityDeletedEvent(
+    val id: String,
+    val accessibilityRegisterer: AccessibilityRegistererDTO,
+    val place: PlaceDTO,
+) : DomainEvent

--- a/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/dto/AccessibilityCommentRegistererDTO.kt
+++ b/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/dto/AccessibilityCommentRegistererDTO.kt
@@ -1,0 +1,5 @@
+package club.staircrusher.domain_event.dto
+
+data class AccessibilityCommentRegistererDTO(
+    val id: String?,
+)

--- a/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/dto/AccessibilityRegistererDTO.kt
+++ b/app-server/subprojects/domain_event/src/main/kotlin/club/staircrusher/domain_event/dto/AccessibilityRegistererDTO.kt
@@ -1,0 +1,5 @@
+package club.staircrusher.domain_event.dto
+
+data class AccessibilityRegistererDTO(
+    val id: String?,
+)

--- a/app-server/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/DB.kt
+++ b/app-server/subprojects/persistence_model/src/main/kotlin/club/staircrusher/infra/persistence/sqldelight/DB.kt
@@ -130,6 +130,10 @@ class DB(dataSource: DataSource) : TransactionManager {
             driver.isolationLevel = null
         }
     }
+
+    override fun doAfterCommit(block: () -> Unit) {
+        block() // TODO: 올바르게 구현하기
+    }
 }
 
 private val objectMapper = jacksonObjectMapper()

--- a/app-server/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/NoopTransactionManager.kt
+++ b/app-server/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/NoopTransactionManager.kt
@@ -18,6 +18,10 @@ class NoopTransactionManager : TransactionManager {
         return NoopTransaction<T>().block()
     }
 
+    override fun doAfterCommit(block: () -> Unit) {
+        block()
+    }
+
     private class NoopTransaction<T> : Transaction<T> {
         override fun afterCommit(block: () -> Unit) {
             TODO("Not yet implemented")

--- a/app-server/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/TransactionManager.kt
+++ b/app-server/subprojects/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/TransactionManager.kt
@@ -3,4 +3,6 @@ package club.staircrusher.stdlib.persistence
 interface TransactionManager {
     fun <T> doInTransaction(block: Transaction<T>.() -> T): T
     fun <T> doInTransaction(isolationLevel: TransactionIsolationLevel, block: Transaction<T>.() -> T): T
+
+    fun doAfterCommit(block: () -> Unit)
 }


### PR DESCRIPTION
## Checklist
- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- 정보 / 코멘트 삭제 시 도메인 이벤트를 발행합니다.
- 해당 도메인 이벤트 수신 시 contribution을 삭제합니다.