### PR TITLE
퀘스트 관리 페이지에서 전체 퀘스트 조회 대신 커서링 방식 사용

### DIFF
--- a/api-admin/api-spec.yaml
+++ b/api-admin/api-spec.yaml
@@ -57,6 +57,31 @@ paths:
                     - id
                     - name
 
+  /clubQuestSummaries/cursored:
+    get:
+      summary: 커서링 방식의 퀘스트 조회 API
+      operationId: getCursoredClubQuestSummaries
+      description: 퀘스트 목록을 커서링 방식으로 조회한다.
+      parameters:
+        - in: query
+          name: cursor
+          schema:
+            type: string
+          required: false
+        - in: query
+          name: limit
+          description: default 값은 50으로 설정된다.
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: 정상적인 경우
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetCursoredClubQuestSummariesResultDTO'
+
   /clubQuests/create/dryRun:
     post:
       summary: 주어진 조건(중심 위치, 반경, 퀘스트 분할 숫자 등)으로 퀘스트를 생성하면 어떻게 생성될지 시뮬레이션하여 미리 확인한다.
@@ -407,6 +432,27 @@ components:
         - questNamePostfix
         - questCenterLocation
         - targetBuildings
+
+    GetCursoredClubQuestSummariesResultDTO:
+      type: object
+      properties:
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClubQuestSummaryDTO'
+        cursor:
+          type: string
+          description: 없으면 다음 페이지가 없다는 의미.
+      required:
+        - list
+
+    ClubQuestSummaryDTO:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
 
     ClubQuestDTO:
       description: 퀘스트.

--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/GetCursoredClubQuestSummariesUseCase.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/in/GetCursoredClubQuestSummariesUseCase.kt
@@ -1,0 +1,76 @@
+package club.staircrusher.quest.application.port.`in`
+
+import club.staircrusher.quest.application.port.out.persistence.ClubQuestRepository
+import club.staircrusher.quest.domain.model.ClubQuestSummary
+import club.staircrusher.stdlib.clock.SccClock
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.domain.SccDomainException
+import club.staircrusher.stdlib.persistence.TransactionManager
+import java.time.Instant
+
+@Component
+class GetCursoredClubQuestSummariesUseCase(
+    private val transactionManager: TransactionManager,
+    private val clubQuestRepository: ClubQuestRepository,
+) {
+    data class Result(
+        val list: List<ClubQuestSummary>,
+        val nextCursor: String?,
+    )
+
+    fun handle(
+        limit: Int?,
+        cursorValue: String?,
+    ): Result = transactionManager.doInTransaction {
+        val cursor = cursorValue?.let { Cursor.parse(it) } ?: Cursor.INITIAL
+        val normalizedLimit = limit ?: DEFAULT_LIMIT
+
+        val summaries = clubQuestRepository.findCursoredSummariesOrderByCreatedAtDesc(
+            cursorCreatedAt = cursor.createdAt,
+            cursorId = cursor.id,
+            limit = normalizedLimit + 1, // 다음 페이지가 존재하는지 확인하기 위해 한 개를 더 조회한다.
+        )
+
+        val nextCursor = if (summaries.size > normalizedLimit) {
+            Cursor(summaries[normalizedLimit - 1])
+        } else {
+            null
+        }
+
+        Result(
+            list = summaries,
+            nextCursor = nextCursor?.value,
+        )
+    }
+
+    private data class Cursor(
+        val id: String,
+        val createdAt: Instant,
+    ) {
+        val value: String = "$id$DELIMITER${createdAt.toEpochMilli()}"
+
+        constructor(summary: ClubQuestSummary) : this(
+            id = summary.id,
+            createdAt = summary.createdAt,
+        )
+
+        companion object {
+            private const val DELIMITER = "__"
+
+            fun parse(cursorValue: String): Cursor {
+                return try {
+                    val (id, createdAtMillis) = cursorValue.split(DELIMITER)
+                    Cursor(id = id, createdAt = Instant.ofEpochMilli(createdAtMillis.toLong()))
+                } catch (t: Throwable) {
+                    throw SccDomainException("Invalid cursor value: $cursorValue", cause = t)
+                }
+            }
+
+            val INITIAL = Cursor(id = "", createdAt = SccClock.instant())
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_LIMIT = 50
+    }
+}

--- a/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/out/persistence/ClubQuestRepository.kt
+++ b/app-server/subprojects/bounded_context/quest/application/src/main/kotlin/club/staircrusher/quest/application/port/out/persistence/ClubQuestRepository.kt
@@ -1,10 +1,17 @@
 package club.staircrusher.quest.application.port.out.persistence
 
 import club.staircrusher.quest.domain.model.ClubQuest
+import club.staircrusher.quest.domain.model.ClubQuestSummary
 import club.staircrusher.stdlib.domain.repository.EntityRepository
+import java.time.Instant
 
 interface ClubQuestRepository : EntityRepository<ClubQuest, String> {
     fun findAllOrderByCreatedAtDesc(): List<ClubQuest>
+    fun findCursoredSummariesOrderByCreatedAtDesc(
+        cursorCreatedAt: Instant,
+        cursorId: String,
+        limit: Int
+    ): List<ClubQuestSummary>
 
     fun remove(clubQuestId: String)
 }

--- a/app-server/subprojects/bounded_context/quest/domain/src/main/kotlin/club/staircrusher/quest/domain/model/ClubQuestSummary.kt
+++ b/app-server/subprojects/bounded_context/quest/domain/src/main/kotlin/club/staircrusher/quest/domain/model/ClubQuestSummary.kt
@@ -1,0 +1,9 @@
+package club.staircrusher.quest.domain.model
+
+import java.time.Instant
+
+data class ClubQuestSummary(
+    val id: String,
+    val name: String,
+    val createdAt: Instant,
+)

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
@@ -62,7 +62,7 @@ class AdminClubQuestController(
         ).run {
             GetCursoredClubQuestSummariesResultDTO(
                 list = list.map { it.toDTO() },
-                cursor = cursor,
+                cursor = nextCursor,
             )
         }
     }

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/controller/AdminClubQuestController.kt
@@ -9,12 +9,14 @@ import club.staircrusher.admin_api.spec.dto.ClubQuestsCreateDryRunPostRequest
 import club.staircrusher.admin_api.spec.dto.ClubQuestsGet200ResponseInner
 import club.staircrusher.admin_api.spec.dto.CreateClubQuestRequest
 import club.staircrusher.admin_api.spec.dto.CreateClubQuestResponseDTO
