### PR TITLE
Doogie/naver map service 3

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/place/application/build.gradle.kts
@@ -1,3 +1,5 @@
 dependencies {
+    val kotlinLoggingVersion: String by project
     implementation(projects.apiSpecification.domainEvent)
+    implementation("io.github.microutils:kotlin-logging-jvm:$kotlinLoggingVersion")
 }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/PlaceService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/PlaceService.kt
@@ -36,7 +36,7 @@ class PlaceService(
 
         var places = mapsService.findAllByKeyword(keyword, option)
         if (option.runCrossValidation) {
-            val existingPlaces = places.map { async { runCrossValidation(it, option) } }.awaitAll()
+            val existingPlaces = places.map { async { crossValidate(it, option) } }.awaitAll()
             places = places.filterIndexed { index, _ -> existingPlaces[index] }
         }
         eventPublisher.publishEvent(PlaceSearchEvent(places.map(Place::toPlaceDTO)))
@@ -65,7 +65,7 @@ class PlaceService(
      * @return true if the place does exist on the secondary maps service, false otherwise.
      */
     @Suppress("ReturnCount")
-    private suspend fun runCrossValidation(
+    suspend fun crossValidate(
         place: Place,
         option: MapsService.SearchByKeywordOption,
     ): Boolean {

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/web/MapsService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/web/MapsService.kt
@@ -22,6 +22,7 @@ interface MapsService {
 
     data class SearchByKeywordOption(
         val region: Region? = null,
+        val runCrossValidation: Boolean = false,
     ) {
         sealed interface Region
         data class CircleRegion(

--- a/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/Building.kt
+++ b/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/Building.kt
@@ -17,4 +17,12 @@ data class Building(
             length = 36,
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        return other is Building && other.id == this.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -32,7 +32,7 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 @Component
-@Priority(value = Int.MAX_VALUE - 1)
+@Priority(Int.MAX_VALUE - 1)
 class KakaoMapsService(
     kakaoProperties: KakaoProperties,
 ) : MapsService {

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
@@ -103,8 +103,7 @@ class NaverMapsService(
         keyword: String,
         option: MapsService.SearchByKeywordOption,
     ): List<Place> {
-        return fetchPageForSearchByKeyword(keyword)
-            .convertToModel()
+        throw NotImplementedError()
     }
 
     override suspend fun findFirstByKeyword(
@@ -120,8 +119,7 @@ class NaverMapsService(
         category: PlaceCategory,
         option: MapsService.SearchByCategoryOption,
     ): List<Place> {
-        return fetchPageForSearchByKeyword(category.humanReadableName)
-            .convertToModel()
+        throw NotImplementedError()
     }
 
     private suspend fun fetchPageForSearchByKeyword(

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
@@ -45,7 +45,7 @@ class NaverMapsService(
     }
 
     @Suppress("UnstableApiUsage", "MagicNumber")
-    private val rateLimiter = RateLimiter.create(20.0)
+    private val rateLimiter = RateLimiter.create(100.0)
 
     private val httpClient = HttpClient.create()
         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT.toMillis().toInt())

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
@@ -103,7 +103,8 @@ class NaverMapsService(
         keyword: String,
         option: MapsService.SearchByKeywordOption,
     ): List<Place> {
-        throw NotImplementedError("Not implemented yet")
+        return fetchPageForSearchByKeyword(keyword)
+            .convertToModel()
     }
 
     override suspend fun findFirstByKeyword(
@@ -113,6 +114,14 @@ class NaverMapsService(
         return fetchPageForSearchByKeyword(keyword)
             .convertToModel()
             .firstOrNull()
+    }
+
+    override suspend fun findAllByCategory(
+        category: PlaceCategory,
+        option: MapsService.SearchByCategoryOption,
+    ): List<Place> {
+        return fetchPageForSearchByKeyword(category.humanReadableName)
+            .convertToModel()
     }
 
     private suspend fun fetchPageForSearchByKeyword(
@@ -127,13 +136,6 @@ class NaverMapsService(
         return naverOpenApiService.localSearch(
             query = keyword,
         ).awaitFirst()
-    }
-
-    override suspend fun findAllByCategory(
-        category: PlaceCategory,
-        option: MapsService.SearchByCategoryOption,
-    ): List<Place> {
-        throw NotImplementedError("Not implemented yet")
     }
 
     @Serializable

--- a/app-server/subprojects/bounded_context/place_search/infra/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/place_search/infra/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
     integrationTestImplementation(projects.boundedContext.place.application)
     integrationTestImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.3")
     integrationTestImplementation(projects.crossCuttingConcern.test.springIt)
+    integrationTestImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+
 }

--- a/app-server/subprojects/bounded_context/place_search/infra/src/integrationTest/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/SearchPlacesTest.kt
+++ b/app-server/subprojects/bounded_context/place_search/infra/src/integrationTest/kotlin/club/staircrusher/place_search/infra/adapter/in/controller/SearchPlacesTest.kt
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.mock.mockito.SpyBean
 
 class SearchPlacesTest : PlaceSearchITBase() {
-    @MockBean
+    @SpyBean
     private lateinit var mapsService: MapsService
 
     @Test

--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/out/web/ClubQuestTargetBuildingClusterer.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/out/web/ClubQuestTargetBuildingClusterer.kt
@@ -1,8 +1,8 @@
 package club.staircrusher.quest.application.port.out.web
 
-import club.staircrusher.quest.domain.model.ClubQuestTargetBuilding
+import club.staircrusher.place.domain.model.Building
 import club.staircrusher.stdlib.geography.Location
 
 interface ClubQuestTargetBuildingClusterer {
-    fun clusterBuildings(buildings: List<ClubQuestTargetBuilding>, clusterCount: Int): Map<Location, List<ClubQuestTargetBuilding>>
+    fun clusterBuildings(buildings: List<Building>, clusterCount: Int): Map<Location, List<Building>>
 }

--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/out/web/ClubQuestTargetPlacesSearcher.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/out/web/ClubQuestTargetPlacesSearcher.kt
@@ -5,4 +5,5 @@ import club.staircrusher.stdlib.geography.Location
 
 interface ClubQuestTargetPlacesSearcher {
     suspend fun searchPlaces(centerLocation: Location, radiusMeters: Int): List<Place>
+    suspend fun crossValidatePlaces(places: List<Place>): List<Boolean>
 }

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
@@ -43,7 +43,7 @@ class AdminClubQuestController(
     }
 
     @PostMapping("/admin/clubQuests/create/dryRun")
-    fun createClubQuestDryRun(@RequestBody request: ClubQuestsCreateDryRunPostRequest): List<ClubQuestCreateDryRunResultItemDTO> {
+    suspend fun createClubQuestDryRun(@RequestBody request: ClubQuestsCreateDryRunPostRequest): List<ClubQuestCreateDryRunResultItemDTO> {
         val result = clubQuestCreateAplService.createDryRun(
             centerLocation = request.centerLocation.toModel(),
             radiusMeters = request.radiusMeters,

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/service/InProcessClubQuestTargetPlaceSearcher.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/service/InProcessClubQuestTargetPlaceSearcher.kt
@@ -1,18 +1,18 @@
 package club.staircrusher.quest.infra.adapter.out.service
 
-import club.staircrusher.place.application.port.out.web.MapsService
 import club.staircrusher.place.application.port.`in`.PlaceService
+import club.staircrusher.place.application.port.out.web.MapsService
 import club.staircrusher.place.domain.model.Building
 import club.staircrusher.place.domain.model.Place
 import club.staircrusher.quest.application.port.out.web.ClubQuestTargetPlacesSearcher
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.geography.Length
 import club.staircrusher.stdlib.geography.Location
+import club.staircrusher.stdlib.geography.LocationUtils
 import club.staircrusher.stdlib.place.PlaceCategory
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import club.staircrusher.stdlib.di.annotation.Component
-import club.staircrusher.stdlib.geography.Length
-import club.staircrusher.stdlib.geography.LocationUtils
 import kotlin.math.ceil
 
 @Component
@@ -38,6 +38,12 @@ class InProcessClubQuestTargetPlaceSearcher(
         val radius = Length.ofMeters(radiusMeters)
         val buildingsInRegion = searchBuildingsInRegion(centerLocation, radius)
         return searchPlacesInBuildings(buildingsInRegion, centerLocation, radius)
+    }
+
+    override suspend fun crossValidatePlaces(places: List<Place>): List<Boolean> = coroutineScope {
+        places
+            .map { async { placeService.crossValidate(it, MapsService.SearchByKeywordOption()) } }
+            .awaitAll()
     }
 
     private suspend fun searchBuildingsInRegion(centerLocation: Location, radius: Length): List<Building> {
@@ -77,7 +83,7 @@ class InProcessClubQuestTargetPlaceSearcher(
                     async {
                         placeService.findAllByKeyword(
                             keyword = building.address.toString(),
-                            option = MapsService.SearchByKeywordOption(runCrossValidation = true),
+                            option = MapsService.SearchByKeywordOption(),
                         )
                     }
                 }

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/service/InProcessClubQuestTargetPlaceSearcher.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/service/InProcessClubQuestTargetPlaceSearcher.kt
@@ -77,7 +77,7 @@ class InProcessClubQuestTargetPlaceSearcher(
                     async {
                         placeService.findAllByKeyword(
                             keyword = building.address.toString(),
-                            option = MapsService.SearchByKeywordOption(),
+                            option = MapsService.SearchByKeywordOption(runCrossValidation = true),
                         )
                     }
                 }

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/service/KMeansClubQuestTargetBuildingClusterer.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/service/KMeansClubQuestTargetBuildingClusterer.kt
@@ -1,13 +1,13 @@
 package club.staircrusher.quest.infra.adapter.out.service
 
+import club.staircrusher.place.domain.model.Building
 import club.staircrusher.quest.application.port.out.web.ClubQuestTargetBuildingClusterer
-import club.staircrusher.quest.domain.model.ClubQuestTargetBuilding
 import club.staircrusher.quest.infra.kmeans.Centroid
 import club.staircrusher.quest.infra.kmeans.EuclideanDistance
 import club.staircrusher.quest.infra.kmeans.KMeans
 import club.staircrusher.quest.infra.kmeans.Record
-import club.staircrusher.stdlib.geography.Location
 import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.geography.Location
 
 @Component
 class KMeansClubQuestTargetBuildingClusterer : ClubQuestTargetBuildingClusterer {
@@ -17,14 +17,14 @@ class KMeansClubQuestTargetBuildingClusterer : ClubQuestTargetBuildingClusterer 
     }
 
     @Suppress("ReturnCount")
-    override fun clusterBuildings(buildings: List<ClubQuestTargetBuilding>, clusterCount: Int): Map<Location, List<ClubQuestTargetBuilding>> {
+    override fun clusterBuildings(buildings: List<Building>, clusterCount: Int): Map<Location, List<Building>> {
         if (clusterCount <= 0) {
             return emptyMap()
         }
-        val buildingById = buildings.associateBy { it.buildingId }
+        val buildingById = buildings.associateBy { it.id }
         val records = buildings.map {
             Record(
-                it.buildingId,
+                it.id,
                 mapOf(
                     "lng" to it.location.lng,
                     "lat" to it.location.lat,

--- a/app-server/subprojects/bounded_context/quest/infra/src/test/kotlin/club/staircrusher/quest/infra/adapter/out/service/KMeansClubQuestTargetBuildingClustererTest.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/test/kotlin/club/staircrusher/quest/infra/adapter/out/service/KMeansClubQuestTargetBuildingClustererTest.kt
@@ -1,6 +1,7 @@
 package club.staircrusher.quest.infra.adapter.out.service
 
-import club.staircrusher.quest.domain.model.ClubQuestTargetBuilding
+import club.staircrusher.place.domain.model.Building
+import club.staircrusher.place.domain.model.BuildingAddress
 import club.staircrusher.stdlib.geography.Location
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -8,11 +9,20 @@ import org.junit.jupiter.api.Test
 class KMeansClubQuestTargetBuildingClustererTest {
     @Test
     fun test() {
+        val buildingAddress = BuildingAddress(
+            siDo = "서울특별시",
+            siGunGu = "강남구",
+            eupMyeonDong = "역삼동",
+            li = "역삼동",
+            roadName = "테헤란로",
+            mainBuildingNumber = "123",
+            subBuildingNumber = "456",
+        )
         val locations = listOf(
-            ClubQuestTargetBuilding(buildingId = "장소 1" , name = "장소 1", location = Location(lng = 1.0, lat = 1.0), places = emptyList()),
-            ClubQuestTargetBuilding(buildingId = "장소 2" , name = "장소 2", location = Location(lng = 1.1, lat = 1.1), places = emptyList()),
-            ClubQuestTargetBuilding(buildingId = "장소 3" , name = "장소 3", location = Location(lng = 2.0, lat = 2.0), places = emptyList()),
-            ClubQuestTargetBuilding(buildingId = "장소 4" , name = "장소 4", location = Location(lng = 2.1, lat = 2.1), places = emptyList()),
+            Building(id = "장소 1" , name = "장소 1", location = Location(lng = 1.0, lat = 1.0), address = buildingAddress, siGunGuId = "강남구", eupMyeonDongId = "역삼동"),
+            Building(id = "장소 2" , name = "장소 2", location = Location(lng = 1.1, lat = 1.1), address = buildingAddress, siGunGuId = "강남구", eupMyeonDongId = "역삼동"),
+            Building(id = "장소 3" , name = "장소 3", location = Location(lng = 2.0, lat = 2.0), address = buildingAddress, siGunGuId = "강남구", eupMyeonDongId = "역삼동"),
+            Building(id = "장소 4" , name = "장소 4", location = Location(lng = 2.1, lat = 2.1), address = buildingAddress, siGunGuId = "강남구", eupMyeonDongId = "역삼동"),
         )
         repeat(100) {
             val result = KMeansClubQuestTargetBuildingClusterer().clusterBuildings(locations, 2)

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/MockMapsService.kt
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/MockMapsService.kt
@@ -4,7 +4,7 @@ import club.staircrusher.place.application.port.out.web.MapsService
 import club.staircrusher.place.domain.model.Place
 import club.staircrusher.stdlib.place.PlaceCategory
 
-class MockMapsService : MapsService {
+open class MockMapsService : MapsService {
     override suspend fun findAllByKeyword(keyword: String, option: MapsService.SearchByKeywordOption): List<Place> {
         return emptyList()
     }

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/SccSpringItMockConfiguration.kt
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/SccSpringItMockConfiguration.kt
@@ -3,6 +3,7 @@ package club.staircrusher.testing.spring_it.mock
 import club.staircrusher.place.application.port.out.web.MapsService
 import club.staircrusher.stdlib.clock.SccClock
 import club.staircrusher.user.application.port.out.web.login.kakao.KakaoLoginService
+import jakarta.annotation.Priority
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
@@ -18,6 +19,7 @@ open class SccSpringItMockConfiguration {
 
     @Bean
     @Primary
+    @Priority(1)
     open fun mockMapsService(): MapsService {
         return MockMapsService()
     }


### PR DESCRIPTION
This commit addresses the current shortcomings of quest; kakao map services
returns too many closed stores as results of place search api and this outdated
information has usually not fixed quickly enough, so that users continue to
experience the frustration of quests containing closed locations and not being
able to fultill them properly. Naver usually updates this kind of outdated
information more quickly, results from kakao api are cross validated by naver
api. If naver can not find exact same place, it is discarded and not returned.

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 