### PR TITLE
퀘스트에 폐업 추정 필드 추가

### DIFF
--- a/api-admin/api-spec.yaml
+++ b/api-admin/api-spec.yaml
@@ -460,9 +460,12 @@ components:
         isConquered:
           type: boolean
           description: 장소가 정복됐는지 여부.
+        isClosedExpected:
+          type: boolean
+          description: 장소가 폐업으로 추정되는지 여부.
         isClosed:
           type: boolean
-          description: 장소가 폐업됐는지 여부.
+          description: 장소가 실제로 폐업됐는지 여부.
         isNotAccessible:
           type: boolean
           description: 장소에 접근 가능한지 여부.
@@ -472,6 +475,7 @@ components:
         - placeId
         - buildingId
         - isConquered
+        - isClosedExpected
         - isClosed
         - isNotAccessible
 

--- a/app-server/subprojects/bounded_context/quest/application/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/quest/application/build.gradle.kts
@@ -2,4 +2,9 @@ dependencies {
     implementation(projects.boundedContext.accessibility.application)
     implementation(projects.boundedContext.place.domain)
     implementation(projects.boundedContext.place.application)
+
+    testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+
+    integrationTestImplementation(projects.crossCuttingConcern.test.springIt)
+    integrationTestImplementation("org.springframework.boot:spring-boot-starter-web")
 }

