### PR TITLE
scc logger가 남기는 로그 더 잘 파싱하기

### DIFF
--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -225,6 +225,7 @@ openobserve-collector:
             from: body.message
             to: resource["message"]
           - type: move
+            if: body.exception
             from: body.exception
             to: resource["scc.exception"]
       hostmetrics:

--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -204,6 +204,8 @@ openobserve-collector:
             from: attributes.uid
             to: resource["k8s.pod.uid"]
           # scc custom attributes
+          - type: json_parser
+            id: scc-json-log-parser
           - type: move
             from: body.level
             to: resource["status"]

--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -203,6 +203,28 @@ openobserve-collector:
           - type: move
             from: attributes.uid
             to: resource["k8s.pod.uid"]
+          # scc custom attributes
+          - type: move
+            from: body.level
+            to: resource["status"]
+          - type: move
+            from: body.thread
+            to: resource["scc.thread"]
+          - type: move
+            from: body.mdc.trace_id
+            to: resource["scc.mdc.trace_id"]
+          - type: move
+            from: body.mdc.span_id
+            to: resource["scc.mdc.span_id"]
+          - type: move
+            from: body.logger
+            to: resource["scc.logger"]
+          - type: move
+            from: body.message
+            to: resource["message"]
+          - type: move
+            from: body.exception
+            to: resource["scc.exception"]
       hostmetrics:
         root_path: /hostfs
         collection_interval: 15s
@@ -602,7 +624,7 @@ openobserve-collector:
             name: trace-latency-policy,
             type: latency,
             latency: { threshold_ms: 500 },
-          }
+          },
           {
             # Rule 4: apply probabilistic sampling for the rest
             name: randomized-policy,


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- 로그가 파싱이 안 되는 이유가 왠지 이거인 것 같아서 올려봅니다.
- 근데 helm diff 때리면 약간 이상한 변경사항들이 보이는데, @jyoo0515 님 확인 부탁드려욤