### PR TITLE
Pod limit 설정 업데이트

### DIFF
--- a/infra/helm/scc-admin-frontend/values-dev.yaml
+++ b/infra/helm/scc-admin-frontend/values-dev.yaml
@@ -66,10 +66,10 @@ resources:
   #   memory: 128Mi
   requests:
     cpu: 50m
-    memory: 64Mi
+    memory: 1Gi
   limits:
     cpu: 50m
-    memory: 64Mi
+    memory: 1Gi
 
 autoscaling:
   enabled: false

--- a/infra/helm/scc-admin-frontend/values-prod.yaml
+++ b/infra/helm/scc-admin-frontend/values-prod.yaml
@@ -57,10 +57,10 @@ resources:
   #   memory: 128Mi
   requests:
     cpu: 50m
-    memory: 64Mi
+    memory: 1Gi
   limits:
     cpu: 50m
-    memory: 64Mi
+    memory: 1Gi
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
- 지표를 보니까 admin-frontend 팟이 평상시에도 약 700 MB 정도 쓰고 있어서 상향합니다
- request 가 너무 작게 잡혀있었네요

![image](https://github.com/Stair-Crusher-Club/scc-server/assets/43549670/b31c0955-8d52-4d1d-99c1-0270d3dc0c94)


## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 