+import club.staircrusher.admin_api.spec.dto.GetCursoredClubQuestSummariesResultDTO
 import club.staircrusher.quest.application.port.`in`.ClubQuestCreateAplService
 import club.staircrusher.quest.application.port.`in`.ClubQuestSetIsClosedUseCase
 import club.staircrusher.quest.application.port.`in`.ClubQuestSetIsNotAccessibleUseCase
 import club.staircrusher.quest.application.port.`in`.CrossValidateClubQuestPlacesUseCase
 import club.staircrusher.quest.application.port.`in`.DeleteClubQuestUseCase
 import club.staircrusher.quest.application.port.`in`.GetClubQuestUseCase
+import club.staircrusher.quest.application.port.`in`.GetCursoredClubQuestSummariesUseCase
 import club.staircrusher.quest.application.port.out.persistence.ClubQuestRepository
 import club.staircrusher.quest.infra.adapter.`in`.converter.toDTO
 import club.staircrusher.quest.infra.adapter.`in`.converter.toModel
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -36,6 +39,7 @@ class AdminClubQuestController(
     private val deleteClubQuestUseCase: DeleteClubQuestUseCase,
     private val clubQuestRepository: ClubQuestRepository,
     private val crossValidateClubQuestPlacesUseCase: CrossValidateClubQuestPlacesUseCase,
+    private val getCursoredClubQuestSummariesUseCase: GetCursoredClubQuestSummariesUseCase,
 ) {
     @GetMapping("/admin/clubQuests")
     fun listClubQuests(): List<ClubQuestsGet200ResponseInner> {
@@ -43,6 +47,22 @@ class AdminClubQuestController(
             ClubQuestsGet200ResponseInner(
                 id = it.id,
                 name = it.name,
+            )
+        }
+    }
+
+    @GetMapping("/admin/clubQuestSummaries/cursored")
+    fun getCursoredClubQuestSummaries(
+        @RequestParam(required = false) limit: Int?,
+        @RequestParam(required = false) cursor: String?,
+    ): GetCursoredClubQuestSummariesResultDTO {
+        return getCursoredClubQuestSummariesUseCase.handle(
+            limit = limit,
+            cursorValue = cursor
+        ).run {
+            GetCursoredClubQuestSummariesResultDTO(
+                list = list.map { it.toDTO() },
+                cursor = cursor,
             )
         }
     }

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/converter/Converters.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/in/converter/Converters.kt
@@ -4,11 +4,13 @@ import club.staircrusher.admin_api.converter.toDTO
 import club.staircrusher.admin_api.converter.toModel
 import club.staircrusher.admin_api.spec.dto.ClubQuestCreateDryRunResultItemDTO
 import club.staircrusher.admin_api.spec.dto.ClubQuestDTO
+import club.staircrusher.admin_api.spec.dto.ClubQuestSummaryDTO
 import club.staircrusher.admin_api.spec.dto.ClubQuestTargetBuildingDTO
 import club.staircrusher.admin_api.spec.dto.ClubQuestTargetPlaceDTO
 import club.staircrusher.place.domain.model.Place
 import club.staircrusher.quest.application.port.`in`.ClubQuestWithDtoInfo
 import club.staircrusher.quest.domain.model.ClubQuestCreateDryRunResultItem
+import club.staircrusher.quest.domain.model.ClubQuestSummary
 import club.staircrusher.quest.domain.model.ClubQuestTargetBuilding
 import club.staircrusher.quest.domain.model.DryRunnedClubQuestTargetBuilding
 import club.staircrusher.quest.domain.model.ClubQuestTargetPlace
@@ -104,3 +106,8 @@ fun ClubQuestTargetPlace.toDTO(
         isNotAccessible = isNotAccessible,
     )
 }
