### PR TITLE
[모니터링] trace 에 tail sampling 달기

### DIFF
--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -284,6 +284,46 @@ openobserve-collector:
           metric:
             - resource.attributes["k8s.namespace.name"]!=nil and resource.attributes["k8s.namespace.name"]!="scc"
             - resource.attributes["namespace"]!=nil and resource.attributes["namespace"]!="scc"
+      tail_sampling:
+        decision_wait: 10s
+        num_traces: 100
+        expected_new_traces_per_sec: 10
+        policies: [
+          {
+            # Rule 1: low sampling for readiness/liveness probes
+            name: team_a-probe,
+            type: and,
+            and:
+              {
+                and_sub_policy:
+                  [
+                    {
+                      # filter by route
+                      name: route-live-ready-policy,
+                      type: string_attribute,
+                      string_attribute:
+                        {
+                          key: http.route,
+                          values: [ /livez, /readyz, /** ],
+                          enabled_regex_matching: false,
+                        },
+                    },
+                    {
+                      # apply probabilistic sampling
+                      name: probabilistic-policy,
+                      type: probabilistic,
+                      probabilistic: { sampling_percentage: 0.1 },
+                    },
+                  ],
+              },
+          },
+          {
+            # Rule 2: always sample if there is an error
+            name: trace-status-policy,
+            type: status_code,
+            status_code: { status_codes: [ ERROR ] },
+          },
+        ]
       resourcedetection:
         detectors: [system, env, k8snode]
         override: true
@@ -365,7 +405,7 @@ openobserve-collector:
           exporters: [otlphttp/openobserve]
         traces:
           receivers: [otlp]
-          processors: [batch, k8sattributes, filter/keep-scc]
+          processors: [batch, k8sattributes, tail_sampling]
           exporters: [otlphttp/openobserve]
 
   gateway:
@@ -558,6 +598,46 @@ openobserve-collector:
           metric:
             - resource.attributes["k8s.namespace.name"]!="scc"
             - resource.attributes["namespace"]!="scc"
+      tail_sampling:
+        decision_wait: 10s
+        num_traces: 100
+        expected_new_traces_per_sec: 10
+        policies: [
+          {
+            # Rule 1: low sampling for readiness/liveness probes
+            name: team_a-probe,
+            type: and,
+            and:
+              {
+                and_sub_policy:
+                  [
+                    {
+                      # filter by route
+                      name: route-live-ready-policy,
+                      type: string_attribute,
+                      string_attribute:
+                        {
+                          key: http.route,
+                          values: [ /livez, /readyz, /** ],
+                          enabled_regex_matching: false,
+                        },
+                    },
+                    {
+                      # apply probabilistic sampling
+                      name: probabilistic-policy,
+                      type: probabilistic,
+                      probabilistic: { sampling_percentage: 0.1 },
+                    },
+                  ],
+              },
+          },
+          {
+            # Rule 2: always sample if there is an error
+            name: trace-status-policy,
+            type: status_code,
+            status_code: { status_codes: [ ERROR ] },
+          },
+        ]
       resourcedetection:
         detectors: [env]
         override: true
@@ -691,5 +771,5 @@ openobserve-collector:
           exporters: [otlphttp/openobserve]
         traces:
           receivers: [otlp]
-          processors: [batch, k8sattributes, resourcedetection, filter/keep-scc]
+          processors: [batch, k8sattributes, resourcedetection, tail_sampling]
           exporters: [otlphttp/openobserve, spanmetrics, servicegraph]


### PR DESCRIPTION
- trace 잘 나오는 것 확인 했고 (dev/scc-server) 헬스체크 trace 는 0.1 % 샘플링하도록 tail sampling 설정했습니다
- 테섭 server 에서 조금 보다가 실섭에도 trace agent 붙이면 될 것 같습니다
- 실섭에서 다른 api 도 sampling 이 필요하다 싶으면 추가하겠습니다

<img width="1124" alt="image" src="https://github.com/Stair-Crusher-Club/scc-server/assets/43549670/126f482d-13af-4601-92e6-067a2c7a9da0">


## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 