### PR TITLE
퀘스트 생성 시 cross validate 뒤에서 처리하기

### DIFF
--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/ClubQuestCreateAplService.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/ClubQuestCreateAplService.kt
@@ -149,7 +149,7 @@ class ClubQuestCreateAplService(
         questNamePrefix: String,
         dryRunResultItems: List<ClubQuestCreateDryRunResultItem>
     ) = transactionManager.doInTransaction {
-        dryRunResultItems.forEachIndexed { idx, dryRunResultItem ->
+        dryRunResultItems.mapIndexed { idx, dryRunResultItem ->
             clubQuestRepository.save(ClubQuest(
                 name = "$questNamePrefix - ${getQuestNamePostfix(idx)}",
                 dryRunResultItem = dryRunResultItem,

--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/CrossValidateClubQuestPlacesUseCase.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/CrossValidateClubQuestPlacesUseCase.kt
@@ -17,7 +17,7 @@ class CrossValidateClubQuestPlacesUseCase(
     private val placeService: PlaceService,
 ) {
     @Suppress("MagicNumber")
-    private val taskExecutor = Executors.newFixedThreadPool(4) // 4인 이유는... 그냥 author 마음임.
+    private val taskExecutor = Executors.newCachedThreadPool()
 
     fun handle(questId: String) {
         taskExecutor.execute {

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
@@ -57,10 +57,13 @@ class AdminClubQuestController(
 
     @PostMapping("/admin/clubQuests/create")
     fun createClubQuest(@RequestBody request: ClubQuestsCreatePostRequest): ResponseEntity<Unit> {
-        clubQuestCreateAplService.createFromDryRunResult(
+        val quests = clubQuestCreateAplService.createFromDryRunResult(
             questNamePrefix = request.questNamePrefix,
             dryRunResultItems = request.dryRunResults.map { it.toModel() }
         )
+        quests.forEach { quest ->
+            crossValidateClubQuestPlacesUseCase.handle(quest.id)
+        }
         return ResponseEntity
             .noContent()
             .build()


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- 퀘스트 생성을 하면 뒤에서 비동기적으로 cross-validate를 적용합니다.