### PR TITLE
docker compose version 태그 없애기

### DIFF
--- a/app-server/docker-compose.yml
+++ b/app-server/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 name: scc
 
 services:


### PR DESCRIPTION
- deprecated 되었고, 그거에 따르지도 않는다고 하네요
- 대신 해당 schema 를 파싱할 수 있는 가장 최신 버전을 사용한다고 합니다
- 테스트 하다가 터미널 창에 워닝 뜨길래 거슬려서 지웁니다
- https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 