### PR TITLE
서버 모니터링용 인프라 작업

### DIFF
--- a/infra/helm/scc-monitoring/Chart.lock
+++ b/infra/helm/scc-monitoring/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
-- name: kube-prometheus-stack
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 56.6.2
-digest: sha256:9cabf099ca6b6d6267fe9fbe4db9b1c2ef311795b0a4cbf94cf781276c2ff600
-generated: "2024-02-05T17:55:13.166201+09:00"
+- name: opentelemetry-operator
+  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  version: 0.48.0
+- name: openobserve-collector
+  repository: https://charts.openobserve.ai
+  version: 0.3.1
+digest: sha256:bc6f82f23e468cf4df9ca5ede2859aefc069711b37d84b765236dc00225968e5
+generated: "2024-03-11T23:30:51.414395+09:00"

--- a/infra/helm/scc-monitoring/Chart.yaml
+++ b/infra/helm/scc-monitoring/Chart.yaml
@@ -23,6 +23,15 @@ version: 0.1.0
 # It is recommended to use it with quotes.
 appVersion: "1.16.0"
 dependencies:
-  - name: kube-prometheus-stack
-    version: 56.6.2
-    repository: https://prometheus-community.github.io/helm-charts
+  - name: cert-manager
+    version: 1.14.3
+    repository: https://charts.jetstack.io
+  - name: opentelemetry-operator
+    version: 0.48.0
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  - name: openobserve-collector
+    version: 0.96.0
+    repository: https://charts.openobserve.ai
+#  - name: kube-prometheus-stack
+#    version: 56.6.2
+#    repository: https://prometheus-community.github.io/helm-charts

--- a/infra/helm/scc-monitoring/Chart.yaml
+++ b/infra/helm/scc-monitoring/Chart.yaml
@@ -23,15 +23,9 @@ version: 0.1.0
 # It is recommended to use it with quotes.
 appVersion: "1.16.0"
 dependencies:
-  - name: cert-manager
-    version: 1.14.3
-    repository: https://charts.jetstack.io
   - name: opentelemetry-operator
     version: 0.48.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   - name: openobserve-collector
-    version: 0.96.0
+    version: 0.3.1
     repository: https://charts.openobserve.ai
-#  - name: kube-prometheus-stack
-#    version: 56.6.2
-#    repository: https://prometheus-community.github.io/helm-charts

--- a/infra/helm/scc-monitoring/files/secret.yaml
+++ b/infra/helm/scc-monitoring/files/secret.yaml
@@ -1,0 +1,4 @@
+openobserve:
+  # TODO: use sop for real secrets
+  endpoint: "https://api.openobserve.ai/api/"
+  authorization: Bearer

--- a/infra/helm/scc-monitoring/files/secret.yaml
+++ b/infra/helm/scc-monitoring/files/secret.yaml
@@ -1,4 +1,24 @@
-openobserve:
-  # TODO: use sop for real secrets
-  endpoint: "https://api.openobserve.ai/api/"
-  authorization: Bearer
+exporters:
+    otlphttp/openobserve:
+        endpoint: ENC[AES256_GCM,data:AoY67QmmyjS2hHW0tCUTELcPVhKH2Tr0AJQMJ61QtFtPK2+rT3096Ev+3TOUWSc1k31KOzPG/KtOJikAmxIRT+fbwIkH4z2+gA==,iv:qWvBVw6eJ+DdSqhXQ5PirK1qCVi+F37hxlOUcJwXL1U=,tag:AZ43F5merGHcg5Pf+VqzLw==,type:str]
+        headers:
+            Authorization: ENC[AES256_GCM,data:85/QsH/gga1KYOHlLGNnw++32bgNgEauoL1xPCld43ibFDrwZDEc5Wvy0BGnWb3EdBiP6s+MXPUzEL7P7SWWtoKG,iv:8bJDzzXzcUt8W3NYgb6k+LL4OeY6pLVp0p65wMpZeD8=,tag:6t4gTvom7g4+CF5hPTZAvw==,type:str]
+    otlphttp/openobserve_k8s_events:
+        endpoint: ENC[AES256_GCM,data:zDXFFXabYKAnsYkCeRWrhlhQwjBspGT5pydjixLeMlpEzA6UdFreunmMT8fDDGSIuQ9NsmKZClSSkeUv8wVPVK6canEwjK3C7g==,iv:AXgjuDI6AJkpxv3/IpK78AZti5g7oDiH0TkHgnq3iE8=,tag:MAR9evbPMuUwDNPvMJpE5g==,type:str]
+        headers:
+            Authorization: ENC[AES256_GCM,data:IS7jWLahY+lX1b+RGposrm1GBXQb1JdZu/aQ7frB0LKdXNV09aOkAEiNvs+yzh+Uc4KuERhLrYvzD3BYzYhsi2kI,iv:u3l8EO7+Fq/CPo4TATTAY9eQ5rN3Q9tj1U+/MFHWZWY=,tag:MHQL/EBiNCBwQwnTZCPqkA==,type:str]
+sops:
+    kms:
+        - arn: arn:aws:kms:ap-northeast-2:291889421067:alias/sops
+          created_at: "2023-07-31T15:54:45Z"
+          enc: AQICAHgF8bYnZL94LzSwlUWA75seDxMTpMHltwauy+q73c/QBwFniCIYq6aVHk8/6aLA+AJtAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM1YMNm0wSD1pN7dRxAgEQgDtFpVZMaweOLSqjHlVDJClQ4G+1D3jpzLa/zFQEgdtDelP/Xo4MrMfHd++njCmbf6asBTNRorBCKvbcsg==
+          aws_profile: ""
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-03-13T17:21:22Z"
+    mac: ENC[AES256_GCM,data:V8YtUVw896AaSKc6ukVnPm1fyXXz0J31f5jMqfkluktq53UFjPScztk4jW07hlSW99q3lkHEf9t0Jb8vbTW323aEE7Va/5QVfh0hAeil2jSch+THA7gVyB51LmaiRWrW+La13VLqYlzKnc5d+VAxAGAMoKg71gd3dEJkPycDi5A=,iv:eF/41v3dIua+yjYp5jdgw89KQTGSCujms8VSDqF3tw8=,tag:q1MUPiu5GjRTf/HCZB7Lgg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/infra/helm/scc-monitoring/templates/configmap-for-secret.yaml
+++ b/infra/helm/scc-monitoring/templates/configmap-for-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "scc-monitoring.fullname" . }}-for-secret
+  labels:
+    {{- include "scc-monitoring.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+data:
+  secret-raw.yaml: |-
+{{ printf "%s/secret.yaml" .Values.filesDir | .Files.Get | indent 4 }}

--- a/infra/helm/scc-monitoring/templates/deploy-secret-job.yaml
+++ b/infra/helm/scc-monitoring/templates/deploy-secret-job.yaml
@@ -1,0 +1,68 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "scc-monitoring.fullname" . }}-deploy-secret-job
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "20"
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "scc-monitoring.serviceAccountName" . }}-deploy-secret
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "mozilla/sops:v3-alpine"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - |-
+              wget "https://dl.k8s.io/release/$(wget https://dl.k8s.io/release/stable.txt -O-)/bin/linux/amd64/kubectl" &&
+              chmod u+x kubectl &&
+              wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq &&
+              chmod +x /usr/bin/yq &&
+              mkdir secret &&
+              sops -d /app/conf/secret-raw.yaml > secret/secret.yaml &&
+              echo 'apiVersion: v1
+              kind: Secret
+              metadata:
+                name: scc-monitoring-secret
+                namespace: scc-monitoring
+              type: Opaque
+              stringData: {}' > scc-monitoring-secret.yaml &&
+              yq -i ".stringData += $(yq secret/secret.yaml -o json)" scc-monitoring-secret.yaml &&
+              ./kubectl apply -f scc-monitoring-secret.yaml
+#              ./kubectl create secret generic {{ include "scc-monitoring.fullname" . }}-secret --from-file=secret/secret.yaml --dry-run=client -o yaml | ./kubectl apply -f -
+#              TODO: kubectl을 이미지에 미리 깔아놓기
+          env:
+            - name: AWS_STS_REGIONAL_ENDPOINTS
+              value: regional
+            - name: AWS_REGION
+              value: ap-northeast-2
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.deploySecret.awsRoleArn }}"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+          volumeMounts:
+            - name: aws-iam-token
+              mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+              readOnly: true
+            - name: config-volume
+              mountPath: /app/conf
+              readOnly: true
+      volumes:
+        - name: aws-iam-token
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  audience: sts.amazonaws.com
+                  expirationSeconds: 86400
+                  path: token
+        - name: config-volume
+          configMap:
+            name: {{ include "scc-monitoring.fullname" . }}-for-secret
+      restartPolicy: Never
+  backoffLimit: 3

--- a/infra/helm/scc-monitoring/templates/deploy-secret-serviceaccount.yaml
+++ b/infra/helm/scc-monitoring/templates/deploy-secret-serviceaccount.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "scc-monitoring.serviceAccountName" . }}-deploy-secret
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: create-secrets
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["secrets"]
+    verbs: ["create", "patch", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: create-secrets-to-{{ include "scc-monitoring.serviceAccountName" . }}-deploy-secret
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "scc-monitoring.serviceAccountName" . }}-deploy-secret
+roleRef:
+  kind: Role
+  name: create-secrets
+  apiGroup: rbac.authorization.k8s.io

--- a/infra/helm/scc-monitoring/values.yaml
+++ b/infra/helm/scc-monitoring/values.yaml
@@ -22,15 +22,14 @@ openobserve-collector:
   enabled: true
   # Default values for openobserve-collector.
   exporters:
-    # TODO: 여기에 secret 어떻게 넣을지 고민
     otlphttp/openobserve:
-      endpoint: https://api.openobserve.ai/api/default/
+      endpoint: ""
       headers:
-        Authorization: Basic < base64 encoded auth >
+        Authorization: ""
     otlphttp/openobserve_k8s_events:
-      endpoint: https://api.openobserve.ai/api/default/
+      endpoint: ""
       headers:
-        Authorization: Basic < base64 encoded auth >
+        Authorization: ""
         stream-name: k8s_events
 
   replicaCount: 1

