### PR TITLE
내가 정복한 장소 API 오류 수정

### DIFF
--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
@@ -349,6 +349,8 @@ class AccessibilityApplicationService(
 
     fun findByUserId(userId: String): Pair<List<PlaceAccessibility>, List<BuildingAccessibility>> {
         val placeAccessibilities = placeAccessibilityRepository.findByUserId(userId)
+        if (placeAccessibilities.isEmpty()) return Pair(emptyList(), emptyList())
+
         val buildingAccessibilities =
             buildingAccessibilityRepository.findByPlaceIds(placeAccessibilities.map { it.placeId })
         return Pair(placeAccessibilities, buildingAccessibilities)


### PR DESCRIPTION

- `ids IN ()` 문법을 쓸 때 항상 empty 인지 확인해줘야할 것 같은데, 이걸 그냥 repository 단에 general 하게 적용하는 방법을 고민해봐도 좋을 것 같아요

<img width="1400" alt="image" src="https://github.com/Stair-Crusher-Club/scc-server/assets/43549670/e48b5811-6339-4b66-8e01-57c800f485c6">


## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 