### PR TITLE
Startup Probe 제대로 설정하기

### DIFF
--- a/infra/helm/scc-server/templates/deployment.yaml
+++ b/infra/helm/scc-server/templates/deployment.yaml
@@ -66,7 +66,8 @@ spec:
               path: /readyz
               port: http
           startupProbe:
-            initialDelaySeconds: 30
+            failureThreshold: 12
+            periodSeconds: 10
             httpGet:
               path: /readyz
               port: http


### PR DESCRIPTION
- 일단 급해서 initialDelaySeconds 넣었는데
- 공식 [문서](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes)를 보니 startup probe 를 제대로 설정하는 법은 따로 있는 것 같아서 다시 설정합니다
- 이 설정에 따르면 최대 2분 (12 * 10 초) 내에 한번이라도 startup probe 에 성공하면, 그제서야 liveless probe 와 readiness probe 를 하기 시작하고
- 그 이전에 2분동안 startup probe 가 실패하면 팟을 kill 합니다

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 