### PR TITLE
add naver api for place search

### DIFF
--- a/app-server/subprojects/bounded_context/place/infra/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/place/infra/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     implementation("org.springframework:spring-webflux")
     implementation("io.projectreactor.netty:reactor-netty")
 
-
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -11,6 +11,7 @@ import com.google.common.util.concurrent.RateLimiter
 import io.netty.channel.ChannelOption
 import io.netty.handler.timeout.ReadTimeoutHandler
 import io.netty.handler.timeout.WriteTimeoutHandler
+import jakarta.annotation.Priority
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -31,6 +32,7 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @Component
+@Priority(value = Int.MAX_VALUE - 1)
 class KakaoMapsService(
     kakaoProperties: KakaoProperties,
 ) : MapsService {

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
@@ -1,0 +1,224 @@
+package club.staircrusher.place.infra.adapter.out.web
+
+import club.staircrusher.place.application.port.out.web.MapsService
+import club.staircrusher.place.domain.model.Building
+import club.staircrusher.place.domain.model.BuildingAddress
+import club.staircrusher.place.domain.model.Place
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.geography.Location
+import club.staircrusher.stdlib.place.PlaceCategory
+import com.google.common.util.concurrent.RateLimiter
+import io.netty.channel.ChannelOption
+import io.netty.handler.timeout.ReadTimeoutHandler
+import io.netty.handler.timeout.WriteTimeoutHandler
+import jakarta.annotation.Priority
+import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.http.codec.json.KotlinSerializationJsonDecoder
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.support.WebClientAdapter
+import org.springframework.web.service.annotation.GetExchange
+import org.springframework.web.service.invoker.HttpServiceProxyFactory
+import reactor.core.publisher.Mono
+import reactor.netty.http.client.HttpClient
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+
+@Component
+@Priority(Int.MAX_VALUE)
+class NaverMapsService(
+    private val naverOpenApiProperties: NaverOpenApiProperties,
+): MapsService {
+    companion object {
+        private val CONNECT_TIMEOUT = Duration.ofSeconds(10)
+        private val READ_TIMEOUT = Duration.ofSeconds(10)
+        private val WRITE_TIMEOUT = Duration.ofSeconds(10)
+
+        private val logger = KotlinLogging.logger {}
+    }
+
+    @Suppress("UnstableApiUsage", "MagicNumber")
+    private val rateLimiter = RateLimiter.create(20.0)
+
+    private val httpClient = HttpClient.create()
+        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT.toMillis().toInt())
+        .compress(true)
+        .followRedirect(true)
+        .doOnConnected {
+            it.addHandlerLast(ReadTimeoutHandler(READ_TIMEOUT.toSeconds(), TimeUnit.SECONDS))
+            it.addHandlerLast(WriteTimeoutHandler(WRITE_TIMEOUT.toSeconds(), TimeUnit.SECONDS))
+        }
+        .responseTimeout(Duration.ofSeconds(2))
+    private val decoder = KotlinSerializationJsonDecoder(Json { ignoreUnknownKeys = true })
+
+    private val naverOpenApiService: NaverOpenApiService by lazy {
+        val client = WebClient.builder()
+            .baseUrl("https://openapi.naver.com")
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .codecs { it.defaultCodecs().kotlinSerializationJsonDecoder(decoder) }
+            .defaultHeaders {
+                it.add("X-Naver-Client-Id", naverOpenApiProperties.clientId)
+                it.add("X-Naver-Client-Secret", naverOpenApiProperties.clientSecret)
+            }
+            .defaultStatusHandler(HttpStatusCode::isError) { response ->
+                response
+                    .bodyToMono(NaverOpenApiError::class.java)
+                    .map { RuntimeException(it.errorMessage) }
+                    .onErrorResume { response.createException() }
+            }
+            .build()
+
+        val factory = HttpServiceProxyFactory
+            .builder(WebClientAdapter.forClient(client))
+            .build()
+        factory.createClient(NaverOpenApiService::class.java)
+    }
+
+    @Suppress("FunctionParameterNaming")
+    interface NaverOpenApiService {
+        @GetExchange(
+            url = "v1/search/local.json",
+            accept = [MediaType.APPLICATION_JSON_VALUE],
+        )
+        fun localSearch(
+            @RequestParam query: String,
+            @RequestParam(required = false) display: Int? = 5,
+            @RequestParam(required = false) start: Int? = 1,
+            @RequestParam(required = false) sort: String? = "random",
+        ): Mono<LocalSearchResult>
+
+        companion object {
+            internal const val defaultSize = 5
+        }
+    }
+
+    override suspend fun findAllByKeyword(
+        keyword: String,
+        option: MapsService.SearchByKeywordOption,
+    ): List<Place> {
+        throw NotImplementedError("Not implemented yet")
+    }
+
+    override suspend fun findFirstByKeyword(
+        keyword: String,
+        option: MapsService.SearchByKeywordOption,
+    ): Place? {
+        return fetchPageForSearchByKeyword(keyword)
+            .convertToModel()
+            .firstOrNull()
+    }
+
+    private suspend fun fetchPageForSearchByKeyword(
+        keyword: String,
+    ): LocalSearchResult {
+        // FIXME: because rate limiter implementation of guice blocks current thread until it can acquire permit,
+        // and we are using kotlin coroutine or project reactor which are using size-limited thread pool normally,
+        // it could block all threads and prevent them from running.
+        @Suppress("UnstableApiUsage")
+        rateLimiter.acquire()
+
+        return naverOpenApiService.localSearch(
+            query = keyword,
+        ).awaitFirst()
+    }
+
+    override suspend fun findAllByCategory(
+        category: PlaceCategory,
+        option: MapsService.SearchByCategoryOption,
+    ): List<Place> {
+        throw NotImplementedError("Not implemented yet")
+    }
+
+    @Serializable
+    data class LocalSearchResult(
+        val lastBuildDate: String,
+        val total: Int,
+        val start: Int,
+        val display: Int,
+        val items: List<LocalSearchItem>,
+    ) {
+        @Serializable
+        data class LocalSearchItem(
+            val title: String,
+            val link: String,
+            val category: String,
+            val description: String?,
+            val telephone: String?,
+            val address: String,
+            val roadAddress: String,
+            val mapx: String,
+            val mapy: String,
+        ) {
+            @Suppress("MagicNumber")
+            val location: Location
+                get() = Location(mapx.toDouble() / 1e7, mapy.toDouble() / 1e7)
+
+            @Suppress("MagicNumber")
+            fun parseToBuildingAddress(): BuildingAddress {
+                val addressNameTokens = address.split(" ")
+                val siDo = addressNameTokens[0]
+                val siGunGu = addressNameTokens[1]
+                val eupMyeonDong = addressNameTokens[2]
+                val li = addressNameTokens[3].takeIf { it.endsWith("리") } ?: ""
+
+                val (roadName, buildingNumber) = this.roadAddress.split(" ").takeLast(2)
+                val buildingNumberTokens = buildingNumber.split("-")
+                val (mainBuildingNumber, subBuildingNumber) = if (buildingNumberTokens.size == 1) {
+                    Pair(buildingNumberTokens[0], "")
+                } else {
+                    Pair(buildingNumberTokens[0], buildingNumberTokens[1])
+                }
+                return BuildingAddress(
+                    siDo = siDo,
+                    siGunGu = siGunGu,
+                    eupMyeonDong = eupMyeonDong,
+                    li = li,
+                    roadName = roadName,
+                    mainBuildingNumber = mainBuildingNumber,
+                    subBuildingNumber = subBuildingNumber,
+                )
+            }
+        }
+
+        fun convertToModel(): List<Place> {
+            return items.mapNotNull {
+                @Suppress("TooGenericExceptionCaught", "SwallowedException")
+                try {
+                    Place(
+                        id = "temp", // TODO: 제대로 채우기
+                        // remove all html tags with regex
+                        name = it.title.replace("<[^>]*>".toRegex(), ""),
+                        location = it.location,
+                        building = Building(
+                            id = Building.generateId(it.roadAddress),
+                            name = it.roadAddress,
+                            location = it.location,
+                            address = it.parseToBuildingAddress(),
+                            siGunGuId = "temp", // TODO: 제대로 채우기
+                            eupMyeonDongId = "temp",
+                        ),
+                        siGunGuId = null,
+                        eupMyeonDongId = null,
+                        category = null,
+                    )
+                } catch (t: Throwable) {
+                    logger.warn(t) { "Cannot convert document to model: $it" }
+                    null
+                }
+            }
+        }
+    }
+
+    @Serializable
+    data class NaverOpenApiError(
+        val errorMessage: String,
+        val errorCode: String,
+    )
+}

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverOpenApiProperties.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverOpenApiProperties.kt
@@ -1,0 +1,9 @@
+package club.staircrusher.place.infra.adapter.out.web
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("scc.naver.openapi")
+data class NaverOpenApiProperties (
+    val clientId: String,
+    val clientSecret: String,
+)

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/resources/application.yaml
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/resources/application.yaml
@@ -16,6 +16,11 @@ scc:
   kakao:
     apiKey: test
 
+  naver:
+    open-api:
+      client-id: test
+      client-secret: test
+
   s3:
     imageUpload:
       bucketName: test

--- a/app-server/subprojects/deploying_apps/scc_server/src/main/resources/application.yaml
+++ b/app-server/subprojects/deploying_apps/scc_server/src/main/resources/application.yaml
@@ -43,6 +43,11 @@ scc:
   kakao-login:
     oauth-client-id: test
 
+  naver:
+    open-api:
+      client-id: test
+      client-secret: test
+
   apple-login:
     service-id: test
     client-secret: test


### PR DESCRIPTION
Because kakao map services tend to not resolve outdated place information in a timely manner and naver does not, we have decided to use naver map service as our primary place search service.

There are two endpoints providing the place search feature

1. Geocoding api provided by naver cloud
2. Local search api provided by naver open api

The first one is not the one that can replace kakao map service because it only works when we query exact road address or ji-bun address; if we query like "Starbucks", it will return empty list.

The second one is not the proper substitute for the kakao either, since it does not allow for us to fetch more than 5 results at once and does not provide pagination feature either.

So this series of PRs concentrates on making up for the shortcomings of kakao by using naver api rather than replacing kakao service with naver's at all.

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 