--- a/infra/helm/scc-monitoring/values.yaml
+++ b/infra/helm/scc-monitoring/values.yaml
@@ -12,11 +12,11 @@ cert-manager:
 exporters:
   # TODO: 여기에 secret 어떻게 넣을지 고민
   otlphttp/openobserve:
-    endpoint: 'https://api.openobserve.ai/api/default/'
+    endpoint: https://api.openobserve.ai/api/default/
     headers:
       Authorization: Basic < base64 encoded auth >
   otlphttp/openobserve_k8s_events:
-    endpoint: 'https://api.openobserve.ai/api/default/'
+    endpoint: https://api.openobserve.ai/api/default/
     headers:
       Authorization: Basic < base64 encoded auth >
       stream-name: k8s_events
@@ -26,16 +26,25 @@ replicaCount: 1
 image:
   repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   pullPolicy: IfNotPresent
-  tag: 0.96.0
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.96.0"
+
 imagePullSecrets: []
-nameOverride: ''
-fullnameOverride: ''
+nameOverride: ""
+fullnameOverride: ""
+
 serviceAccount:
+  # Specifies whether a service account should be created
   create: true
+  # Annotations to add to the service account
   annotations: {}
-  name: ''
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 labels: {}
 
+# If Opentelemetry operator should be installed with the chart. If you already have the operator installed, set enabled to false. Refer https://opentelemetry.io/docs/kubernetes/operator/ and https://opentelemetry.io/docs/kubernetes/helm/operator/
 opentelemetry-operator:
   enabled: false
   admissionWebhooks:
@@ -43,26 +52,63 @@ opentelemetry-operator:
       enabled: false
       autoGenerateCert: true
   manager:
-    featureGates: '--operator.autoinstrumentation.go=true'
+    # auto-instrumentation can be enabled for go which is disabled by default. go auto-instrumentation uses eBPF and requires privileged mode.
+    featureGates: "--operator.autoinstrumentation.go=true"
+
+## Auto-Instrumentation resource to be installed in the cluster
+## Can be used by setting the following to the pod/namespace annotations:
+##  Java: instrumentation.opentelemetry.io/inject-java: "true"
+##  NodeJS: instrumentation.opentelemetry.io/inject-nodejs: "true"
+##  Python: instrumentation.opentelemetry.io/inject-python: "true"
+##  DotNet: instrumentation.opentelemetry.io/inject-dotnet: "true"
+##  Go: instrumentation.opentelemetry.io/inject-go: "true" , instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/path/to/container/executable"
+##  OpenTelemetry SDK environment variables only: instrumentation.opentelemetry.io/inject-sdk: "true"
 autoinstrumentation:
   enabled: true
+  ## The collector name to send traces to
   collectorTarget: traces
   propagators:
     - tracecontext
     - baggage
+
 podAndServiceMonitor:
+  # Specifies whether PodMonitor and ServiceMonitor CRs should be created
   create: true
+
 podAnnotations: {}
-podSecurityContext: {}
-securityContext: {}
+
+podSecurityContext:
+  {}
+# fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+# runAsUser: 1000
+
 agent:
   enabled: true
   tolerations:
