### PR TITLE
Pod limit 추가하기

### DIFF
--- a/infra/helm/scc-admin-frontend/values-dev.yaml
+++ b/infra/helm/scc-admin-frontend/values-dev.yaml
@@ -67,6 +67,9 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
+  limits:
+    cpu: 50m
+    memory: 64Mi
 
 autoscaling:
   enabled: false

--- a/infra/helm/scc-admin-frontend/values-prod.yaml
+++ b/infra/helm/scc-admin-frontend/values-prod.yaml
@@ -58,6 +58,9 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
+  limits:
+    cpu: 50m
+    memory: 64Mi
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/infra/helm/scc-server/values-dev.yaml
+++ b/infra/helm/scc-server/values-dev.yaml
@@ -75,6 +75,9 @@ resources:
   requests:
     cpu: 500m
     memory: 1Gi
+  limits:
+    cpu: 500m
+    memory: 1Gi
 
 autoscaling:
   enabled: false

--- a/infra/helm/scc-server/values-prod.yaml
+++ b/infra/helm/scc-server/values-prod.yaml
@@ -64,6 +64,10 @@ resources:
   requests:
     cpu: 500m
     memory: 1Gi
+  limits:
+    cpu: 500m
+    memory: 1Gi
+
 autoscaling:
   enabled: true
   minReplicas: 2


### PR DESCRIPTION
- 왠지 모를 이유로 Node 가 cpu 100 을 찍고 Not ready 가 되어서 팟에 limit 을 걸어줍니다 (의심하는 것은 썸네일 생성 후 gc 가 빡세게 돌았다)
- 이와 별개로 monitoring 지표도 고도화해야 더 정확한 원인 파악이 가능할듯

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 