--- a/app-server/subprojects/bounded_context/quest/application/src/integrationTest/kotlin/club/staircrusher/quest/application/port/in/CrossValidateClubQuestPlacesUseCaseTest.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/integrationTest/kotlin/club/staircrusher/quest/application/port/in/CrossValidateClubQuestPlacesUseCaseTest.kt
@@ -1,0 +1,108 @@
+package club.staircrusher.quest.application.port.`in`
+
+import club.staircrusher.place.application.port.out.persistence.PlaceRepository
+import club.staircrusher.quest.application.port.out.persistence.ClubQuestRepository
+import club.staircrusher.quest.application.port.out.persistence.ClubQuestTargetPlaceRepository
+import club.staircrusher.quest.application.port.out.web.ClubQuestTargetPlacesSearcher
+import club.staircrusher.quest.domain.model.ClubQuest
+import club.staircrusher.quest.domain.model.ClubQuestCreateDryRunResultItem
+import club.staircrusher.quest.domain.model.DryRunnedClubQuestTargetBuilding
+import club.staircrusher.quest.domain.model.DryRunnedClubQuestTargetPlace
+import club.staircrusher.stdlib.clock.SccClock
+import club.staircrusher.stdlib.persistence.TransactionManager
+import club.staircrusher.testing.spring_it.ITDataGenerator
+import club.staircrusher.testing.spring_it.base.SccSpringITApplication
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.stub
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+
+@SpringBootTest(classes = [SccSpringITApplication::class], webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CrossValidateClubQuestPlacesUseCaseTest {
+    @Autowired
+    private lateinit var sut: CrossValidateClubQuestPlacesUseCase
+
+    @Autowired
+    private lateinit var transactionManager: TransactionManager
+
+    @Autowired
+    private lateinit var dataGenerator: ITDataGenerator
+
+    @Autowired
+    private lateinit var clubQuestRepository: ClubQuestRepository
+
+    @MockBean
+    private lateinit var clubQuestTargetPlacesSearcher: ClubQuestTargetPlacesSearcher
+
+    @Autowired
+    private lateinit var clubQuestTargetPlaceRepository: ClubQuestTargetPlaceRepository
+
+    @Autowired
+    private lateinit var placeRepository: PlaceRepository
+
+    @Test
+    fun `정상적인 경우`() {
+        val (place1, place2, clubQuest) = transactionManager.doInTransaction {
+            val place1 = dataGenerator.createBuildingAndPlace()
+            val building = place1.building
+            val place2 = dataGenerator.createPlace(building = building)
+            val clubQuest = ClubQuest.of(
+                name = "quest",
+                dryRunResultItem = ClubQuestCreateDryRunResultItem(
+                    questNamePostfix = "1",
+                    questCenterLocation = building.location,
+                    targetBuildings = listOf(
+                        DryRunnedClubQuestTargetBuilding(
+                            buildingId = building.id,
+                            name = building.name ?: "",
+                            location = building.location,
+                            places = listOf(
+                                DryRunnedClubQuestTargetPlace(
+                                    buildingId = building.id,
+                                    placeId = place1.id,
+                                    name = place1.name,
+                                    location = place1.location,
+                                ),
+                                DryRunnedClubQuestTargetPlace(
+                                    buildingId = building.id,
+                                    placeId = place2.id,
+                                    name = place2.name,
+                                    location = place2.location,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                createdAt = SccClock.instant(),
+            )
+            clubQuestRepository.save(clubQuest)
+            Triple(place1, place2, clubQuest)
+        }
+
+        // given - place1은 invalid, place2는 valid
+        // how to mock suspend function: https://github.com/mockito/mockito-kotlin/issues/311#issuecomment-454183020
+        clubQuestTargetPlacesSearcher.stub {
+            onBlocking { crossValidatePlaces(listOf(place1, place2)) }.thenReturn(listOf(false, true))
+        }
+
+        // when
+        sut.handle(clubQuest.id)
+
+        // then - targetPlace1의 isClosedExpected만 true이고, targetPlace2와 place1, place2는 변한 게 없다.
+        transactionManager.doInTransaction {
+            val targetPlaces = clubQuestTargetPlaceRepository.findByClubQuestIdAndPlaceIds(
+                clubQuestId = clubQuest.id,
+                placeIds = listOf(place1.id, place2.id),
+            )
+            assertTrue(targetPlaces.find { it.placeId == place1.id }!!.isClosedExpected)
+            assertFalse(targetPlaces.find { it.placeId == place2.id }!!.isClosedExpected)
+
+            val places = placeRepository.findByIdIn(listOf(place1.id, place2.id))
+            assertFalse(places.find { it.id == place1.id }!!.isClosed)
+            assertFalse(places.find { it.id == place2.id }!!.isClosed)
+        }
+    }
+}

--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/CrossValidateClubQuestPlacesUseCase.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/CrossValidateClubQuestPlacesUseCase.kt
@@ -2,6 +2,7 @@ package club.staircrusher.quest.application.port.`in`
 
 import club.staircrusher.place.application.port.`in`.PlaceApplicationService
 import club.staircrusher.quest.application.port.out.persistence.ClubQuestRepository
+import club.staircrusher.quest.application.port.out.persistence.ClubQuestTargetPlaceRepository
 import club.staircrusher.quest.application.port.out.web.ClubQuestTargetPlacesSearcher
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.persistence.TransactionManager
@@ -15,42 +16,52 @@ class CrossValidateClubQuestPlacesUseCase(
     private val clubQuestRepository: ClubQuestRepository,
     private val clubQuestTargetPlacesSearcher: ClubQuestTargetPlacesSearcher,
     private val placeApplicationService: PlaceApplicationService,
+    private val clubQuestTargetPlaceRepository: ClubQuestTargetPlaceRepository,
 ) {
     @Suppress("MagicNumber")
     private val taskExecutor = Executors.newCachedThreadPool()
 
-    fun handle(questId: String) {
+    fun handleAsync(questId: String) {
         taskExecutor.execute {
-            logger.info("[$questId] Start CrossValidateClubQuestPlaces")
-            try {
-                val places = transactionManager.doInTransaction {
-                    val placeIdsInQuest = clubQuestRepository.findById(questId).targetBuildings.flatMap { it.places }.map { it.placeId }
-                    logger.info("[$questId] placeIdsInQuest: $placeIdsInQuest")
-                    placeApplicationService.findAllByIds(placeIdsInQuest)
-                }
-
-                val closedPlaceIds = runBlocking {
-                    val isNotClosedList = clubQuestTargetPlacesSearcher.crossValidatePlaces(places)
-                    places.zip(isNotClosedList)
-                        .filter { (_, isNotClosed) -> !isNotClosed }
-                        .map { (place, _) -> place.id }
-                }
-                logger.info("[$questId] closedPlaceIds: $closedPlaceIds")
-
-                transactionManager.doInTransaction {
-                    closedPlaceIds.forEach { closedPlaceId ->
-                        try {
-                            placeApplicationService.setIsClosed(closedPlaceId, isClosed = true)
-                        } catch (e: IllegalArgumentException) {
-                            // ignore
-                        }
-                    }
-                }
-            } catch (t: Throwable) {
-                logger.error(t) { "[$questId] CrossValidateClubQuestPlaces failed" }
-            }
-            logger.info("[$questId] Finish CrossValidateClubQuestPlaces")
+            doHandle(questId)
         }
+    }
+
+    fun handle(questId: String) {
+        doHandle(questId)
+    }
+
+    private fun doHandle(questId: String) {
+        logger.info("[$questId] Start CrossValidateClubQuestPlaces")
+        try {
+            val places = transactionManager.doInTransaction {
+                val placeIdsInQuest = clubQuestRepository.findById(questId).targetBuildings.flatMap { it.places }.map { it.placeId }
+                logger.info("[$questId] placeIdsInQuest: $placeIdsInQuest")
+                placeApplicationService.findAllByIds(placeIdsInQuest)
+            }
+
+            val closedExpectedPlaceIds = runBlocking {
+                val isNotClosedList = clubQuestTargetPlacesSearcher.crossValidatePlaces(places)
+                places.zip(isNotClosedList)
+                    .filter { (_, isNotClosed) -> !isNotClosed }
+                    .map { (place, _) -> place.id }
+            }
+            logger.info("[$questId] closedExpectedPlaceIds: $closedExpectedPlaceIds")
+
+            transactionManager.doInTransaction {
+                val targetPlaces = clubQuestTargetPlaceRepository.findByClubQuestIdAndPlaceIds(
+                    clubQuestId = questId,
+                    placeIds = closedExpectedPlaceIds,
+                )
+                targetPlaces.forEach {
+                    it.expectToBeClosed()
+                }
+                clubQuestTargetPlaceRepository.saveAll(targetPlaces)
+            }
+        } catch (t: Throwable) {
+            logger.error(t) { "[$questId] CrossValidateClubQuestPlaces failed" }
+        }
+        logger.info("[$questId] Finish CrossValidateClubQuestPlaces")
     }
 
     companion object {

--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/out/persistence/ClubQuestTargetPlaceRepository.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/out/persistence/ClubQuestTargetPlaceRepository.kt
@@ -5,6 +5,7 @@ import club.staircrusher.stdlib.domain.repository.EntityRepository
 
 interface ClubQuestTargetPlaceRepository : EntityRepository<ClubQuestTargetPlace, String> {
     fun findByClubQuestIdAndPlaceId(clubQuestId: String, placeId: String): ClubQuestTargetPlace?
+    fun findByClubQuestIdAndPlaceIds(clubQuestId: String, placeIds: List<String>): List<ClubQuestTargetPlace>
     fun findByTargetBuildingId(targetBuildingId: String): List<ClubQuestTargetPlace>
     fun removeByClubQuestId(clubQuestId: String)
 }

--- a/app-server/subprojects/bounded_context/quest/domain/src/main/kotlin/club/staircrusher/quest/domain/model/ClubQuestTargetPlace.kt
+++ b/app-server/subprojects/bounded_context/quest/domain/src/main/kotlin/club/staircrusher/quest/domain/model/ClubQuestTargetPlace.kt
@@ -13,6 +13,7 @@ class ClubQuestTargetPlace(
     val placeId: String,
     val name: String,
     val location: Location,
+    isClosedExpected: Boolean,
     createdAt: Instant = SccClock.instant(),
     updatedAt: Instant = SccClock.instant(),
 ) {
@@ -20,6 +21,14 @@ class ClubQuestTargetPlace(
 
     var updatedAt: Instant = updatedAt
         protected set
+
+    var isClosedExpected: Boolean = isClosedExpected
+        protected set
+
+    fun expectToBeClosed() {
+        isClosedExpected = true
+        updatedAt = SccClock.instant()
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -53,6 +62,7 @@ class ClubQuestTargetPlace(
                 placeId = valueObject.placeId,
                 name = valueObject.name,
                 location = valueObject.location,
+                isClosedExpected = false,
             )
         }
     }

--- a/app-server/subprojects/bounded_context/quest/domain/src/main/kotlin/club/staircrusher/quest/domain/model/DryRunnedClubQuestTargetBuilding.kt
+++ b/app-server/subprojects/bounded_context/quest/domain/src/main/kotlin/club/staircrusher/quest/domain/model/DryRunnedClubQuestTargetBuilding.kt
@@ -2,11 +2,6 @@ package club.staircrusher.quest.domain.model
 
 import club.staircrusher.stdlib.geography.Location
 
-// FIXME: rename to DryRunnedClubQuestTargetBuilding after DB column delete
-@Deprecated(
-    "성능 이슈로 인해 별도의 entity로 분리한다.",
-    replaceWith = ReplaceWith("ClubQuestTargetBuilding"),
-)
 data class DryRunnedClubQuestTargetBuilding(
     val buildingId: String,
     val name: String,

--- a/app-server/subprojects/bounded_context/quest/infra/src/integrationTest/kotlin/club/staircrusher/quest/infra/adapter/in/controller/ClubQuestITBase.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/integrationTest/kotlin/club/staircrusher/quest/infra/adapter/in/controller/ClubQuestITBase.kt
@@ -41,6 +41,7 @@ open class ClubQuestITBase : SccSpringITBase() {
                                 name = "placeName",
                                 location = LocationDTO(lng = 127.0, lat = 37.0),
                                 isConquered = false,
+                                isClosedExpected = false,
                                 isClosed = false,
                                 isNotAccessible = false,
                             ),

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
@@ -65,7 +65,7 @@ class AdminClubQuestController(
             dryRunResultItems = request.dryRunResults.map { it.toModel() }
         )
         quests.forEach { quest ->
-            crossValidateClubQuestPlacesUseCase.handle(quest.id)
+            crossValidateClubQuestPlacesUseCase.handleAsync(quest.id)
         }
         return CreateClubQuestResponseDTO(
             clubQuestIds = quests.map { it.id },
@@ -113,6 +113,6 @@ class AdminClubQuestController(
 
     @PutMapping("/admin/clubQuests/{clubQuestId}/crossValidate")
     fun crossValidate(@PathVariable clubQuestId: String) {
-        return crossValidateClubQuestPlacesUseCase.handle(clubQuestId)
+        return crossValidateClubQuestPlacesUseCase.handleAsync(clubQuestId)
     }
 }

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/converter/Converters.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/converter/Converters.kt
@@ -47,6 +47,7 @@ fun DryRunnedClubQuestTargetPlace.toDTO(isConquered: Boolean): ClubQuestTargetPl
         buildingId = buildingId,
         isConquered = isConquered,
         isClosed = false, // DryRunnedClubQuestTargetPlace에는 필요 없는 필드이지만, 프론트엔드 하위호환을 위해 남겨둔다.
+        isClosedExpected = false, // DryRunnedClubQuestTargetPlace에는 필요 없는 필드이지만, 프론트엔드 하위호환을 위해 남겨둔다.
         isNotAccessible = false, // DryRunnedClubQuestTargetPlace에는 필요 없는 필드이지만, 프론트엔드 하위호환을 위해 남겨둔다.
     )
 }
@@ -98,6 +99,7 @@ fun ClubQuestTargetPlace.toDTO(
         placeId = placeId,
         buildingId = buildingId,
         isConquered = isConquered,
+        isClosedExpected = isClosedExpected,
         isClosed = isClosed,
         isNotAccessible = isNotAccessible,
     )

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/persistence/Converters.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/persistence/Converters.kt
@@ -58,6 +58,7 @@ fun ClubQuestTargetPlace.toPersistenceModel() = Club_quest_target_place(
     name = name,
     location_x = location.lng,
     location_y = location.lat,
+    is_closed_expected = isClosedExpected,
     created_at = createdAt.toOffsetDateTime(),
     updated_at = updatedAt.toOffsetDateTime(),
 )
@@ -70,6 +71,7 @@ fun Club_quest_target_place.toDomainModel() = ClubQuestTargetPlace(
     placeId = place_id,
     name = name,
     location = Location(lng = location_x, lat = location_y),
+    isClosedExpected = is_closed_expected,
     createdAt = created_at.toInstant(),
     updatedAt = updated_at.toInstant(),
 )

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/persistence/SqlDelightClubQuestTargetPlaceRepository.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/persistence/SqlDelightClubQuestTargetPlaceRepository.kt
@@ -17,6 +17,15 @@ class SqlDelightClubQuestTargetPlaceRepository(
             ?.toDomainModel()
     }
 
+    override fun findByClubQuestIdAndPlaceIds(
+        clubQuestId: String,
+        placeIds: List<String>
+    ): List<ClubQuestTargetPlace> {
+        return queries.findByClubQuestIdAndPlaceIds(clubQuestId = clubQuestId, placeIds = placeIds)
+            .executeAsList()
+            .map { it.toDomainModel() }
+    }
+
     override fun findByTargetBuildingId(targetBuildingId: String): List<ClubQuestTargetPlace> {
         return queries.findByTargetBuildingId(targetBuildingId = targetBuildingId)
             .executeAsList()

--- a/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/migration/V19__club_quest_target_place_is_closed_expected.sqm
+++ b/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/migration/V19__club_quest_target_place_is_closed_expected.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE club_quest_target_place ADD COLUMN is_closed_expected BOOLEAN NOT NULL DEFAULT FALSE;

--- a/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/quest/ClubQuestTargetPlace.sq
+++ b/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/quest/ClubQuestTargetPlace.sq
@@ -9,6 +9,7 @@ ON CONFLICT(id) DO UPDATE SET
     name = EXCLUDED.name,
     location_x = EXCLUDED.location_x,
     location_y = EXCLUDED.location_y,
+    is_closed_expected = EXCLUDED.is_closed_expected,
     created_at = EXCLUDED.created_at,
     updated_at = EXCLUDED.updated_at;
 
@@ -30,6 +31,13 @@ FROM club_quest_target_place
 WHERE
     club_quest_id = :clubQuestId
     AND place_id = :placeId;
+
+findByClubQuestIdAndPlaceIds:
+SELECT *
+FROM club_quest_target_place
+WHERE
+    club_quest_id = :clubQuestId
+    AND place_id IN :placeIds;
 
 findByClubQuestIds:
 SELECT *


### PR DESCRIPTION
## Checklist
- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- [칸반 카드](https://www.notion.so/agnica/61f7a8498a27410ba4c3929a57312d24)
- 폐업 추정과 폐업 여부를 분리합니다.
  - 네이버 지도 API로 크로스체크해서 폐업 처리를 할 때 폐업 추정으로만 설정합니다.
  - 어드민에 폐업 추정 필드를 내려줍니다.
- 폐업 추정은 장소 도메인이 아니라 퀘스트 도메인에 두었습니다.