### PR TITLE
SearchPlace 성능 개선

### DIFF
--- a/app-server/subprojects/cross_cutting_concern/infra/spring_message/src/main/kotlin/club/staircrusher/spring_message/SpringEventListenerAsyncExecutorConfiguration.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_message/src/main/kotlin/club/staircrusher/spring_message/SpringEventListenerAsyncExecutorConfiguration.kt
@@ -2,10 +2,12 @@ package club.staircrusher.spring_message
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 @Configuration(proxyBeanMethods = false)
+@EnableAsync
 open class SpringEventListenerAsyncExecutorConfiguration {
     @Bean
     open fun springEventListenerAsyncExecutor(): ExecutorService {


### PR DESCRIPTION
- search place 엔드포인트에서 검색 결과를 db 에 저장하는데, insert 작업은 http response 와 무관하게 async 하게 처리하도록 의도된 것 같은데 그렇게 동작하고 있지 않다
- api latency 의 약 절반을 차지하는 insert 문
- `@Async` 어노테이션을 사용하려면 `@EnableAsync` 가 필요한데 안보여서 추가한다

<img width="1416" alt="image" src="https://github.com/Stair-Crusher-Club/scc-server/assets/43549670/c688c38e-e68e-4c62-96d6-f6d598bf2050">


## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 