### PR TITLE
Building 위경도 정보 같이 내려주기

### DIFF
--- a/app-server/subprojects/api_specification/api/scc-api/api-spec.yaml
+++ b/app-server/subprojects/api_specification/api/scc-api/api-spec.yaml
@@ -794,6 +794,9 @@ components:
         address:
           type: string
           description: 건물의 human-readable한 주소.
+        location:
+          $ref: '#/components/schemas/Location'
+          description: 건물의 위경도.
       required:
         - id
         - address

--- a/app-server/subprojects/bounded_context/place_search/infra/src/main/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/Converters.kt
+++ b/app-server/subprojects/bounded_context/place_search/infra/src/main/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/Converters.kt
@@ -15,6 +15,7 @@ fun Place.toDTO() = club.staircrusher.api.spec.dto.Place(
 fun Building.toDTO() = club.staircrusher.api.spec.dto.Building(
     id = id,
     address = address.toString(),
+    location = address.location.toDTO(),
 )
 
 fun PlaceSearchService.SearchPlacesResult.toDTO() = PlaceListItem(

--- a/app-server/subprojects/bounded_context/place_search/infra/src/main/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/Converters.kt
+++ b/app-server/subprojects/bounded_context/place_search/infra/src/main/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/Converters.kt
@@ -1,5 +1,6 @@
 package club.staircrusher.place_search.infra.adapter.`in`.controller
 
+import club.staircrusher.api.converter.toDTO
 import club.staircrusher.api.spec.dto.PlaceCategoryDto
 import club.staircrusher.api.spec.dto.PlaceListItem
 import club.staircrusher.place.domain.model.Building
@@ -15,7 +16,7 @@ fun Place.toDTO() = club.staircrusher.api.spec.dto.Place(
 fun Building.toDTO() = club.staircrusher.api.spec.dto.Building(
     id = id,
     address = address.toString(),
-    location = address.location.toDTO(),
+    location = location.toDTO(),
 )
 
 fun PlaceSearchService.SearchPlacesResult.toDTO() = PlaceListItem(


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다.

지도 UI 보여주기를 위해 장소(건물) 위경도 정보가 필요하다

현재 위경도 정보를 내려주는 DTO 가 Building (== PlaceListItem) 뿐이고,
이걸 사용하는 엔드포인트는 searchPlace, listConqueredPlaces, listPlaceInBuilding

정도여서 위경도 같이 내려주는게 큰 문제는 없어보인다