### PR TITLE
[모니터링] OTEL metric export 끄기

### DIFF
--- a/infra/helm/scc-server/files/dev/application.yaml
+++ b/infra/helm/scc-server/files/dev/application.yaml
@@ -48,6 +48,10 @@ sentry:
     enabled: true
   environment: dev
 
+otel:
+  metrics:
+    exporter: none
+
 scc:
   s3:
     imageUpload:


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

- 아래 로그가 서버 팟에서 뜨고 있는데, agent 는 export 하려고 하고 gateway (중간 수집자)에서 받아주고 있지 않기 때문입니다
- [여기](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#otlp-exporter-span-metric-and-log-exporters) 나온대로 export 옵션을 꺼줍니다

```
[otel.javaagent 2024-04-13 08:55:07:726 +0000] [OkHttp http://monitoring-openobserve-collector-gateway-collector.monitoring.svc.cluster.local:4318/...] WARN io.opentelemetry.exporter.internal.http.HttpExporter - Failed to export metrics. Server responded with HTTP status code 404. Error message: Unable to parse response body, HTTP status message: Not Found
```