### PR TITLE
애플 로그인 오류 수정

### DIFF
--- a/infra/helm/scc-server/files/dev/secret.yaml
+++ b/infra/helm/scc-server/files/dev/secret.yaml
@@ -12,7 +12,7 @@ scc:
         password: ENC[AES256_GCM,data:VyZvo4HRjZw6kQ==,iv:HqFCq6cMeWAb7dBxu9jNgIBOnd/+zWhNpSjCx//g2uk=,tag:cJ203Se2Er4i689pr/Eskw==,type:str]
     apple-login:
         service-id: ENC[AES256_GCM,data:qcEl8fod/ujZNOHgeBAa113rCwh1qK/6vw==,iv:m5MeqNtbCAWHETCTVf+awfHHzzxBAyTPbEsVyqTXOns=,tag:PQSORVWsBCYtCylmWqAX6A==,type:str]
-        client-secret: ENC[AES256_GCM,data:2/cMTQMtgqa+ytIXZR++Zs/OJzEOk15PToyAWMihYlvBLEIMA9jZmcwTUhRLS9GCwXsuNKnRhnZ612SXBsS8HWS4kGUh9wu0FsMiQeRe/H6tWg/Uy7VzYiWFh4noTYHLra4uVjQbTjBRDbJHzwUtoXRvIlDQbbHcKdIMunSz+J2G+1MIBN+I4IreZFZYF9GJKVdTz5PruI9K6rnJ4G8Em233jzbe3zUKuk8rrnaPfKLF21Mqe3DVpbT6Jq3Dn4ajSL10OPzLIKgyfwASkTiKD3iaWUprPXep+Gu/tSlX02O5em/9ldeMJwqyzrIgreNWEr6DQtXmudIZgBsHSdwa7vriCFSu2uJPO6HfnZiEwvJwCXXgKh+Vz5InpUK2ctLAAgULMfZOKMO14IlcyD2Q74XYrfMQQSMDVA==,iv:YKzw4B0MvE3/2rX30yi+WLmwDiCw5If2HLICoDv4UC8=,tag:pT3G3yXOTu43jQWywAZRFQ==,type:str]
+        client-secret: ENC[AES256_GCM,data:tbu0VMK8CHOYoVxBncdPKn1Ey8npTOuiYqonprhE0o7zeXpyEcyUNdaXYN/Kgkqm0yqurI1lN5vkYc66Q4BBHwccTO+L4Rp7VF4Xlq1c9s5sGaEVuzS4tfbe/b8+3LTao1C3xtVsojuYgLi0XtxGsXxfwq3Xr8vpwGe9MeQbAY/4KthdO0Lx3U+xmxDECUS1nOqJHAe8FKhZpmHYOEJp3LQg3GNDR1XQWBVmzcTZ2WXdMcd3ntryAhV8JPaMeR5KQTU2IAf00U/jkgjiZUUHPy4dgj2l/gtNX5+uEvTqM54pAOke664I4iIo8ZKFPvxHI5OKM0uU9TldqptPoAngnFXjr2+G0UjKRQKPvq5qT11EyX58TUBEsKVfP1aYZHGxjWPt10OCXPXRoboPXqwabVOdxU5c0SkLbQ==,iv:fGTTW33d6XLUT8QGPJig4sWq85zlt2o3vAqEFK5ZRHQ=,tag:Mnb3n+i+d+sP2h0XtvM0eg==,type:str]
     naver:
         open-api:
             client-id: ENC[AES256_GCM,data:B8f6yx+4YPNcHdl7H+pfqjZPcp4=,iv:q7wiMStGXbqwx0MXTbyK05TUkrtzFaIl/ImssBnPenU=,tag:yrGE8ZA6IfxEKE77y/FQMw==,type:str]
@@ -27,8 +27,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-15T14:42:19Z"
-    mac: ENC[AES256_GCM,data:3C7d5ASb5+4VzbYYT0W7zWtXQgI2f8M6Lla/uEO9pOnXPqz/DAzde9TObHCDZzBLeQqizKYcT+pCvRWyHkE2lgEbwNkrjkzPul3eHQDB5Im6Bs+KPuUqNUxk+1L2JOzq+iQaE+aQyqabLBci07rBTa+6heNMtIjA2QBxJubZM3Y=,iv:8FDmJYkENdQsKbOo6/Cq96icdbm6ieMvuhcRmHbyqpQ=,tag:f0Rrx+8enpCEQ9BBLHlupg==,type:str]
+    lastmodified: "2024-05-09T15:06:29Z"
+    mac: ENC[AES256_GCM,data:DydO4lDzRIVtXYeoQEEfp+9wz5dtGBIybkpPZ572MKUpxH8406bFSiqo4QuXdMzK2KZo2lHv13gHIKuW09KLtCKI+ZWntosFATXLXmOSp51osZ+a/G5AJ2aXtZgtEziT378tMbD7w5KHnVxjmv5CskWRGMCdCrHybgPUPpRxavY=,iv:PMivOBxnPG6jugV5ihmqhjl48af5hvqQS2DHa9Zz4Dw=,tag:4ixuZQyWZFLIHSlKGvSlgg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/infra/helm/scc-server/files/prod/secret.yaml
+++ b/infra/helm/scc-server/files/prod/secret.yaml
@@ -12,7 +12,7 @@ scc:
         password: ENC[AES256_GCM,data:nxQSfCYrS2dpHw==,iv:LYZe//z2/aYVUBqjPPLDEi9TlqlHGaJ8FfhLcYcv2Cs=,tag:g9D/3brOdBmoESFEDiQj6Q==,type:str]
     apple-login:
         service-id: ENC[AES256_GCM,data:F8nBXeM+p22MislU3DmOCFM=,iv:E5XD5VP3/A+X6mxITJTcHADR/ol0SDvjshG84c0PfLY=,tag:9vMWFglvJKQtiX+z6L6btA==,type:str]
-        client-secret: ENC[AES256_GCM,data:pyYcYp9YeamgGUYOcSfDIQ73Sa4DUP4JT00SfY2TWEzxAZI5K0O1kCmg94rfmdTRJT84BlDnjjsJjP6vy3+ms6d9kalRJ9KZctJ1tZSsz8gcCbNFg61HJTtUUzrJIcamLi/4WkkxZ/V6gQvqEmBaZY1rfhbKdEQxy0vPo/V3pCldhgBPpq3QCBSM45jRY9NKVFzZ/U4nbUudEGq8ROk/tqx6ne0TTHJDr8iQh/vjPIq2upNGzMO3xfPhsKoJvABR9dlOCK8qqCKyz/dt8lwkDOYbNMGFUhVlnw2HO68z30BR8uxQkXKwIIfj6YvD8bG06SMwIIdPtXZXu5E84mCiWNDMwIeoe7/L3tJXCEQsUOs4f8eU1XvufTwAobVpATTa6gsztqhu2ASDjkxcdM0=,iv:mYGVshFaT3sAJZIpq4qZtfT7QWISP5N+FYwR4NSJNy4=,tag:ST2HhhnscMojvYcywhBiOA==,type:str]
+        client-secret: ENC[AES256_GCM,data:Q90B5KausBKPCcHmXBneLPrGLjVMKsHJnMA4vRxyyj22S9VK+QPk2iegKNA/1C9exY25gVreSIKCVCLHW6Bp19RCzSQ24K0LKhf/TAtjZF9hjusj42F18TUjvZZShlqOYTvzc00cr3x9hkLvl4NVPkG3JUrky92yQws68QvEdJc28koUPFg0W9WbXPH3jBf4qC02UR2kWsZq6A6QS3DK9um3neXyUDO+LKn9rhOS+gx7yH1V2h8NshFfKTAbGAwATa0goCs76DEYHeurgaVrRpEAtD1xgIB0X0Y6tXLY9byHX1QnfBjrR8JrishMoF+nwL3hfuHGWuJvzhPnhxdrJANGB2rCJngWeEvd/kxGU0yqzoyPhSP8653I+RbkxFP4MlbfEGUY8EQNvTgCi04=,iv:ljfgSzjNGPAxIQ1i3RyZSmR7FzfgB7s4TwWyTM+PoGQ=,tag:t5ojIAG0p35PzyZ5IVbGUA==,type:str]
     naver:
         open-api:
             client-id: ENC[AES256_GCM,data:N7RF7hTgqZiTcTMkXA1UPJHc+GU=,iv:4tCcmOE8y5BORRAFHkg+XkgAr1F+IsqTmFF43t1U51Q=,tag:E/pJGTycWux49/LlW3I/MA==,type:str]
@@ -27,8 +27,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-15T14:43:00Z"
-    mac: ENC[AES256_GCM,data:dX0PDpu/1SMpMqNxwB8Qou9Xqx0TV/vPzpRhF30m7mU5q+bz2T/1rDs4dvi3v2Ila6ant/KRVuULC0hUcl0R4qBM1KSZS6EksnxBuVl8HlGfsiiMevAXkidxfRviNMNLSKBlrmOzEjBc7E+fpiqcTmScw0UdoCWDnxlgs+K75nI=,iv:mHCm4SZ5bzaqU7hfmq0AQnGAGQJuK+iBQuM2aGPQndU=,tag:svgVFtyCsA/4yRGa3x/Y8g==,type:str]
+    lastmodified: "2024-05-09T15:01:40Z"
+    mac: ENC[AES256_GCM,data:9f/CvRVWKHqpDvjvZ3Nqaa8pVnrdxSbV6cz1QPrbbe9Ljhck2Dl69xQ6oHNlNEdwshAprhX2wnhRVqmA9fLR23bme8BJBBOaWlSmGK7YJ9kuF8ky6DPnppnNryzphmvY48Q4q0s5UgytBPp4y0pvLeK72mpA63a+U0oAcvHFr8I=,iv:D5bcXqTQrTlap1R4XI9Iu+fQC2UkZzg9PELLm8kqJko=,tag:o9mva91No64zcSD4wQqwNg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1


### PR DESCRIPTION
- client-secret (서버에서 애플 로그인 서버로 요청을 보낼 때 함께 보내는 jwt)가 만료되어서 요청이 거부되고 있었고
- 다시 갱신한 jwt 로 바꿔줍니다
- 까먹기 쉬운 것 같아서 이걸 자동을 갱신되게 하거나 노티를 주는 어떤 프로세스를 만들어야 할듯..?

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 