### PR TITLE
[Fix] IndexOutOfBoundsException 수정

### DIFF
--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -418,7 +418,7 @@ class KakaoMapsService(
         val siDo = addressNameTokens[0]
         val siGunGu = addressNameTokens[1]
         val eupMyeonDong = addressNameTokens[2]
-        val li = addressNameTokens[3].takeIf { it.endsWith("리") } ?: ""
+        val li = addressNameTokens.getOrNull(3)?.takeIf { it.endsWith("리") } ?: ""
 
         val (roadName, buildingNumber) = roadAddressName.split(" ").takeLast(2)
         val buildingNumberTokens = buildingNumber.split("-")

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/NaverMapsService.kt
@@ -183,12 +183,15 @@ class NaverMapsService(
                 val (roadName, buildingNumber) = this.roadAddress
                     .split(" ")
                     .dropLastWhile { !건물번호_정규식.matches(it) }
-                    .takeLast(2)
+                    .let {
+                        if (it.isNotEmpty()) it.takeLast(2)
+                        else listOf("", "")
+                    }
                 val buildingNumberTokens = buildingNumber.split("-")
-                val (mainBuildingNumber, subBuildingNumber) = if (buildingNumberTokens.size == 1) {
-                    Pair(buildingNumberTokens[0], "")
-                } else {
-                    Pair(buildingNumberTokens[0], buildingNumberTokens[1])
+                val (mainBuildingNumber, subBuildingNumber) = when (buildingNumberTokens.size) {
+                    0 -> Pair("", "")
+                    1 -> Pair(buildingNumberTokens[0], "")
+                    else -> Pair(buildingNumberTokens[0], buildingNumberTokens[1])
                 }
                 return BuildingAddress(
                     siDo = siDo,

--- a/app-server/subprojects/bounded_context/quest/domain/src/main/kotlin/club/staircrusher/quest/domain/model/ClubQuest.kt
+++ b/app-server/subprojects/bounded_context/quest/domain/src/main/kotlin/club/staircrusher/quest/domain/model/ClubQuest.kt
@@ -64,9 +64,12 @@ class ClubQuest(
     private fun <T> List<T>.replaced(predicateBlock: (T) -> Boolean, convertBlock: (T) -> T): List<T> {
         val mutableList = this.toMutableList()
         val matchingItemIdx = indexOfFirst(predicateBlock)
-        val newItem = convertBlock(this[matchingItemIdx])
-        mutableList.removeAt(matchingItemIdx)
-        mutableList.add(matchingItemIdx, newItem)
+        if (matchingItemIdx != -1) {
+            val newItem = convertBlock(this[matchingItemIdx])
+            mutableList.removeAt(matchingItemIdx)
+            mutableList.add(matchingItemIdx, newItem)
+        }
+
         return mutableList.toList()
     }
 }


### PR DESCRIPTION
이런 exception 이 떠서 수정합니다

`CrossValidateClubQuestPlacesUseCase`
```
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 12
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at club.staircrusher.quest.domain.model.ClubQuest.replaced(ClubQuest.kt:67)
	at club.staircrusher.quest.domain.model.ClubQuest.setIsClosed(ClubQuest.kt:36)
	at club.staircrusher.quest.application.port.in.CrossValidateClubQuestPlacesUseCase$handle$1$1.invoke(CrossValidateClubQuestPlacesUseCase.kt:45)
```

`KakaoMapsService`
```
java.lang.IndexOutOfBoundsException: Index 3 out of bounds for length 3
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at club.staircrusher.place.infra.adapter.out.web.KakaoMapsService.parseToBuildingAddress(KakaoMapsService.kt:421)
	at club.staircrusher.place.infra.adapter.out.web.KakaoMapsService.convertToModel(KakaoMapsService.kt:250)
```

`NaverMapsService`
```
java.lang.IndexOutOfBoundsException: Empty list doesn't contain element at index 0.
	at kotlin.collections.EmptyList.get(Collections.kt:36)
	at kotlin.collections.EmptyList.get(Collections.kt:24)
	at club.staircrusher.place.infra.adapter.out.web.NaverMapsService$LocalSearchResult$LocalSearchItem.parseToBuildingAddress(NaverMapsService.kt:186)
	at club.staircrusher.place.infra.adapter.out.web.NaverMapsService$LocalSearchResult.convertToModel(NaverMapsService.kt:218)
	at club.staircrusher.place.infra.adapter.out.web.NaverMapsService.findFirstByKeyword(NaverMapsService.kt:114)
	at club.staircrusher.place.infra.adapter.out.web.NaverMapsService$findFirstByKeyword$1.invokeSuspend(NaverMapsService.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
```

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 