### PR TITLE
퀘스트 리팩토링 2 - VO -> entity 마이그레이션 API 추가

### DIFF
--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/ClubQuestMigrateEntitiesUseCase.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/ClubQuestMigrateEntitiesUseCase.kt
@@ -1,0 +1,53 @@
+package club.staircrusher.quest.application.port.`in`
+
+import club.staircrusher.quest.application.port.out.persistence.ClubQuestRepository
+import club.staircrusher.quest.application.port.out.persistence.ClubQuestTargetBuildingRepository
+import club.staircrusher.quest.application.port.out.persistence.ClubQuestTargetPlaceRepository
+import club.staircrusher.quest.domain.model.ClubQuestTargetBuilding
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionManager
+
+@Component
+class ClubQuestMigrateEntitiesUseCase(
+    private val transactionManager: TransactionManager,
+    private val clubQuestRepository: ClubQuestRepository,
+    private val clubQuestTargetBuildingRepository: ClubQuestTargetBuildingRepository,
+    private val clubQuestTargetPlaceRepository: ClubQuestTargetPlaceRepository,
+) {
+    fun handle() {
+        val allClubQuestIds = transactionManager.doInTransaction {
+            clubQuestRepository.findAllOrderByCreatedAtDesc().map { it.id }
+        }
+        allClubQuestIds.forEach { clubQuestId ->
+            transactionManager.doInTransaction {
+                val clubQuest = clubQuestRepository.findById(clubQuestId)
+                val targetBuildings = clubQuest.targetBuildings
+                    .map { ClubQuestTargetBuilding.of(valueObject = it, clubQuestId = clubQuest.id) }
+                    .map { newTargetBuilding ->
+                        val existingTargetBuilding = clubQuestTargetBuildingRepository.findByClubQuestIdAndBuildingId(
+                            clubQuestId = clubQuest.id,
+                            buildingId = newTargetBuilding.buildingId,
+                        )
+                        existingTargetBuilding ?: newTargetBuilding
+                    }
+                val targetPlaces = targetBuildings
+                    .flatMap { it.places }
+                    .map { newTargetPlace ->
+                        val existingTargetPlace = clubQuestTargetPlaceRepository.findByClubQuestIdAndPlaceId(
+                            clubQuestId = clubQuest.id,
+                            placeId = newTargetPlace.placeId,
+                        )
+                        if (existingTargetPlace != null) {
+                            existingTargetPlace.setIsClosed(newTargetPlace.isClosed)
+                            existingTargetPlace.setIsNotAccessible(newTargetPlace.isNotAccessible)
+                            existingTargetPlace
+                        } else {
+                            newTargetPlace
+                        }
+                    }
+                clubQuestTargetBuildingRepository.saveAll(targetBuildings)
+                clubQuestTargetPlaceRepository.saveAll(targetPlaces)
+            }
+        }
+    }
+}

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
@@ -10,6 +10,7 @@ import club.staircrusher.admin_api.spec.dto.ClubQuestsGet200ResponseInner
 import club.staircrusher.admin_api.spec.dto.CreateClubQuestRequest
 import club.staircrusher.admin_api.spec.dto.CreateClubQuestResponseDTO
 import club.staircrusher.quest.application.port.`in`.ClubQuestCreateAplService
+import club.staircrusher.quest.application.port.`in`.ClubQuestMigrateEntitiesUseCase
 import club.staircrusher.quest.application.port.`in`.ClubQuestSetIsClosedUseCase
 import club.staircrusher.quest.application.port.`in`.ClubQuestSetIsNotAccessibleUseCase
 import club.staircrusher.quest.application.port.`in`.CrossValidateClubQuestPlacesUseCase
@@ -36,6 +37,7 @@ class AdminClubQuestController(
     private val deleteClubQuestUseCase: DeleteClubQuestUseCase,
     private val clubQuestRepository: ClubQuestRepository,
     private val crossValidateClubQuestPlacesUseCase: CrossValidateClubQuestPlacesUseCase,
+    private val clubQuestMigrateEntitiesUseCase: ClubQuestMigrateEntitiesUseCase,
 ) {
     @GetMapping("/admin/clubQuests")
     fun listClubQuests(): List<ClubQuestsGet200ResponseInner> {
@@ -108,5 +110,10 @@ class AdminClubQuestController(
     @PutMapping("/admin/clubQuests/{clubQuestId}/crossValidate")
     fun crossValidate(@PathVariable clubQuestId: String) {
         return crossValidateClubQuestPlacesUseCase.handle(clubQuestId)
+    }
+
+    @PutMapping("/admin/clubQuests/migrateEntities")
+    fun migrateEntities() {
+        return clubQuestMigrateEntitiesUseCase.handle()
     }
 }


### PR DESCRIPTION
## Checklist
- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- #291 에 이어서, VO -> entity 마이그레이션 API를 추가합니다. 쿼리로 하려다가 약간 복잡해서 걍 API를 하나 추가하고 직접 호출한 뒤 API를 삭제하려고 합니다.
  1. 퀘스트 장소 엔티티 도입 & dual write 로직을 넣고 배포 <- #291
  2. 기존 퀘스트 통짜 json 데이터 -> 퀘스트 장소 엔티티 마이그레이션 (수동으로 진행) <- 이 PR
  3. 모든 퀘스트 read를 퀘스트 장소 엔티티를 보도록 수정 <- #301
  4. 퀘스트에서 기존에 통짜 json으로 저장하던 로직 제거 (배포 도중 퀘스트 테이블에 대한 mutation이 없다는 가정 하에 3번 작업과 동시에 진행 가능) <- #301
- #291 로 인해 dual write이 올바르게 수행했는지를 아래 쿼리로 확인해보았습니다.
  ```
  SELECT
      *
  FROM
      club_quest_target_place p
      LEFT JOIN club_quest_place vop ON p.club_quest_id = vop.club_quest_id AND p.place_id = vop.place_id
  WHERE
      ((p.is_closed = vop.is_closed) AND (p.is_not_accessible = vop.is_not_accessible)) IS FALSE
  ```
  확인해보니 지난 주말 퀘스트가 진행된 약 1700개 장소 중에서 1600개 정도는 dual write가 잘 됐고 100개 좀 넘는 건 잘 안 됐는데, CrossValidateClubQuestPlacesUseCase에서 dual write 로직을 누락해서 그런 것으로 확인했습니다. 마이그레이션 전부 다 돌리면 큰 문제 없을 것으로 예상합니다.