### PR TITLE
[모니터링] latency 기반 trace 샘플링 추가

### DIFF
--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -284,52 +284,6 @@ openobserve-collector:
           metric:
             - resource.attributes["k8s.namespace.name"]!=nil and resource.attributes["k8s.namespace.name"]!="scc"
             - resource.attributes["namespace"]!=nil and resource.attributes["namespace"]!="scc"
-      tail_sampling:
-        decision_wait: 10s
-        num_traces: 100
-        expected_new_traces_per_sec: 10
-        policies: [
-          {
-            # Rule 1: low sampling for readiness/liveness probes
-            name: low-probe-policy,
-            type: and,
-            and:
-              {
-                and_sub_policy:
-                  [
-                    {
-                      # filter by route
-                      name: route-live-ready-policy,
-                      type: string_attribute,
-                      string_attribute:
-                        {
-                          key: http.route,
-                          values: [ /livez, /readyz, /** ],
-                          enabled_regex_matching: false,
-                        },
-                    },
-                    {
-                      # apply probabilistic sampling
-                      name: probabilistic-policy,
-                      type: probabilistic,
-                      probabilistic: { sampling_percentage: 0.1 },
-                    },
-                  ],
-              },
-          },
-          {
-            # Rule 2: always sample if there is an error
-            name: trace-status-policy,
-            type: status_code,
-            status_code: { status_codes: [ ERROR ] },
-          },
-          {
-            # apply probabilistic sampling for the rest
-            name: probabilistic-policy,
-            type: probabilistic,
-            probabilistic: { sampling_percentage: 20 },
-          },
-        ]
       resourcedetection:
         detectors: [system, env, k8snode]
         override: true
@@ -411,7 +365,7 @@ openobserve-collector:
           exporters: [otlphttp/openobserve]
         traces:
           receivers: [otlp]
-          processors: [batch, k8sattributes, tail_sampling]
+          processors: [batch, k8sattributes]
           exporters: [otlphttp/openobserve]
 
   gateway:
@@ -644,10 +598,16 @@ openobserve-collector:
             status_code: { status_codes: [ ERROR ] },
           },
           {
-            # apply probabilistic sampling for the rest
-            name: probabilistic-policy,
+            # Rule 3: sample if latency is greater than 500ms
+            name: trace-latency-policy,
+            type: latency,
+            latency: { threshold_ms: 500 },
+          }
+          {
+            # Rule 4: apply probabilistic sampling for the rest
+            name: randomized-policy,
             type: probabilistic,
-            probabilistic: { sampling_percentage: 20 },
+            probabilistic: { sampling_percentage: 30 },
           },
         ]
       resourcedetection:


### PR DESCRIPTION
- latency 500 ms 넘어가는 api 는 trace 가 무조건 샘플링 되도록
- agent 와 gateway 에서 두번 sampling 하게 되는 것 같아서 모든 데이터가 다 모이는 gateway 에서만 샘플링하도록 합니다

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 