### PR TITLE
이전 버전에서 장소 등록할 때 에러나는 문제 해결

### DIFF
--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
@@ -241,8 +241,8 @@ class AccessibilityApplicationService(
                 id = EntityIdGenerator.generateRandom(),
                 placeId = createPlaceAccessibilityParams.placeId,
                 floors = createPlaceAccessibilityParams.floors,
-                isFirstFloor = createPlaceAccessibilityParams.floors?.let { it.size == 1 && it.firstOrNull() == 1 }
-                    ?: false,
+                isFirstFloor = createPlaceAccessibilityParams.isFirstFloor
+                    ?: createPlaceAccessibilityParams.floors?.let { it.size == 1 && it.first() == 1 } ?: false,
                 isStairOnlyOption = createPlaceAccessibilityParams.isStairOnlyOption,
                 stairInfo = createPlaceAccessibilityParams.stairInfo,
                 stairHeightLevel = createPlaceAccessibilityParams.stairHeightLevel,

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/PlaceAccessibilityRepository.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/PlaceAccessibilityRepository.kt
@@ -22,6 +22,7 @@ interface PlaceAccessibilityRepository : EntityRepository<PlaceAccessibility, St
         val placeId: String,
         val userId: String?,
         val floors: List<Int>?,
+        val isFirstFloor: Boolean?,
         val isStairOnlyOption: Boolean?,
         val stairInfo: StairInfo,
         val stairHeightLevel: StairHeightLevel?,

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/RegisterPlaceAccessibilityTest.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/RegisterPlaceAccessibilityTest.kt
@@ -72,7 +72,7 @@ class RegisterPlaceAccessibilityTest : AccessibilityITBase() {
 
                     val placeAccessibility = accessibilityInfo.placeAccessibility!!
                     assertEquals(place.id, placeAccessibility.placeId)
-                    assertFalse(placeAccessibility.isFirstFloor)
+                    assertEquals(params.isFirstFloor, placeAccessibility.isFirstFloor)
                     assertEquals(StairInfo.ONE, placeAccessibility.stairInfo.toModel())
                     assertTrue(placeAccessibility.hasSlope)
                     assertTrue(placeAccessibility.imageUrls.isEmpty())
@@ -378,7 +378,7 @@ class RegisterPlaceAccessibilityTest : AccessibilityITBase() {
     private fun getDefaultRegisterPlaceAccessibilityRequestParamsBefore240401(place: Place): RegisterPlaceAccessibilityRequestDto {
         return RegisterPlaceAccessibilityRequestDto(
             placeId = place.id,
-            isFirstFloor = false,
+            isFirstFloor = true,
             stairInfo = StairInfo.ONE.toDTO(),
             imageUrls = emptyList(),
             hasSlope = true,

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/Converters.kt
@@ -172,7 +172,8 @@ fun EntranceDoorType.toDTO() = when (this) {
 fun RegisterPlaceAccessibilityRequestDto.toModel(userId: String?) =
     PlaceAccessibilityRepository.CreateParams(
         placeId = placeId,
-        floors = isFirstFloor?.let { if (it) listOf(1) else null } ?: floors,
+        floors = floors,
+        isFirstFloor = isFirstFloor,
         isStairOnlyOption = isStairOnlyOption,
         stairInfo = stairInfo.toModel(),
         stairHeightLevel = stairHeightLevel?.toModel(),


### PR DESCRIPTION
`RegisterPlaceAccessibilityRequestDto` - `PlaceAccessibilityRepository.CreateParams` 로 바꾸는 과정에서 floors 를 자동으로 채워주고 있음
이전 버전 유저들은 `PlaceAccessibilityRepository.CreateParams.isValid` 에서 floors 가 항상 있어서 isValid 를 통과하지 못함
우선 저장할 때 isFirstFloor 를 채워주게 수정