+
+fun ClubQuestSummary.toDTO() = ClubQuestSummaryDTO(
+    id = id,
+    name = name,
+)

--- a/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/persistence/SqlDelightClubQuestRepository.kt
+++ b/app-server/subprojects/bounded_context/quest/infra/src/main/kotlin/club/staircrusher/quest/infra/adapter/out/persistence/SqlDelightClubQuestRepository.kt
@@ -5,7 +5,10 @@ import club.staircrusher.infra.persistence.sqldelight.migration.Club_quest
 import club.staircrusher.quest.application.port.out.persistence.ClubQuestRepository
 import club.staircrusher.quest.application.port.out.persistence.ClubQuestTargetBuildingRepository
 import club.staircrusher.quest.domain.model.ClubQuest
+import club.staircrusher.quest.domain.model.ClubQuestSummary
 import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.time.toOffsetDateTime
+import java.time.Instant
 
 @Component
 class SqlDelightClubQuestRepository(
@@ -44,6 +47,22 @@ class SqlDelightClubQuestRepository(
         return clubQuestQueries.findAllOrderByCreatedAtDesc()
             .executeAsList()
             .map { it.toDomainModel() }
+    }
+
+    override fun findCursoredSummariesOrderByCreatedAtDesc(
+        cursorCreatedAt: Instant,
+        cursorId: String,
+        limit: Int
+    ): List<ClubQuestSummary> {
+        return clubQuestQueries.findCursoredSummariesOrderByCreatedAtDesc(
+            cursorCreatedAt = cursorCreatedAt.toOffsetDateTime(),
+            cursorId = cursorId,
+            limit = limit.toLong(),
+        )
+            .executeAsList()
+            .map {
+                ClubQuestSummary(id = it.id, name = it.name, createdAt = it.created_at.toInstant())
+            }
     }
 
     override fun remove(clubQuestId: String) {

--- a/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/accessibility/PlaceAccessibility.sq
+++ b/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/accessibility/PlaceAccessibility.sq
@@ -84,7 +84,7 @@ WHERE
         OR (pa.created_at < :cursorCreatedAt)
     )
     AND pa.deleted_at IS NULL
-ORDER BY pa.created_at DESC
+ORDER BY pa.created_at DESC, pa.id DESC
 LIMIT :limit;
 
 countAll:

--- a/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/quest/ClubQuest.sq
+++ b/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/sqldelight/club/staircrusher/infra/persistence/sqldelight/query/quest/ClubQuest.sq
@@ -25,3 +25,15 @@ findAllOrderByCreatedAtDesc:
 SELECT *
 FROM club_quest
 ORDER BY created_at DESC;
+
+findCursoredSummariesOrderByCreatedAtDesc:
+SELECT id, name, created_at
+FROM club_quest
+WHERE
+    1 = 1
+    AND (
+        (created_at = :cursorCreatedAt AND id < :cursorId)
+        OR (created_at < :cursorCreatedAt)
+    )
+ORDER BY created_at DESC, id DESC
+LIMIT :limit;


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- 제곧내입니다. 해당 페이지 로딩이 점점 무거워지네요 ㅜ