### PR TITLE
Replace 할 s3 domain 수정

### DIFF
--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/cdn/SccCdn.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/cdn/SccCdn.kt
@@ -26,7 +26,7 @@ open class SccCdn(
     }
 
     companion object {
-        private const val S3_DOMAIN = "s3.amazonaws.com/"
+        private const val S3_DOMAIN = "amazonaws.com/"
 
         fun replaceIfPossible(url: String): String {
             val globalSccCdn = SccCdnBeanHolder.get()


### PR DESCRIPTION
- 데이터를 확인해보니 image url 이 `https://{bucket}.s3.ap-northeast-2.amazonaws.com/{object_key}` 의 형태로 들어가 있어서 수정합니다

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 