### PR TITLE
회원 탈퇴 시 소셜 로그인 계정 연결 정보 삭제하기

### DIFF
--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
@@ -6,6 +6,7 @@ import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
 import club.staircrusher.stdlib.persistence.TransactionManager
 import club.staircrusher.stdlib.validation.email.EmailValidator
+import club.staircrusher.user.application.port.out.persistence.UserAuthInfoRepository
 import club.staircrusher.user.domain.model.AuthTokens
 import club.staircrusher.user.application.port.out.persistence.UserRepository
 import club.staircrusher.user.domain.model.User
@@ -20,6 +21,7 @@ class UserApplicationService(
     private val userRepository: UserRepository,
     private val userAuthService: UserAuthService,
     private val passwordEncryptor: PasswordEncryptor,
+    private val userAuthInfoRepository: UserAuthInfoRepository,
     private val clock: Clock,
 ) {
     @Deprecated("닉네임 로그인은 사라질 예정")
@@ -132,6 +134,8 @@ class UserApplicationService(
         val user = userRepository.findById(userId)
         user.delete(clock.instant())
         userRepository.save(user)
+
+        userAuthInfoRepository.removeByUserId(userId)
     }
 
     fun getUser(userId: String): User? = transactionManager.doInTransaction {

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/out/persistence/UserAuthInfoRepository.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/out/persistence/UserAuthInfoRepository.kt
@@ -7,4 +7,5 @@ import club.staircrusher.user.domain.model.UserAuthProviderType
 interface UserAuthInfoRepository : EntityRepository<UserAuthInfo, String> {
     fun findByExternalId(authProviderType: UserAuthProviderType, externalId: String): UserAuthInfo?
     fun findByUserId(userId: String): List<UserAuthInfo>
+    fun removeByUserId(userId: String)
 }

--- a/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/DeleteUserTest.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/DeleteUserTest.kt
@@ -1,16 +1,35 @@
 package club.staircrusher.user.infra.adapter.`in`.controller
 
+import club.staircrusher.api.spec.dto.KakaoTokensDto
 import club.staircrusher.api.spec.dto.LoginPostRequest
+import club.staircrusher.api.spec.dto.LoginResultDto
+import club.staircrusher.api.spec.dto.LoginWithKakaoPostRequest
+import club.staircrusher.stdlib.clock.SccClock
+import club.staircrusher.user.application.port.out.persistence.UserAuthInfoRepository
 import club.staircrusher.user.application.port.out.persistence.UserRepository
+import club.staircrusher.user.application.port.out.web.login.kakao.KakaoIdToken
+import club.staircrusher.user.application.port.out.web.login.kakao.KakaoLoginService
+import club.staircrusher.user.domain.model.UserAuthProviderType
 import club.staircrusher.user.infra.adapter.`in`.controller.base.UserITBase
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.web.servlet.ResultActionsDsl
 
 class DeleteUserTest : UserITBase() {
+    @MockBean
+    lateinit var kakaoLoginService: KakaoLoginService
+
     @Autowired
     private lateinit var userRepository: UserRepository
+
+    @Autowired
+    lateinit var userAuthInfoRepository: UserAuthInfoRepository
 
     @Test
     fun deleteUserTest() {
@@ -42,5 +61,83 @@ class DeleteUserTest : UserITBase() {
         login().andExpect {
             status { isBadRequest() }
         }
+    }
+
+    @Test
+    fun `소셜 로그인으로 가입한 유저 탈퇴 테스트`() {
+        val params = LoginWithKakaoPostRequest(
+            kakaoTokens = KakaoTokensDto(
+                accessToken = "dummy",
+                refreshToken = "refreshToken",
+                idToken = "dummy",
+            )
+        )
+
+        // given - 소셜 로그인으로 회원가입
+        Mockito.`when`(kakaoLoginService.parseIdToken("dummy")).thenReturn(
+            KakaoIdToken(
+                issuer = "https://kauth.kakao.com",
+                audience = "clientId",
+                expiresAtEpochSecond = SccClock.instant().epochSecond + 10,
+                kakaoSyncUserId = "kakaoSyncUserId1",
+            )
+        )
+        val user = mvc
+            .sccRequest("/loginWithKakao", params)
+            .run {
+                val result = getResult(LoginResultDto::class)
+
+                val newUser = transactionManager.doInTransaction {
+                    userRepository.findById(result.user.id)
+                }
+
+                val newUserAuthInfo = transactionManager.doInTransaction {
+                    userAuthInfoRepository.findByUserId(newUser.id).find { it.authProviderType == UserAuthProviderType.KAKAO }
+                }
+                assertNotNull(newUserAuthInfo)
+
+                newUser
+            }
+
+        // given - 소셜 로그인으로 한 명 더 유저를 만들어둔다.
+        Mockito.`when`(kakaoLoginService.parseIdToken("dummy")).thenReturn(
+            KakaoIdToken(
+                issuer = "https://kauth.kakao.com",
+                audience = "clientId",
+                expiresAtEpochSecond = SccClock.instant().epochSecond + 10,
+                kakaoSyncUserId = "kakaoSyncUserId2",
+            )
+        )
+        val otherUser = mvc
+            .sccRequest("/loginWithKakao", params)
+            .run {
+                val result = getResult(LoginResultDto::class)
+                val otherUser = transactionManager.doInTransaction {
+                    userRepository.findById(result.user.id)
+                }
+                assertNotNull(otherUser)
+                assertNotEquals(user.id, otherUser.id)
+
+                otherUser
+            }
+
+        // when
+        mvc
+            .sccRequest("/deleteUser", "", user = user)
+            .andExpect {
+                // then
+                status { isNoContent() }
+                transactionManager.doInTransaction {
+                    val deletedUser = userRepository.findById(user.id)
+                    assertTrue(deletedUser.isDeleted)
+
+                    val userAuthInfo = userAuthInfoRepository.findByUserId(user.id).find { it.authProviderType == UserAuthProviderType.KAKAO }
+                    assertNull(userAuthInfo)
+
+                    // 다른 유저의 userAuthInfo는 삭제되지 않는다.
+                    val otherUserAuthInfo = userAuthInfoRepository.findByUserId(otherUser.id).find { it.authProviderType == UserAuthProviderType.KAKAO }
+                    assertNotNull(otherUserAuthInfo)
+                }
+            }
     }
 }

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/UserAuthInfoRepository.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/persistence/UserAuthInfoRepository.kt
@@ -44,4 +44,8 @@ class UserAuthInfoRepository(
             .executeAsList()
             .map { it.toDomainModel() }
     }
+
+    override fun removeByUserId(userId: String) {
+        queries.removeByUserId(userId)
+    }
 }

--- a/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/user/UserAuthInfo.sq
+++ b/app-server/subprojects/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/user/UserAuthInfo.sq
@@ -34,3 +34,9 @@ SELECT *
 FROM user_auth_info
 WHERE
     user_auth_info.user_id = :userId;
+
+removeByUserId:
+DELETE
+FROM user_auth_info
+WHERE
+    user_auth_info.user_id = :userId;

--- a/app-server/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/InMemoryUserAuthInfoRepository.kt
+++ b/app-server/subprojects/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/mock/InMemoryUserAuthInfoRepository.kt
@@ -36,4 +36,10 @@ class InMemoryUserAuthInfoRepository : UserAuthInfoRepository {
     override fun findByUserId(userId: String): List<UserAuthInfo> {
         return userById.values.filter { it.userId == userId }
     }
+
+    override fun removeByUserId(userId: String) {
+        userById.values.filter { it.userId == userId }.forEach {
+            userById.remove(it.id)
+        }
+    }
 }


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- 회원 탈퇴 시 User는 지우는데 UserAuthInfo를 삭제 안 하고 있어서, 이를 삭제하도록 수정합니다.