### PR TITLE
스프링 이벤트 Retry 추가하기

### DIFF
--- a/app-server/subprojects/cross_cutting_concern/infra/spring_message/build.gradle.kts
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_message/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.retry:spring-retry")
+    implementation("org.springframework:spring-aspects")
     implementation("io.github.microutils:kotlin-logging-jvm:$kotlinLoggingVersion")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_message/build.gradle.kts
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_message/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(projects.crossCuttingConcern.stdlib)
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.retry:spring-retry")
     implementation("io.github.microutils:kotlin-logging-jvm:$kotlinLoggingVersion")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_message/src/main/kotlin/club/staircrusher/spring_message/SpringEventListener.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_message/src/main/kotlin/club/staircrusher/spring_message/SpringEventListener.kt
@@ -6,6 +6,9 @@ import club.staircrusher.stdlib.persistence.TransactionManager
 import com.fasterxml.jackson.databind.ObjectMapper
 import mu.KotlinLogging
 import org.springframework.context.ApplicationListener
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Recover
+import org.springframework.retry.annotation.Retryable
 import org.springframework.scheduling.annotation.Async
 
 @Component
@@ -17,12 +20,8 @@ open class SpringEventListener(
     private val logger = KotlinLogging.logger {}
 
     @Suppress("TooGenericExceptionCaught")
-    // FIXME: domain event 처리로 인해서 HTTP 요청 처리가 늦어지는 경우가 있어서
-    //        임시로 별도 쓰레드풀에서 비동기적으로 실행하도록 조치한다.
-    //        하지만 이렇게 되면 domain event 처리 로직이 domain event를 발행한 트랜잭션 바깥에서 실행되므로
-    //        domain event 로직 실행에 실패할 수 있다.
-    //        따라서 실패 시 재시도를 하도록 나중에 수정해줘야 한다.
     @Async("springEventListenerAsyncExecutor")
+    @Retryable(maxAttempts = 3, backoff = Backoff(value = 1000))
     override fun onApplicationEvent(springEvent: JacksonSerializedSpringEvent<*>) {
         val event = objectMapper.readValue(springEvent.value, springEvent.type)
         transactionManager.doInTransaction {
@@ -31,8 +30,14 @@ open class SpringEventListener(
                     it(event)
                 } catch (e: Throwable) {
                     logger.error(e) { }
+                    throw e
                 }
             }
         }
+    }
+
+    @Recover
+    fun recover(err: Throwable, springEvent: JacksonSerializedSpringEvent<*>) {
+        logger.error { "Failed to process spring event of type ${springEvent.type} after retry" }
     }
 }

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_message/src/main/kotlin/club/staircrusher/spring_message/SpringEventListener.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_message/src/main/kotlin/club/staircrusher/spring_message/SpringEventListener.kt
@@ -36,6 +36,7 @@ open class SpringEventListener(
         }
     }
 
+    @Suppress("UnusedPrivateMember")
     @Recover
     fun recover(err: Throwable, springEvent: JacksonSerializedSpringEvent<*>) {
         logger.error { "Failed to process spring event of type ${springEvent.type} after retry" }

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_message/src/main/kotlin/club/staircrusher/spring_message/SpringEventListenerAsyncExecutorConfiguration.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_message/src/main/kotlin/club/staircrusher/spring_message/SpringEventListenerAsyncExecutorConfiguration.kt
@@ -2,12 +2,14 @@ package club.staircrusher.spring_message
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.retry.annotation.EnableRetry
 import org.springframework.scheduling.annotation.EnableAsync
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 @Configuration(proxyBeanMethods = false)
 @EnableAsync
+@EnableRetry
 open class SpringEventListenerAsyncExecutorConfiguration {
     @Bean
     open fun springEventListenerAsyncExecutor(): ExecutorService {


### PR DESCRIPTION
- Event 의 처리를 별도의 executor 를 두면서 retry 로직의 필요성이 생김
- resilience4j 까지는 좀 과한 것 같아서 spring-retry 로 간단하게 추가해봤습니다
- 도메인 이벤트로 실행되는 로직이 멱등성 있게 되어 있어서 단순하게 retry 했습니다

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 