-    - key: exampleKey1
-      operator: Equal
-      value: 'true'
-      effect: NoSchedule
-  resources: {}
+    - key: "exampleKey1"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+  resources:
+    {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+  #   memory: 128Mi
   receivers:
     otlp:
       protocols:
@@ -71,22 +117,23 @@ agent:
     prometheus:
       config:
         scrape_configs:
-          - job_name: otel-collector
+          - job_name: "otel-collector"
             scrape_interval: 5s
             static_configs:
-              - targets:
-                  - '0.0.0.0:8888'
+              - targets: ["0.0.0.0:8888"]
+
     filelog/std:
-      include:
-        - /var/log/pods/*/*/*.log
+      include: [/var/log/pods/*/*/*.log]
       exclude:
-        - /var/log/pods/*/otel-collector/*.log
-        - /var/log/pods/*/otc-container/*.log
-        - /var/log/pods/*/openobserve/*.log
+        # Exclude logs from all containers named otel-collector or otc-container (otel-contrib)
+        - /var/log/pods/*/otel-collector/*.log # named otel-collector
+        - /var/log/pods/*/otc-container/*.log # named otc-container (for otel-contrib containers)
+        - /var/log/pods/*/openobserve/*.log # named openobserve. Would want to avoid cyclical logs
       start_at: end
       include_file_path: true
       include_file_name: false
       operators:
+        # Find out which format is used by kubernetes
         - type: router
           id: get-format
           routes:
@@ -96,59 +143,60 @@ agent:
               expr: 'body matches "^[^ Z]+ "'
             - output: parser-containerd
               expr: 'body matches "^[^ Z]+Z"'
+        # Parse CRI-O format
         - type: regex_parser
           id: parser-crio
-          regex: >-
-            ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)
-            ?(?P<log>.*)$
+          regex: "^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
           output: extract_metadata_from_filepath
           timestamp:
             parse_from: attributes.time
             layout_type: gotime
-            layout: '2006-01-02T15:04:05.999999999Z07:00'
+            layout: "2006-01-02T15:04:05.999999999Z07:00"
+        # Parse CRI-Containerd format
         - type: regex_parser
           id: parser-containerd
-          regex: >-
-            ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)
-            ?(?P<log>.*)$
+          regex: "^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
           output: extract_metadata_from_filepath
           timestamp:
             parse_from: attributes.time
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+        # Parse Docker format
         - type: json_parser
           id: parser-docker
           output: extract_metadata_from_filepath
           timestamp:
             parse_from: attributes.time
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+        # Extract metadata from file path
         - type: regex_parser
           id: extract_metadata_from_filepath
-          regex: >-
-            ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
-          parse_from: 'attributes["log.file.path"]'
+          regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+          parse_from: attributes["log.file.path"]
           cache:
-            size: 128
+            size: 128 # default maximum amount of Pods per Node is 110
+        # Update body field after finishing all parsing
         - type: move
           from: attributes.log
           to: body
+        # Rename attributes
         - type: move
           from: attributes.stream
-          to: 'attributes["log.iostream"]'
+          to: attributes["log.iostream"]
         - type: move
           from: attributes.container_name
-          to: 'resource["k8s.container.name"]'
+          to: resource["k8s.container.name"]
         - type: move
           from: attributes.namespace
-          to: 'resource["k8s.namespace.name"]'
+          to: resource["k8s.namespace.name"]
         - type: move
           from: attributes.pod_name
-          to: 'resource["k8s.pod.name"]'
+          to: resource["k8s.pod.name"]
         - type: move
           from: attributes.restart_count
-          to: 'resource["k8s.container.restart_count"]'
+          to: resource["k8s.container.restart_count"]
         - type: move
           from: attributes.uid
-          to: 'resource["k8s.pod.uid"]'
+          to: resource["k8s.pod.uid"]
     hostmetrics:
       root_path: /hostfs
       collection_interval: 15s
@@ -193,12 +241,15 @@ agent:
               - sysfs
               - tracefs
         load: {}
+        #     memory: {}
         network: {}
-        process: {}
+        #     paging: {}
+        #     processes: {}
+        process: {} # a bug in the process scraper causes the collector to throw errors so disabling it for now
     kubeletstats:
       collection_interval: 15s
-      auth_type: serviceAccount
-      endpoint: 'https://${env:K8S_NODE_NAME}:10250'
+      auth_type: "serviceAccount"
+      endpoint: "https://${env:K8S_NODE_NAME}:10250"
       insecure_skip_verify: true
       extra_metadata_labels:
         - container.id
@@ -219,17 +270,12 @@ agent:
           enabled: true
   processors:
     resourcedetection:
-      detectors:
-        - system
-        - env
-        - k8snode
+      detectors: [system, env, k8snode]
       override: true
       system:
-        hostname_sources:
-          - os
-          - dns
+        hostname_sources: [os, dns]
     k8sattributes:
-      auth_type: serviceAccount
+      auth_type: "serviceAccount"
       passthrough: false
       filter:
         node_from_env_var: K8S_NODE_NAME
@@ -278,40 +324,35 @@ agent:
               name: k8s.namespace.name
         - sources:
             - from: connection
+      # memory_limiter:
+      #   check_interval: 1s
+      #   limit_percentage: 75
+      # spike_limit_percentage: 15
     batch:
       send_batch_size: 10000
       timeout: 10s
   extensions:
     zpages: {}
+    # memory_ballast:
+    #   # Memory Ballast size should be max 1/3 to 1/2 of memory. It's a large buffer that is pre-allocated in the memory to help stabilize and reduce the garbage collection (GC) pressure on the Go runtime.
+    #   size_mib: 512
   connectors: {}
   service:
-    extensions:
-      - zpages
+    extensions: [zpages]
     pipelines:
       logs:
-        receivers:
-          - filelog/std
-        processors:
-          - batch
-          - k8sattributes
-        exporters:
-          - otlphttp/openobserve
+        receivers: [filelog/std]
+        processors: [batch, k8sattributes]
+        exporters: [otlphttp/openobserve]
       metrics:
-        receivers:
-          - kubeletstats
-        processors:
-          - batch
-          - k8sattributes
-        exporters:
-          - otlphttp/openobserve
+        receivers: [kubeletstats]
+        processors: [batch, k8sattributes]
+        exporters: [otlphttp/openobserve]
       traces:
-        receivers:
-          - otlp
-        processors:
-          - batch
-          - k8sattributes
-        exporters:
-          - otlphttp/openobserve
+        receivers: [otlp]
+        processors: [batch, k8sattributes]
+        exporters: [otlphttp/openobserve]
+
 gateway:
   enabled: true
   targetAllocator:
@@ -319,12 +360,24 @@ gateway:
   affinity: {}
   nodeSelector: {}
   tolerations: []
-  resources: {}
+  resources:
+    {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+  #   memory: 128Mi
   autoscaling:
     enabled: false
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
   receivers:
     otlp:
       protocols:
@@ -333,22 +386,16 @@ gateway:
     k8s_cluster:
       collection_interval: 30s
       node_conditions_to_report:
-        - Ready
-        - MemoryPressure
-        - DiskPressure
-        - PIDPressure
-      allocatable_types_to_report:
-        - cpu
-        - memory
-        - storage
+        [Ready, MemoryPressure, DiskPressure, PIDPressure]
+      allocatable_types_to_report: [cpu, memory, storage]
       metrics:
-        k8s.container.cpu_limit:
+        k8s.container.cpu_limit: # redundant
           enabled: false
-        k8s.container.cpu_request:
+        k8s.container.cpu_request: # redundant
           enabled: false
-        k8s.container.memory_limit:
+        k8s.container.memory_limit: # redundant
           enabled: false
-        k8s.container.memory_request:
+        k8s.container.memory_request: # redundant
           enabled: false
     k8s_events:
       auth_type: serviceAccount
@@ -357,19 +404,49 @@ gateway:
       objects:
         - name: pods
           mode: pull
+          # label_selector: environment in (production),tier in (frontend)
           field_selector: status.phase=Running
           interval: 15m
         - name: events
           mode: watch
           group: events.k8s.io
+          # namespaces: []
     prometheus:
       config:
         scrape_configs:
-          - job_name: otel-collector
+          # - job_name: "kubeApiServer"
+          #   sample_limit: 10000
+          #   # Default to scraping over https. If required, just disable this or change to `http`.
+          #   scheme: http
+          #   scrape_interval: 15s
+          #   scrape_timeout: 10s
+          #   metrics_path: /metrics
+
+          #   kubernetes_sd_configs:
+          #     - role: endpoints
+          #       follow_redirects: true
+          #   tls_config:
+          #     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          #     insecure_skip_verify: true
+          #   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+          #   metric_relabel_configs:
+          #     - action: keep
+          #       regex: default;kubernetes;https
+          #       source_labels:
+          #       - __meta_kubernetes_namespace
+          #       - __meta_kubernetes_service_name
+          #       - __meta_kubernetes_endpoint_port_name
+          #     # Drop excessively noisy apiserver buckets.
+          #     - action: drop
+          #       regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
+          #       source_labels:
+          #         - __name__
+          #         - le
+          - job_name: "otel-collector"
             scrape_interval: 5s
             static_configs:
-              - targets:
-                  - '0.0.0.0:8888'
+              - targets: ["0.0.0.0:8888"]
           - job_name: cadvisor
             scheme: https
             sample_limit: 10000
@@ -380,83 +457,92 @@ gateway:
               ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
               insecure_skip_verify: true
             authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              credentials_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
               type: Bearer
             kubernetes_sd_configs:
               - role: node
+            # static_configs:
+            #   - targets:
+            #       - ${K8S_NODE_NAME}:10250
             metric_relabel_configs:
               - action: labeldrop
-                regex: name
+                regex: name # dropping id results in error - inconsistent timestamps on metric points for metric container_fs_reads_total, container_fs_writes_bytes_total, etc
+              # Drop less useful container CPU metrics.
               - action: drop
-                regex: >-
-                  container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)
-                replacement: $1
-                separator: ;
+                regex: container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)
+                replacement: "$1"
+                separator: ";"
                 source_labels:
                   - __name__
+              # Drop less useful container / always zero filesystem metrics.
               - action: drop
-                regex: >-
-                  container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
-                separator: ;
+                regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+                separator: ";"
                 source_labels:
                   - __name__
+              # Drop less useful / always zero container memory metrics.
               - action: drop
                 regex: container_memory_(mapped_file|swap)
-                replacement: $1
-                separator: ;
+                replacement: "$1"
+                separator: ";"
                 source_labels:
                   - __name__
+              # Drop less useful container process metrics.
               - action: drop
                 regex: container_(file_descriptors|tasks_state|threads_max)
-                replacement: $1
-                separator: ;
+                replacement: "$1"
+                separator: ";"
                 source_labels:
                   - __name__
+              # Drop container spec metrics that overlap with kube-state-metrics.
               - action: drop
                 regex: container_spec.*
-                replacement: $1
-                separator: ;
+                replacement: "$1"
+                separator: ";"
                 source_labels:
                   - __name__
+              # Drop cgroup metrics with no pod.
               - action: drop
-                regex: .+;
-                replacement: $1
-                separator: ;
+                regex: ".+;"
+                replacement: "$1"
+                separator: ";"
                 source_labels:
                   - id
                   - pod
             relabel_configs:
               - action: replace
-                regex: (.*)
+                regex: "(.*)"
                 replacement: https-metrics
-                separator: ;
+                separator: ";"
                 target_label: endpoint
               - action: replace
-                replacement: kubelet
+                replacement: "kubelet"
                 target_label: job
               - action: replace
-                regex: (.*)
-                replacement: '${1}'
-                separator: ;
+                regex: "(.*)"
+                replacement: "${1}"
+                separator: ";"
                 source_labels:
                   - __meta_kubernetes_node_name
                 target_label: node
               - action: replace
-                regex: (.*)
-                replacement: $1
-                separator: ;
+                regex: "(.*)"
+                replacement: "$1"
+                separator: ";"
                 source_labels:
                   - __metrics_path__
                 target_label: metrics_path
+
   processors:
     resourcedetection:
-      detectors:
-        - env
+      detectors: [env]
       override: true
       timeout: 2s
     k8sattributes:
-      auth_type: serviceAccount
+      auth_type: "serviceAccount"
       passthrough: false
+      # filter:
+      #   node_from_env_var: K8S_NODE_NAME
       extract:
         labels:
           - tag_name: service.name
@@ -515,34 +601,43 @@ gateway:
               name: k8s.namespace.name
         - sources:
             - from: connection
+    # memory_limiter:
+    #   check_interval: 1s
+    #   limit_percentage: 75
+    #   spike_limit_percentage: 15
     batch:
       send_batch_size: 10000
       timeout: 10s
   extensions:
     zpages: {}
+    # memory_ballast:
+    #   # Memory Ballast size should be max 1/3 to 1/2 of memory. It's a large buffer that is pre-allocated in the memory to help stabilize and reduce the garbage collection (GC) pressure on the Go runtime.
+    #   size_mib: 512
   connectors:
     spanmetrics:
       histogram:
         explicit:
           buckets:
-            - 100us
-            - 1ms
-            - 2ms
-            - 6ms
-            - 10ms
-            - 100ms
-            - 250ms
-            - 500ms
-            - 1000ms
-            - 1400ms
-            - 2000ms
-            - 5s
-            - 10s
-            - 30s
-            - 60s
-            - 120s
-            - 300s
-            - 600s
+            [
+              100us,
+              1ms,
+              2ms,
+              6ms,
+              10ms,
+              100ms,
+              250ms,
+              500ms,
+              1000ms,
+              1400ms,
+              2000ms,
+              5s,
+              10s,
+              30s,
+              60s,
+              120s,
+              300s,
+              600s,
+            ]
       dimensions:
         - name: http.method
           default: GET
@@ -550,56 +645,30 @@ gateway:
       exemplars:
         enabled: true
       dimensions_cache_size: 1000
-      aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+      aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"
       metrics_flush_interval: 15s
     servicegraph:
-      latency_histogram_buckets:
-        - 1
-        - 2
-        - 3
-        - 4
-        - 5
+      latency_histogram_buckets: [1, 2, 3, 4, 5]
       dimensions:
         - http.method
       store:
         ttl: 1s
         max_items: 10
   service:
-    extensions:
-      - zpages
+    extensions: [zpages]
     pipelines:
       logs/k8s_events:
-        receivers:
-          - k8s_events
-        processors:
-          - batch
-          - k8sattributes
-          - resourcedetection
-        exporters:
-          - otlphttp/openobserve_k8s_events
+        receivers: [k8s_events]
+        processors: [batch, k8sattributes, resourcedetection]
+        exporters: [otlphttp/openobserve_k8s_events]
       metrics:
-        receivers:
-          - k8s_cluster
-          - prometheus
-          - spanmetrics
-          - servicegraph
-        processors:
-          - batch
-          - k8sattributes
-          - resourcedetection
-        exporters:
-          - otlphttp/openobserve
+        receivers: [k8s_cluster, prometheus, spanmetrics, servicegraph]
+        processors: [batch, k8sattributes, resourcedetection]
+        exporters: [otlphttp/openobserve]
       traces:
-        receivers:
-          - otlp
-        processors:
-          - batch
-          - k8sattributes
-          - resourcedetection
-        exporters:
-          - otlphttp/openobserve
-          - spanmetrics
-          - servicegraph
+        receivers: [otlp]
+        processors: [batch, k8sattributes, resourcedetection]
+        exporters: [otlphttp/openobserve, spanmetrics, servicegraph]
 
 # refs: https://github.com/prometheus-community/helm-charts/blob/5bd2f828f67aea8861f31433edb9c5c503fe5fcc/charts/kube-prometheus-stack/values.yaml
 #kube-prometheus-stack:

--- a/infra/helm/scc-monitoring/values.yaml
+++ b/infra/helm/scc-monitoring/values.yaml
@@ -1,48 +1,651 @@
-# refs: https://github.com/prometheus-community/helm-charts/blob/5bd2f828f67aea8861f31433edb9c5c503fe5fcc/charts/kube-prometheus-stack/values.yaml
-kube-prometheus-stack:
-  alertmanager:
+deploySecret:
+  awsRoleArn: arn:aws:iam::291889421067:role/scc-deploy-secret
+
+filesDir: files
+
+cert-manager:
+  installCRDs: true
+  prometheus:
+    enabled: false
+
+# Default values for openobserve-collector.
+exporters:
+  # TODO: 여기에 secret 어떻게 넣을지 고민
+  otlphttp/openobserve:
+    endpoint: 'https://api.openobserve.ai/api/default/'
+    headers:
+      Authorization: Basic < base64 encoded auth >
+  otlphttp/openobserve_k8s_events:
+    endpoint: 'https://api.openobserve.ai/api/default/'
+    headers:
+      Authorization: Basic < base64 encoded auth >
+      stream-name: k8s_events
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  pullPolicy: IfNotPresent
+  tag: 0.96.0
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ''
+labels: {}
+
+opentelemetry-operator:
+  enabled: false
+  admissionWebhooks:
+    certManager:
+      enabled: false
+      autoGenerateCert: true
+  manager:
+    featureGates: '--operator.autoinstrumentation.go=true'
+autoinstrumentation:
+  enabled: true
+  collectorTarget: traces
+  propagators:
+    - tracecontext
+    - baggage
+podAndServiceMonitor:
+  create: true
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+agent:
+  enabled: true
+  tolerations:
+    - key: exampleKey1
+      operator: Equal
+      value: 'true'
+      effect: NoSchedule
+  resources: {}
+  receivers:
+    otlp:
+      protocols:
+        grpc: {}
+        http: {}
+    prometheus:
+      config:
+        scrape_configs:
+          - job_name: otel-collector
+            scrape_interval: 5s
+            static_configs:
+              - targets:
+                  - '0.0.0.0:8888'
+    filelog/std:
+      include:
+        - /var/log/pods/*/*/*.log
+      exclude:
+        - /var/log/pods/*/otel-collector/*.log
+        - /var/log/pods/*/otc-container/*.log
+        - /var/log/pods/*/openobserve/*.log
+      start_at: end
+      include_file_path: true
+      include_file_name: false
+      operators:
+        - type: router
+          id: get-format
+          routes:
+            - output: parser-docker
+              expr: 'body matches "^\\{"'
+            - output: parser-crio
+              expr: 'body matches "^[^ Z]+ "'
+            - output: parser-containerd
+              expr: 'body matches "^[^ Z]+Z"'
+        - type: regex_parser
+          id: parser-crio
+          regex: >-
+            ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)
+            ?(?P<log>.*)$
+          output: extract_metadata_from_filepath
+          timestamp:
+            parse_from: attributes.time
+            layout_type: gotime
+            layout: '2006-01-02T15:04:05.999999999Z07:00'
+        - type: regex_parser
+          id: parser-containerd
+          regex: >-
+            ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)
+            ?(?P<log>.*)$
+          output: extract_metadata_from_filepath
+          timestamp:
+            parse_from: attributes.time
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+        - type: json_parser
+          id: parser-docker
+          output: extract_metadata_from_filepath
+          timestamp:
+            parse_from: attributes.time
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+        - type: regex_parser
+          id: extract_metadata_from_filepath
+          regex: >-
+            ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          parse_from: 'attributes["log.file.path"]'
+          cache:
+            size: 128
+        - type: move
+          from: attributes.log
+          to: body
+        - type: move
+          from: attributes.stream
+          to: 'attributes["log.iostream"]'
+        - type: move
+          from: attributes.container_name
+          to: 'resource["k8s.container.name"]'
+        - type: move
+          from: attributes.namespace
+          to: 'resource["k8s.namespace.name"]'
+        - type: move
+          from: attributes.pod_name
+          to: 'resource["k8s.pod.name"]'
+        - type: move
+          from: attributes.restart_count
+          to: 'resource["k8s.container.restart_count"]'
+        - type: move
+          from: attributes.uid
+          to: 'resource["k8s.pod.uid"]'
+    hostmetrics:
+      root_path: /hostfs
+      collection_interval: 15s
+      scrapers:
+        cpu: {}
+        disk: {}
+        filesystem:
+          exclude_mount_points:
+            match_type: regexp
+            mount_points:
+              - /dev/.*
+              - /proc/.*
+              - /sys/.*
+              - /run/k3s/containerd/.*
+              - /var/lib/docker/.*
+              - /var/lib/kubelet/.*
+              - /snap/.*
+          exclude_fs_types:
+            match_type: strict
+            fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+        load: {}
+        network: {}
+        process: {}
+    kubeletstats:
+      collection_interval: 15s
+      auth_type: serviceAccount
+      endpoint: 'https://${env:K8S_NODE_NAME}:10250'
+      insecure_skip_verify: true
+      extra_metadata_labels:
+        - container.id
+        - k8s.volume.type
+      metric_groups:
+        - node
+        - pod
+        - container
+        - volume
+      metrics:
+        k8s.pod.cpu_limit_utilization:
+          enabled: true
+        k8s.pod.cpu_request_utilization:
+          enabled: true
+        k8s.pod.memory_limit_utilization:
+          enabled: true
+        k8s.pod.memory_request_utilization:
+          enabled: true
+  processors:
+    resourcedetection:
+      detectors:
+        - system
+        - env
+        - k8snode
+      override: true
+      system:
+        hostname_sources:
+          - os
+          - dns
+    k8sattributes:
+      auth_type: serviceAccount
+      passthrough: false
+      filter:
+        node_from_env_var: K8S_NODE_NAME
+      extract:
+        labels:
+          - tag_name: service.name
+            key: app.kubernetes.io/name
+            from: pod
+          - tag_name: service.name
+            key: k8s-app
+            from: pod
+          - tag_name: k8s.app.instance
+            key: app.kubernetes.io/instance
+            from: pod
+          - tag_name: service.version
+            key: app.kubernetes.io/version
+            from: pod
+          - tag_name: k8s.app.component
+            key: app.kubernetes.io/component
+            from: pod
+        metadata:
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.deployment.name
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.start_time
+      pod_association:
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+            - from: resource_attribute
+              name: k8s.node.name
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+        - sources:
+            - from: connection
+    batch:
+      send_batch_size: 10000
+      timeout: 10s
+  extensions:
+    zpages: {}
+  connectors: {}
+  service:
+    extensions:
+      - zpages
+    pipelines:
+      logs:
+        receivers:
+          - filelog/std
+        processors:
+          - batch
+          - k8sattributes
+        exporters:
+          - otlphttp/openobserve
+      metrics:
+        receivers:
+          - kubeletstats
+        processors:
+          - batch
+          - k8sattributes
+        exporters:
+          - otlphttp/openobserve
+      traces:
+        receivers:
+          - otlp
+        processors:
+          - batch
+          - k8sattributes
+        exporters:
+          - otlphttp/openobserve
+gateway:
+  enabled: true
+  targetAllocator:
     enabled: true
-    config:
-      global:
-        resolve_timeout: 5m
-      inhibit_rules:
-        - source_matchers:
-            - 'severity = critical'
-          target_matchers:
-            - 'severity =~ warning|info'
-          equal:
-            - 'namespace'
-            - 'alertname'
-        - source_matchers:
-            - 'severity = warning'
-          target_matchers:
-            - 'severity = info'
-          equal:
-            - 'namespace'
-            - 'alertname'
-        - source_matchers:
-            - 'alertname = InfoInhibitor'
-          target_matchers:
-            - 'severity = info'
-          equal:
-            - 'namespace'
-        - target_matchers:
-            - 'alertname = InfoInhibitor'
-      route:
-        group_by: [ 'namespace' ]
-        group_wait: 30s
-        group_interval: 5m
-        repeat_interval: 12h
-        receiver: 'slack-agnica'
-        routes:
-          - receiver: 'slack-agnica'
-            matchers:
-              - alertname = "Watchdog"
-      templates:
-        - '/etc/alertmanager/config/*.tmpl'
-      receivers:
-        - name: 'null'
-        - name: 'slack-agnica'
-          slack_configs:
-            - send_resolved: true
-              api_url: https://hooks.slack.com/services/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
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+  receivers:
+    otlp:
+      protocols:
+        grpc: {}
+        http: {}
+    k8s_cluster:
+      collection_interval: 30s
+      node_conditions_to_report:
+        - Ready
+        - MemoryPressure
+        - DiskPressure
+        - PIDPressure
+      allocatable_types_to_report:
+        - cpu
+        - memory
+        - storage
+      metrics:
+        k8s.container.cpu_limit:
+          enabled: false
+        k8s.container.cpu_request:
+          enabled: false
+        k8s.container.memory_limit:
+          enabled: false
+        k8s.container.memory_request:
+          enabled: false
+    k8s_events:
+      auth_type: serviceAccount
+    k8sobjects:
+      auth_type: serviceAccount
+      objects:
+        - name: pods
+          mode: pull
+          field_selector: status.phase=Running
+          interval: 15m
+        - name: events
+          mode: watch
+          group: events.k8s.io
+    prometheus:
+      config:
+        scrape_configs:
+          - job_name: otel-collector
+            scrape_interval: 5s
+            static_configs:
+              - targets:
+                  - '0.0.0.0:8888'
+          - job_name: cadvisor
+            scheme: https
+            sample_limit: 10000
+            scrape_interval: 15s
+            scrape_timeout: 10s
+            metrics_path: /metrics/cadvisor
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              type: Bearer
+            kubernetes_sd_configs:
+              - role: node
+            metric_relabel_configs:
+              - action: labeldrop
+                regex: name
+              - action: drop
+                regex: >-
+                  container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)
+                replacement: $1
+                separator: ;
+                source_labels:
+                  - __name__
+              - action: drop
+                regex: >-
+                  container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+                separator: ;
+                source_labels:
+                  - __name__
+              - action: drop
+                regex: container_memory_(mapped_file|swap)
+                replacement: $1
+                separator: ;
+                source_labels:
+                  - __name__
+              - action: drop
+                regex: container_(file_descriptors|tasks_state|threads_max)
+                replacement: $1
+                separator: ;
+                source_labels:
+                  - __name__
+              - action: drop
+                regex: container_spec.*
+                replacement: $1
+                separator: ;
+                source_labels:
+                  - __name__
+              - action: drop
+                regex: .+;
+                replacement: $1
+                separator: ;
+                source_labels:
+                  - id
+                  - pod
+            relabel_configs:
+              - action: replace
+                regex: (.*)
+                replacement: https-metrics
+                separator: ;
+                target_label: endpoint
+              - action: replace
+                replacement: kubelet
+                target_label: job
+              - action: replace
+                regex: (.*)
+                replacement: '${1}'
+                separator: ;
+                source_labels:
+                  - __meta_kubernetes_node_name
+                target_label: node
+              - action: replace
+                regex: (.*)
+                replacement: $1
+                separator: ;
+                source_labels:
+                  - __metrics_path__
+                target_label: metrics_path
+  processors:
+    resourcedetection:
+      detectors:
+        - env
+      override: true
+      timeout: 2s
+    k8sattributes:
+      auth_type: serviceAccount
+      passthrough: false
+      extract:
+        labels:
+          - tag_name: service.name
+            key: app.kubernetes.io/name
+            from: pod
+          - tag_name: service.name
+            key: k8s-app
+            from: pod
+          - tag_name: k8s.app.instance
+            key: app.kubernetes.io/instance
+            from: pod
+          - tag_name: service.version
+            key: app.kubernetes.io/version
+            from: pod
+          - tag_name: k8s.app.component
+            key: app.kubernetes.io/component
+            from: pod
+        metadata:
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.node.name
+          - k8s.pod.start_time
+          - k8s.deployment.name
+          - k8s.replicaset.name
+          - k8s.replicaset.uid
+          - k8s.daemonset.name
+          - k8s.daemonset.uid
+          - k8s.job.name
+          - k8s.job.uid
+          - k8s.container.name
+          - k8s.cronjob.name
+          - k8s.statefulset.name
+          - k8s.statefulset.uid
+          - container.image.tag
+          - container.image.name
+          - k8s.cluster.uid
+      pod_association:
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+            - from: resource_attribute
+              name: k8s.node.name
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+        - sources:
+            - from: connection
+    batch:
+      send_batch_size: 10000
+      timeout: 10s
+  extensions:
+    zpages: {}
+  connectors:
+    spanmetrics:
+      histogram:
+        explicit:
+          buckets:
+            - 100us
+            - 1ms
+            - 2ms
+            - 6ms
+            - 10ms
+            - 100ms
+            - 250ms
+            - 500ms
+            - 1000ms
+            - 1400ms
+            - 2000ms
+            - 5s
+            - 10s
+            - 30s
+            - 60s
+            - 120s
+            - 300s
+            - 600s
+      dimensions:
+        - name: http.method
+          default: GET
+        - name: http.status_code
+      exemplars:
+        enabled: true
+      dimensions_cache_size: 1000
+      aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE
+      metrics_flush_interval: 15s
+    servicegraph:
+      latency_histogram_buckets:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+      dimensions:
+        - http.method
+      store:
+        ttl: 1s
+        max_items: 10
+  service:
+    extensions:
+      - zpages
+    pipelines:
+      logs/k8s_events:
+        receivers:
+          - k8s_events
+        processors:
+          - batch
+          - k8sattributes
+          - resourcedetection
+        exporters:
+          - otlphttp/openobserve_k8s_events
+      metrics:
+        receivers:
+          - k8s_cluster
+          - prometheus
+          - spanmetrics
+          - servicegraph
+        processors:
+          - batch
+          - k8sattributes
+          - resourcedetection
+        exporters:
+          - otlphttp/openobserve
+      traces:
+        receivers:
+          - otlp
+        processors:
+          - batch
+          - k8sattributes
+          - resourcedetection
+        exporters:
+          - otlphttp/openobserve
+          - spanmetrics
+          - servicegraph
+
+# refs: https://github.com/prometheus-community/helm-charts/blob/5bd2f828f67aea8861f31433edb9c5c503fe5fcc/charts/kube-prometheus-stack/values.yaml
+#kube-prometheus-stack:
+#  alertmanager:
+#    enabled: true
+#    config:
+#      global:
+#        resolve_timeout: 5m
+#      inhibit_rules:
+#        - source_matchers:
+#            - 'severity = critical'
+#          target_matchers:
+#            - 'severity =~ warning|info'
+#          equal:
+#            - 'namespace'
+#            - 'alertname'
+#        - source_matchers:
+#            - 'severity = warning'
+#          target_matchers:
+#            - 'severity = info'
+#          equal:
+#            - 'namespace'
+#            - 'alertname'
+#        - source_matchers:
+#            - 'alertname = InfoInhibitor'
+#          target_matchers:
+#            - 'severity = info'
+#          equal:
+#            - 'namespace'
+#        - target_matchers:
+#            - 'alertname = InfoInhibitor'
+#      route:
+#        group_by: [ 'namespace' ]
+#        group_wait: 30s
+#        group_interval: 5m
+#        repeat_interval: 12h
+#        receiver: 'slack-agnica'
+#        routes:
+#          - receiver: 'slack-agnica'
+#            matchers:
+#              - alertname = "Watchdog"
+#      templates:
+#        - '/etc/alertmanager/config/*.tmpl'
+#      receivers:
+#        - name: 'null'
+#        - name: 'slack-agnica'
+#          slack_configs:
+#            - send_resolved: true
+#              api_url: https://hooks.slack.com/services/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

--- a/infra/helm/scc-monitoring/values.yaml
+++ b/infra/helm/scc-monitoring/values.yaml
@@ -3,36 +3,6 @@ deploySecret:
 
 filesDir: files
 
-cert-manager:
-  installCRDs: true
-  prometheus:
-    enabled: false
-
-# Default values for openobserve-collector.
-exporters:
-  # TODO: 여기에 secret 어떻게 넣을지 고민
-  otlphttp/openobserve:
-    endpoint: https://api.openobserve.ai/api/default/
-    headers:
-      Authorization: Basic < base64 encoded auth >
-  otlphttp/openobserve_k8s_events:
-    endpoint: https://api.openobserve.ai/api/default/
-    headers:
-      Authorization: Basic < base64 encoded auth >
-      stream-name: k8s_events
-
-replicaCount: 1
-
-image:
-  repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.96.0"
-
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -42,679 +12,672 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-labels: {}
-
-# If Opentelemetry operator should be installed with the chart. If you already have the operator installed, set enabled to false. Refer https://opentelemetry.io/docs/kubernetes/operator/ and https://opentelemetry.io/docs/kubernetes/helm/operator/
 opentelemetry-operator:
-  enabled: false
   admissionWebhooks:
     certManager:
-      enabled: false
-      autoGenerateCert: true
-  manager:
-    # auto-instrumentation can be enabled for go which is disabled by default. go auto-instrumentation uses eBPF and requires privileged mode.
-    featureGates: "--operator.autoinstrumentation.go=true"
+      enabled: true
+      autoGenerateCert: false
 
-## Auto-Instrumentation resource to be installed in the cluster
-## Can be used by setting the following to the pod/namespace annotations:
-##  Java: instrumentation.opentelemetry.io/inject-java: "true"
-##  NodeJS: instrumentation.opentelemetry.io/inject-nodejs: "true"
-##  Python: instrumentation.opentelemetry.io/inject-python: "true"
-##  DotNet: instrumentation.opentelemetry.io/inject-dotnet: "true"
-##  Go: instrumentation.opentelemetry.io/inject-go: "true" , instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/path/to/container/executable"
-##  OpenTelemetry SDK environment variables only: instrumentation.opentelemetry.io/inject-sdk: "true"
-autoinstrumentation:
+openobserve-collector:
   enabled: true
-  ## The collector name to send traces to
-  collectorTarget: traces
-  propagators:
-    - tracecontext
-    - baggage
+  # Default values for openobserve-collector.
+  exporters:
+    # TODO: 여기에 secret 어떻게 넣을지 고민
+    otlphttp/openobserve:
+      endpoint: https://api.openobserve.ai/api/default/
+      headers:
+        Authorization: Basic < base64 encoded auth >
+    otlphttp/openobserve_k8s_events:
+      endpoint: https://api.openobserve.ai/api/default/
+      headers:
+        Authorization: Basic < base64 encoded auth >
+        stream-name: k8s_events
 
-podAndServiceMonitor:
-  # Specifies whether PodMonitor and ServiceMonitor CRs should be created
-  create: true
+  replicaCount: 1
 
-podAnnotations: {}
+  image:
+    repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "0.96.0"
 
-podSecurityContext:
-  {}
-# fsGroup: 2000
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
 
-securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-# runAsUser: 1000
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
 
-agent:
-  enabled: true
-  tolerations:
-    - key: "exampleKey1"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
-  resources:
+  labels: {}
+
+  # If Opentelemetry operator should be installed with the chart. If you already have the operator installed, set enabled to false. Refer https://opentelemetry.io/docs/kubernetes/operator/ and https://opentelemetry.io/docs/kubernetes/helm/operator/
+  opentelemetry-operator:
+    enabled: false
+    admissionWebhooks:
+      certManager:
+        enabled: false
+        autoGenerateCert: true
+    # manager:
+      # auto-instrumentation can be enabled for go which is disabled by default. go auto-instrumentation uses eBPF and requires privileged mode.
+      # featureGates: "--operator.autoinstrumentation.go=true"
+
+  ## Auto-Instrumentation resource to be installed in the cluster
+  ## Can be used by setting the following to the pod/namespace annotations:
+  ##  Java: instrumentation.opentelemetry.io/inject-java: "true"
+  ##  NodeJS: instrumentation.opentelemetry.io/inject-nodejs: "true"
+  ##  Python: instrumentation.opentelemetry.io/inject-python: "true"
+  ##  DotNet: instrumentation.opentelemetry.io/inject-dotnet: "true"
+  ##  Go: instrumentation.opentelemetry.io/inject-go: "true" , instrumentation.opentelemetry.io/otel-go-auto-target-exe: "/path/to/container/executable"
+  ##  OpenTelemetry SDK environment variables only: instrumentation.opentelemetry.io/inject-sdk: "true"
+  autoinstrumentation:
+    enabled: true
+    ## The collector name to send traces to
+    collectorTarget: traces
+    propagators:
+      - tracecontext
+      - baggage
+
+  podAndServiceMonitor:
+    # Specifies whether PodMonitor and ServiceMonitor CRs should be created
+    create: true
+
+  podAnnotations: {}
+
+  podSecurityContext:
     {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-  #   memory: 128Mi
-  receivers:
-    otlp:
-      protocols:
-        grpc: {}
-        http: {}
-    prometheus:
-      config:
-        scrape_configs:
-          - job_name: "otel-collector"
-            scrape_interval: 5s
-            static_configs:
-              - targets: ["0.0.0.0:8888"]
+  # fsGroup: 2000
 
-    filelog/std:
-      include: [/var/log/pods/*/*/*.log]
-      exclude:
-        # Exclude logs from all containers named otel-collector or otc-container (otel-contrib)
-        - /var/log/pods/*/otel-collector/*.log # named otel-collector
-        - /var/log/pods/*/otc-container/*.log # named otc-container (for otel-contrib containers)
-        - /var/log/pods/*/openobserve/*.log # named openobserve. Would want to avoid cyclical logs
-      start_at: end
-      include_file_path: true
-      include_file_name: false
-      operators:
-        # Find out which format is used by kubernetes
-        - type: router
-          id: get-format
-          routes:
-            - output: parser-docker
-              expr: 'body matches "^\\{"'
-            - output: parser-crio
-              expr: 'body matches "^[^ Z]+ "'
-            - output: parser-containerd
-              expr: 'body matches "^[^ Z]+Z"'
-        # Parse CRI-O format
-        - type: regex_parser
-          id: parser-crio
-          regex: "^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
-          output: extract_metadata_from_filepath
-          timestamp:
-            parse_from: attributes.time
-            layout_type: gotime
-            layout: "2006-01-02T15:04:05.999999999Z07:00"
-        # Parse CRI-Containerd format
-        - type: regex_parser
-          id: parser-containerd
-          regex: "^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
-          output: extract_metadata_from_filepath
-          timestamp:
-            parse_from: attributes.time
-            layout: "%Y-%m-%dT%H:%M:%S.%LZ"
-        # Parse Docker format
-        - type: json_parser
-          id: parser-docker
-          output: extract_metadata_from_filepath
-          timestamp:
-            parse_from: attributes.time
-            layout: "%Y-%m-%dT%H:%M:%S.%LZ"
-        # Extract metadata from file path
-        - type: regex_parser
-          id: extract_metadata_from_filepath
-          regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
-          parse_from: attributes["log.file.path"]
-          cache:
-            size: 128 # default maximum amount of Pods per Node is 110
-        # Update body field after finishing all parsing
-        - type: move
-          from: attributes.log
-          to: body
-        # Rename attributes
-        - type: move
-          from: attributes.stream
-          to: attributes["log.iostream"]
-        - type: move
-          from: attributes.container_name
-          to: resource["k8s.container.name"]
-        - type: move
-          from: attributes.namespace
-          to: resource["k8s.namespace.name"]
-        - type: move
-          from: attributes.pod_name
-          to: resource["k8s.pod.name"]
-        - type: move
-          from: attributes.restart_count
-          to: resource["k8s.container.restart_count"]
-        - type: move
-          from: attributes.uid
-          to: resource["k8s.pod.uid"]
-    hostmetrics:
-      root_path: /hostfs
-      collection_interval: 15s
-      scrapers:
-        cpu: {}
-        disk: {}
-        filesystem:
-          exclude_mount_points:
-            match_type: regexp
-            mount_points:
-              - /dev/.*
-              - /proc/.*
-              - /sys/.*
-              - /run/k3s/containerd/.*
-              - /var/lib/docker/.*
-              - /var/lib/kubelet/.*
-              - /snap/.*
-          exclude_fs_types:
-            match_type: strict
-            fs_types:
-              - autofs
-              - binfmt_misc
-              - bpf
-              - cgroup2
-              - configfs
-              - debugfs
-              - devpts
-              - devtmpfs
-              - fusectl
-              - hugetlbfs
-              - iso9660
-              - mqueue
-              - nsfs
-              - overlay
-              - proc
-              - procfs
-              - pstore
-              - rpc_pipefs
-              - securityfs
-              - selinuxfs
-              - squashfs
-              - sysfs
-              - tracefs
-        load: {}
-        #     memory: {}
-        network: {}
-        #     paging: {}
-        #     processes: {}
-        process: {} # a bug in the process scraper causes the collector to throw errors so disabling it for now
-    kubeletstats:
-      collection_interval: 15s
-      auth_type: "serviceAccount"
-      endpoint: "https://${env:K8S_NODE_NAME}:10250"
-      insecure_skip_verify: true
-      extra_metadata_labels:
-        - container.id
-        - k8s.volume.type
-      metric_groups:
-        - node
-        - pod
-        - container
-        - volume
-      metrics:
-        k8s.pod.cpu_limit_utilization:
-          enabled: true
-        k8s.pod.cpu_request_utilization:
-          enabled: true
-        k8s.pod.memory_limit_utilization:
-          enabled: true
-        k8s.pod.memory_request_utilization:
-          enabled: true
-  processors:
-    resourcedetection:
-      detectors: [system, env, k8snode]
-      override: true
-      system:
-        hostname_sources: [os, dns]
-    k8sattributes:
-      auth_type: "serviceAccount"
-      passthrough: false
-      filter:
-        node_from_env_var: K8S_NODE_NAME
-      extract:
-        labels:
-          - tag_name: service.name
-            key: app.kubernetes.io/name
-            from: pod
-          - tag_name: service.name
-            key: k8s-app
-            from: pod
-          - tag_name: k8s.app.instance
-            key: app.kubernetes.io/instance
-            from: pod
-          - tag_name: service.version
-            key: app.kubernetes.io/version
-            from: pod
-          - tag_name: k8s.app.component
-            key: app.kubernetes.io/component
-            from: pod
-        metadata:
-          - k8s.pod.name
-          - k8s.pod.uid
-          - k8s.deployment.name
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.start_time
-      pod_association:
-        - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-        - sources:
-            - from: resource_attribute
-              name: k8s.pod.name
-            - from: resource_attribute
-              name: k8s.namespace.name
-            - from: resource_attribute
-              name: k8s.node.name
-        - sources:
-            - from: resource_attribute
-              name: k8s.pod.ip
-        - sources:
-            - from: resource_attribute
-              name: k8s.pod.name
-            - from: resource_attribute
-              name: k8s.namespace.name
-        - sources:
-            - from: connection
+  securityContext:
+    {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+  # runAsUser: 1000
+
+  agent:
+    enabled: true
+    tolerations:
+      - key: "exampleKey1"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+    resources:
+      {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 100m
+    #   memory: 128Mi
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "otel-collector"
+              scrape_interval: 5s
+              static_configs:
+                - targets: ["0.0.0.0:8888"]
+
+      filelog/std:
+        include: [/var/log/pods/*/*/*.log]
+        exclude:
+          # Exclude logs from all containers named otel-collector or otc-container (otel-contrib)
+          - /var/log/pods/*/otel-collector/*.log # named otel-collector
+          - /var/log/pods/*/otc-container/*.log # named otc-container (for otel-contrib containers)
+          - /var/log/pods/*/openobserve/*.log # named openobserve. Would want to avoid cyclical logs
+        start_at: end
+        include_file_path: true
+        include_file_name: false
+        operators:
+          # Find out which format is used by kubernetes
+          - type: router
+            id: get-format
+            routes:
+              - output: parser-docker
+                expr: 'body matches "^\\{"'
+              - output: parser-crio
+                expr: 'body matches "^[^ Z]+ "'
+              - output: parser-containerd
+                expr: 'body matches "^[^ Z]+Z"'
+          # Parse CRI-O format
+          - type: regex_parser
+            id: parser-crio
+            regex: "^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout_type: gotime
+              layout: "2006-01-02T15:04:05.999999999Z07:00"
+          # Parse CRI-Containerd format
+          - type: regex_parser
+            id: parser-containerd
+            regex: "^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$"
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          # Parse Docker format
+          - type: json_parser
+            id: parser-docker
+            output: extract_metadata_from_filepath
+            timestamp:
+              parse_from: attributes.time
+              layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+          # Extract metadata from file path
+          - type: regex_parser
+            id: extract_metadata_from_filepath
+            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+            parse_from: attributes["log.file.path"]
+            cache:
+              size: 128 # default maximum amount of Pods per Node is 110
+          # Update body field after finishing all parsing
+          - type: move
+            from: attributes.log
+            to: body
+          # Rename attributes
+          - type: move
+            from: attributes.stream
+            to: attributes["log.iostream"]
+          - type: move
+            from: attributes.container_name
+            to: resource["k8s.container.name"]
+          - type: move
+            from: attributes.namespace
+            to: resource["k8s.namespace.name"]
+          - type: move
+            from: attributes.pod_name
+            to: resource["k8s.pod.name"]
+          - type: move
+            from: attributes.restart_count
+            to: resource["k8s.container.restart_count"]
+          - type: move
+            from: attributes.uid
+            to: resource["k8s.pod.uid"]
+      hostmetrics:
+        root_path: /hostfs
+        collection_interval: 15s
+        scrapers:
+          cpu: {}
+          disk: {}
+          filesystem:
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+                - /dev/.*
+                - /proc/.*
+                - /sys/.*
+                - /run/k3s/containerd/.*
+                - /var/lib/docker/.*
+                - /var/lib/kubelet/.*
+                - /snap/.*
+            exclude_fs_types:
+              match_type: strict
+              fs_types:
+                - autofs
+                - binfmt_misc
+                - bpf
+                - cgroup2
+                - configfs
+                - debugfs
+                - devpts
+                - devtmpfs
+                - fusectl
+                - hugetlbfs
+                - iso9660
+                - mqueue
+                - nsfs
+                - overlay
+                - proc
+                - procfs
+                - pstore
+                - rpc_pipefs
+                - securityfs
+                - selinuxfs
+                - squashfs
+                - sysfs
+                - tracefs
+          load: {}
+          #     memory: {}
+          network: {}
+          #     paging: {}
+          #     processes: {}
+          process: {} # a bug in the process scraper causes the collector to throw errors so disabling it for now
+      kubeletstats:
+        collection_interval: 15s
+        auth_type: "serviceAccount"
+        endpoint: "https://${env:K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
+        extra_metadata_labels:
+          - container.id
+          - k8s.volume.type
+        metric_groups:
+          - node
+          - pod
+          - container
+          - volume
+        metrics:
+          k8s.pod.cpu_limit_utilization:
+            enabled: true
+          k8s.pod.cpu_request_utilization:
+            enabled: true
+          k8s.pod.memory_limit_utilization:
+            enabled: true
+          k8s.pod.memory_request_utilization:
+            enabled: true
+    processors:
+      resourcedetection:
+        detectors: [system, env, k8snode]
+        override: true
+        system:
+          hostname_sources: [os, dns]
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        extract:
+          labels:
+            - tag_name: service.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: service.name
+              key: k8s-app
+              from: pod
+            - tag_name: k8s.app.instance
+              key: app.kubernetes.io/instance
+              from: pod
+            - tag_name: service.version
+              key: app.kubernetes.io/version
+              from: pod
+            - tag_name: k8s.app.component
+              key: app.kubernetes.io/component
+              from: pod
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+              - from: resource_attribute
+                name: k8s.node.name
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+          - sources:
+              - from: connection
+        # memory_limiter:
+        #   check_interval: 1s
+        #   limit_percentage: 75
+        # spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    extensions:
+      zpages: {}
+      # memory_ballast:
+      #   # Memory Ballast size should be max 1/3 to 1/2 of memory. It's a large buffer that is pre-allocated in the memory to help stabilize and reduce the garbage collection (GC) pressure on the Go runtime.
+      #   size_mib: 512
+    connectors: {}
+    service:
+      extensions: [zpages]
+      pipelines:
+        logs:
+          receivers: [filelog/std]
+          processors: [batch, k8sattributes]
+          exporters: [otlphttp/openobserve]
+        metrics:
+          receivers: [kubeletstats]
+          processors: [batch, k8sattributes]
+          exporters: [otlphttp/openobserve]
+        traces:
+          receivers: [otlp]
+          processors: [batch, k8sattributes]
+          exporters: [otlphttp/openobserve]
+
+  gateway:
+    enabled: true
+    targetAllocator:
+      enabled: true
+    affinity: {}
+    nodeSelector: {}
+    tolerations: []
+    resources:
+      {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 100m
+    #   memory: 128Mi
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 100
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+      k8s_cluster:
+        collection_interval: 30s
+        node_conditions_to_report:
+          [Ready, MemoryPressure, DiskPressure, PIDPressure]
+        allocatable_types_to_report: [cpu, memory, storage]
+        metrics:
+          k8s.container.cpu_limit: # redundant
+            enabled: false
+          k8s.container.cpu_request: # redundant
+            enabled: false
+          k8s.container.memory_limit: # redundant
+            enabled: false
+          k8s.container.memory_request: # redundant
+            enabled: false
+      k8s_events:
+        auth_type: serviceAccount
+      k8sobjects:
+        auth_type: serviceAccount
+        objects:
+          - name: pods
+            mode: pull
+            # label_selector: environment in (production),tier in (frontend)
+            field_selector: status.phase=Running
+            interval: 15m
+          - name: events
+            mode: watch
+            group: events.k8s.io
+            # namespaces: []
+      prometheus:
+        config:
+          scrape_configs:
+            # - job_name: "kubeApiServer"
+            #   sample_limit: 10000
+            #   # Default to scraping over https. If required, just disable this or change to `http`.
+            #   scheme: http
+            #   scrape_interval: 15s
+            #   scrape_timeout: 10s
+            #   metrics_path: /metrics
+
+            #   kubernetes_sd_configs:
+            #     - role: endpoints
+            #       follow_redirects: true
+            #   tls_config:
+            #     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            #     insecure_skip_verify: true
+            #   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+            #   metric_relabel_configs:
+            #     - action: keep
+            #       regex: default;kubernetes;https
+            #       source_labels:
+            #       - __meta_kubernetes_namespace
+            #       - __meta_kubernetes_service_name
+            #       - __meta_kubernetes_endpoint_port_name
+            #     # Drop excessively noisy apiserver buckets.
+            #     - action: drop
+            #       regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
+            #       source_labels:
+            #         - __name__
+            #         - le
+            - job_name: "otel-collector"
+              scrape_interval: 5s
+              static_configs:
+                - targets: ["0.0.0.0:8888"]
+            - job_name: cadvisor
+              scheme: https
+              sample_limit: 10000
+              scrape_interval: 15s
+              scrape_timeout: 10s
+              metrics_path: /metrics/cadvisor
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+              authorization:
+                credentials_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+                type: Bearer
+              kubernetes_sd_configs:
+                - role: node
+              # static_configs:
+              #   - targets:
+              #       - ${K8S_NODE_NAME}:10250
+              metric_relabel_configs:
+                - action: labeldrop
+                  regex: name # dropping id results in error - inconsistent timestamps on metric points for metric container_fs_reads_total, container_fs_writes_bytes_total, etc
+                # Drop less useful container CPU metrics.
+                - action: drop
+                  regex: container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)
+                  replacement: "$1"
+                  separator: ";"
+                  source_labels:
+                    - __name__
+                # Drop less useful container / always zero filesystem metrics.
+                - action: drop
+                  regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+                  separator: ";"
+                  source_labels:
+                    - __name__
+                # Drop less useful / always zero container memory metrics.
+                - action: drop
+                  regex: container_memory_(mapped_file|swap)
+                  replacement: "$1"
+                  separator: ";"
+                  source_labels:
+                    - __name__
+                # Drop less useful container process metrics.
+                - action: drop
+                  regex: container_(file_descriptors|tasks_state|threads_max)
+                  replacement: "$1"
+                  separator: ";"
+                  source_labels:
+                    - __name__
+                # Drop container spec metrics that overlap with kube-state-metrics.
+                - action: drop
+                  regex: container_spec.*
+                  replacement: "$1"
+                  separator: ";"
+                  source_labels:
+                    - __name__
+                # Drop cgroup metrics with no pod.
+                - action: drop
+                  regex: ".+;"
+                  replacement: "$1"
+                  separator: ";"
+                  source_labels:
+                    - id
+                    - pod
+              relabel_configs:
+                - action: replace
+                  regex: "(.*)"
+                  replacement: https-metrics
+                  separator: ";"
+                  target_label: endpoint
+                - action: replace
+                  replacement: "kubelet"
+                  target_label: job
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "${1}"
+                  separator: ";"
+                  source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: node
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$1"
+                  separator: ";"
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+
+    processors:
+      resourcedetection:
+        detectors: [env]
+        override: true
+        timeout: 2s
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+        # filter:
+        #   node_from_env_var: K8S_NODE_NAME
+        extract:
+          labels:
+            - tag_name: service.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: service.name
+              key: k8s-app
+              from: pod
+            - tag_name: k8s.app.instance
+              key: app.kubernetes.io/instance
+              from: pod
+            - tag_name: service.version
+              key: app.kubernetes.io/version
+              from: pod
+            - tag_name: k8s.app.component
+              key: app.kubernetes.io/component
+              from: pod
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.node.name
+            - k8s.pod.start_time
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.replicaset.uid
+            - k8s.daemonset.name
+            - k8s.daemonset.uid
+            - k8s.job.name
+            - k8s.job.uid
+            - k8s.container.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+            - k8s.statefulset.uid
+            - container.image.tag
+            - container.image.name
+            - k8s.cluster.uid
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+              - from: resource_attribute
+                name: k8s.node.name
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+          - sources:
+              - from: connection
       # memory_limiter:
       #   check_interval: 1s
       #   limit_percentage: 75
-      # spike_limit_percentage: 15
-    batch:
-      send_batch_size: 10000
-      timeout: 10s
-  extensions:
-    zpages: {}
-    # memory_ballast:
-    #   # Memory Ballast size should be max 1/3 to 1/2 of memory. It's a large buffer that is pre-allocated in the memory to help stabilize and reduce the garbage collection (GC) pressure on the Go runtime.
-    #   size_mib: 512
-  connectors: {}
-  service:
-    extensions: [zpages]
-    pipelines:
-      logs:
-        receivers: [filelog/std]
-        processors: [batch, k8sattributes]
-        exporters: [otlphttp/openobserve]
-      metrics:
-        receivers: [kubeletstats]
-        processors: [batch, k8sattributes]
-        exporters: [otlphttp/openobserve]
-      traces:
-        receivers: [otlp]
-        processors: [batch, k8sattributes]
-        exporters: [otlphttp/openobserve]
-
-gateway:
-  enabled: true
-  targetAllocator:
-    enabled: true
-  affinity: {}
-  nodeSelector: {}
-  tolerations: []
-  resources:
-    {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-  #   memory: 128Mi
-  autoscaling:
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 100
-    targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
-  receivers:
-    otlp:
-      protocols:
-        grpc: {}
-        http: {}
-    k8s_cluster:
-      collection_interval: 30s
-      node_conditions_to_report:
-        [Ready, MemoryPressure, DiskPressure, PIDPressure]
-      allocatable_types_to_report: [cpu, memory, storage]
-      metrics:
-        k8s.container.cpu_limit: # redundant
-          enabled: false
-        k8s.container.cpu_request: # redundant
-          enabled: false
-        k8s.container.memory_limit: # redundant
-          enabled: false
-        k8s.container.memory_request: # redundant
-          enabled: false
-    k8s_events:
-      auth_type: serviceAccount
-    k8sobjects:
-      auth_type: serviceAccount
-      objects:
-        - name: pods
-          mode: pull
-          # label_selector: environment in (production),tier in (frontend)
-          field_selector: status.phase=Running
-          interval: 15m
-        - name: events
-          mode: watch
-          group: events.k8s.io
-          # namespaces: []
-    prometheus:
-      config:
-        scrape_configs:
-          # - job_name: "kubeApiServer"
-          #   sample_limit: 10000
-          #   # Default to scraping over https. If required, just disable this or change to `http`.
-          #   scheme: http
-          #   scrape_interval: 15s
-          #   scrape_timeout: 10s
-          #   metrics_path: /metrics
-
-          #   kubernetes_sd_configs:
-          #     - role: endpoints
-          #       follow_redirects: true
-          #   tls_config:
-          #     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          #     insecure_skip_verify: true
-          #   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-          #   metric_relabel_configs:
-          #     - action: keep
-          #       regex: default;kubernetes;https
-          #       source_labels:
-          #       - __meta_kubernetes_namespace
-          #       - __meta_kubernetes_service_name
-          #       - __meta_kubernetes_endpoint_port_name
-          #     # Drop excessively noisy apiserver buckets.
-          #     - action: drop
-          #       regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
-          #       source_labels:
-          #         - __name__
-          #         - le
-          - job_name: "otel-collector"
-            scrape_interval: 5s
-            static_configs:
-              - targets: ["0.0.0.0:8888"]
-          - job_name: cadvisor
-            scheme: https
-            sample_limit: 10000
-            scrape_interval: 15s
-            scrape_timeout: 10s
-            metrics_path: /metrics/cadvisor
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-            authorization:
-              credentials_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-              type: Bearer
-            kubernetes_sd_configs:
-              - role: node
-            # static_configs:
-            #   - targets:
-            #       - ${K8S_NODE_NAME}:10250
-            metric_relabel_configs:
-              - action: labeldrop
-                regex: name # dropping id results in error - inconsistent timestamps on metric points for metric container_fs_reads_total, container_fs_writes_bytes_total, etc
-              # Drop less useful container CPU metrics.
-              - action: drop
-                regex: container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)
-                replacement: "$1"
-                separator: ";"
-                source_labels:
-                  - __name__
-              # Drop less useful container / always zero filesystem metrics.
-              - action: drop
-                regex: container_fs_(io_current|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
-                separator: ";"
-                source_labels:
-                  - __name__
-              # Drop less useful / always zero container memory metrics.
-              - action: drop
-                regex: container_memory_(mapped_file|swap)
-                replacement: "$1"
-                separator: ";"
-                source_labels:
-                  - __name__
-              # Drop less useful container process metrics.
-              - action: drop
-                regex: container_(file_descriptors|tasks_state|threads_max)
-                replacement: "$1"
-                separator: ";"
-                source_labels:
-                  - __name__
-              # Drop container spec metrics that overlap with kube-state-metrics.
-              - action: drop
-                regex: container_spec.*
-                replacement: "$1"
-                separator: ";"
-                source_labels:
-                  - __name__
-              # Drop cgroup metrics with no pod.
-              - action: drop
-                regex: ".+;"
-                replacement: "$1"
-                separator: ";"
-                source_labels:
-                  - id
-                  - pod
-            relabel_configs:
-              - action: replace
-                regex: "(.*)"
-                replacement: https-metrics
-                separator: ";"
-                target_label: endpoint
-              - action: replace
-                replacement: "kubelet"
-                target_label: job
-              - action: replace
-                regex: "(.*)"
-                replacement: "${1}"
-                separator: ";"
-                source_labels:
-                  - __meta_kubernetes_node_name
-                target_label: node
-              - action: replace
-                regex: "(.*)"
-                replacement: "$1"
-                separator: ";"
-                source_labels:
-                  - __metrics_path__
-                target_label: metrics_path
-
-  processors:
-    resourcedetection:
-      detectors: [env]
-      override: true
-      timeout: 2s
-    k8sattributes:
-      auth_type: "serviceAccount"
-      passthrough: false
-      # filter:
-      #   node_from_env_var: K8S_NODE_NAME
-      extract:
-        labels:
-          - tag_name: service.name
-            key: app.kubernetes.io/name
-            from: pod
-          - tag_name: service.name
-            key: k8s-app
-            from: pod
-          - tag_name: k8s.app.instance
-            key: app.kubernetes.io/instance
-            from: pod
-          - tag_name: service.version
-            key: app.kubernetes.io/version
-            from: pod
-          - tag_name: k8s.app.component
-            key: app.kubernetes.io/component
-            from: pod
-        metadata:
-          - k8s.namespace.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - k8s.node.name
-          - k8s.pod.start_time
-          - k8s.deployment.name
-          - k8s.replicaset.name
-          - k8s.replicaset.uid
-          - k8s.daemonset.name
-          - k8s.daemonset.uid
-          - k8s.job.name
-          - k8s.job.uid
-          - k8s.container.name
-          - k8s.cronjob.name
-          - k8s.statefulset.name
-          - k8s.statefulset.uid
-          - container.image.tag
-          - container.image.name
-          - k8s.cluster.uid
-      pod_association:
-        - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-        - sources:
-            - from: resource_attribute
-              name: k8s.pod.name
-            - from: resource_attribute
-              name: k8s.namespace.name
-            - from: resource_attribute
-              name: k8s.node.name
-        - sources:
-            - from: resource_attribute
-              name: k8s.pod.ip
-        - sources:
-            - from: resource_attribute
-              name: k8s.pod.name
-            - from: resource_attribute
-              name: k8s.namespace.name
-        - sources:
-            - from: connection
-    # memory_limiter:
-    #   check_interval: 1s
-    #   limit_percentage: 75
-    #   spike_limit_percentage: 15
-    batch:
-      send_batch_size: 10000
-      timeout: 10s
-  extensions:
-    zpages: {}
-    # memory_ballast:
-    #   # Memory Ballast size should be max 1/3 to 1/2 of memory. It's a large buffer that is pre-allocated in the memory to help stabilize and reduce the garbage collection (GC) pressure on the Go runtime.
-    #   size_mib: 512
-  connectors:
-    spanmetrics:
-      histogram:
-        explicit:
-          buckets:
-            [
-              100us,
-              1ms,
-              2ms,
-              6ms,
-              10ms,
-              100ms,
-              250ms,
-              500ms,
-              1000ms,
-              1400ms,
-              2000ms,
-              5s,
-              10s,
-              30s,
-              60s,
-              120s,
-              300s,
-              600s,
-            ]
-      dimensions:
-        - name: http.method
-          default: GET
-        - name: http.status_code
-      exemplars:
-        enabled: true
-      dimensions_cache_size: 1000
-      aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"
-      metrics_flush_interval: 15s
-    servicegraph:
-      latency_histogram_buckets: [1, 2, 3, 4, 5]
-      dimensions:
-        - http.method
-      store:
-        ttl: 1s
-        max_items: 10
-  service:
-    extensions: [zpages]
-    pipelines:
-      logs/k8s_events:
-        receivers: [k8s_events]
-        processors: [batch, k8sattributes, resourcedetection]
-        exporters: [otlphttp/openobserve_k8s_events]
-      metrics:
-        receivers: [k8s_cluster, prometheus, spanmetrics, servicegraph]
-        processors: [batch, k8sattributes, resourcedetection]
-        exporters: [otlphttp/openobserve]
-      traces:
-        receivers: [otlp]
-        processors: [batch, k8sattributes, resourcedetection]
-        exporters: [otlphttp/openobserve, spanmetrics, servicegraph]
-
-# refs: https://github.com/prometheus-community/helm-charts/blob/5bd2f828f67aea8861f31433edb9c5c503fe5fcc/charts/kube-prometheus-stack/values.yaml
-#kube-prometheus-stack:
-#  alertmanager:
-#    enabled: true
-#    config:
-#      global:
-#        resolve_timeout: 5m
-#      inhibit_rules:
-#        - source_matchers:
-#            - 'severity = critical'
-#          target_matchers:
-#            - 'severity =~ warning|info'
-#          equal:
-#            - 'namespace'
-#            - 'alertname'
-#        - source_matchers:
-#            - 'severity = warning'
-#          target_matchers:
-#            - 'severity = info'
-#          equal:
-#            - 'namespace'
-#            - 'alertname'
-#        - source_matchers:
-#            - 'alertname = InfoInhibitor'
-#          target_matchers:
-#            - 'severity = info'
-#          equal:
-#            - 'namespace'
-#        - target_matchers:
-#            - 'alertname = InfoInhibitor'
-#      route:
-#        group_by: [ 'namespace' ]
-#        group_wait: 30s
-#        group_interval: 5m
-#        repeat_interval: 12h
-#        receiver: 'slack-agnica'
-#        routes:
-#          - receiver: 'slack-agnica'
-#            matchers:
-#              - alertname = "Watchdog"
-#      templates:
-#        - '/etc/alertmanager/config/*.tmpl'
-#      receivers:
-#        - name: 'null'
-#        - name: 'slack-agnica'
-#          slack_configs:
-#            - send_resolved: true
-#              api_url: https://hooks.slack.com/services/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
+      #   spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    extensions:
+      zpages: {}
+      # memory_ballast:
+      #   # Memory Ballast size should be max 1/3 to 1/2 of memory. It's a large buffer that is pre-allocated in the memory to help stabilize and reduce the garbage collection (GC) pressure on the Go runtime.
+      #   size_mib: 512
+    connectors:
+      spanmetrics:
+        histogram:
+          explicit:
+            buckets:
+              [
+                100us,
+                1ms,
+                2ms,
+                6ms,
+                10ms,
+                100ms,
+                250ms,
+                500ms,
+                1000ms,
+                1400ms,
+                2000ms,
+                5s,
+                10s,
+                30s,
+                60s,
+                120s,
+                300s,
+                600s,
+              ]
+        dimensions:
+          - name: http.method
+            default: GET
+          - name: http.status_code
+        exemplars:
+          enabled: true
+        dimensions_cache_size: 1000
+        aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"
+        metrics_flush_interval: 15s
+      servicegraph:
+        latency_histogram_buckets: [1, 2, 3, 4, 5]
+        dimensions:
+          - http.method
+        store:
+          ttl: 1s
+          max_items: 10
+    service:
+      extensions: [zpages]
+      pipelines:
+        logs/k8s_events:
+          receivers: [k8s_events]
+          processors: [batch, k8sattributes, resourcedetection]
+          exporters: [otlphttp/openobserve_k8s_events]
+        metrics:
+          receivers: [k8s_cluster, prometheus, spanmetrics, servicegraph]
+          processors: [batch, k8sattributes, resourcedetection]
+          exporters: [otlphttp/openobserve]
+        traces:
+          receivers: [otlp]
+          processors: [batch, k8sattributes, resourcedetection]
+          exporters: [otlphttp/openobserve, spanmetrics, servicegraph]

--- a/infra/helm/scc-server/values-dev.yaml
+++ b/infra/helm/scc-server/values-dev.yaml
@@ -29,7 +29,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
+podAnnotations:
+  instrumentation.opentelemetry.io/inject-java: "true"
 
 podSecurityContext:
   fsGroup: 2000


### PR DESCRIPTION
## Proposed Changes
- 서버 지표 모니터링 + 로그 확인을 위해 [OpenObserve](https://openobserve.ai/) 도입 시도
- prometheus + grafana + loki 조합보다 설치가 쉬울 것 같았고 현 규모에서는 무료로 이용 가능해서 사용해보려 합니다 (관련 [슬랙 링크](https://agnica-coworkingspace.slack.com/archives/C051C5KTMNF/p1709565060992039))
- openobserve-collector 를 통해 지표를 수집하고 이를 cloud 콘솔에서 확인할 수 있는 구조
- collector 의 dependency 로 opentelemetry-operator 와 cert-manager 가 있어서 함께 설치해줍니다
  - ~cert-manager 는 이미 쿠버 환경에 깔려 있을지도??~
  - cert-manager 는 따로 설치하겠습니다
- 참고 자료)
  - [openobserve-helm-chart](https://github.com/openobserve/openobserve-helm-chart/blob/main/charts/openobserve-collector/README.md)

## Todo
- [x] secret 주입 방법 고민하기
- [x] 모니터링할 팟에 `autoinstrumentation` 어노테이션 달기

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 