### PR TITLE
정복 리포트 로직 & 테스트 수정

### DIFF
--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/GetAccessibilityActivityReportUseCase.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/GetAccessibilityActivityReportUseCase.kt
@@ -3,9 +3,6 @@ package club.staircrusher.accessibility.application.port.`in`
 import club.staircrusher.stdlib.clock.SccClock
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.time.getDayOfWeek
-import club.staircrusher.stdlib.time.toEndOfDay
-import club.staircrusher.stdlib.time.toEndOfMonth
-import club.staircrusher.stdlib.time.toEndOfWeek
 import club.staircrusher.stdlib.time.toStartOfDay
 import club.staircrusher.stdlib.time.toStartOfMonth
 import club.staircrusher.stdlib.time.toStartOfWeek
@@ -18,13 +15,13 @@ class GetAccessibilityActivityReportUseCase(
     fun handle(request: Request): Response {
         val now = SccClock.instant()
         val todayConqueredCount = accessibilityApplicationService.countByUserIdAndCreatedAtBetween(
-            userId = request.userId, from = now.toStartOfDay(), to = now.toEndOfDay()
+            userId = request.userId, from = now.toStartOfDay(), to = now
         )
         val thisMonthConqueredCount = accessibilityApplicationService.countByUserIdAndCreatedAtBetween(
-            userId = request.userId, from = now.toStartOfMonth(), to = now.toEndOfMonth()
+            userId = request.userId, from = now.toStartOfMonth(), to = now
         )
         val (placeAccessibilities, buildingAccessibilities) = accessibilityApplicationService.findByUserIdAndCreatedAtBetween(
-            userId = request.userId, from = now.toStartOfWeek(), to = now.toEndOfWeek()
+            userId = request.userId, from = now.toStartOfWeek(), to = now
         )
         val createdAts = placeAccessibilities.map { it.createdAt }.plus(buildingAccessibilities.map { it.createdAt })
         return Response(

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityActivityReportTest.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityActivityReportTest.kt
@@ -2,21 +2,24 @@ package club.staircrusher.accesssibility.infra.adapter.`in`.controller
 
 import club.staircrusher.api.spec.dto.DayOfWeek
 import club.staircrusher.api.spec.dto.GetAccessibilityActivityReportResponseDto
-import club.staircrusher.stdlib.clock.SccClock
 import club.staircrusher.stdlib.time.getDayOfMonth
 import club.staircrusher.stdlib.time.toEndOfMonth
 import club.staircrusher.stdlib.time.toStartOfMonth
 import club.staircrusher.stdlib.time.toStartOfWeek
 import club.staircrusher.testing.spring_it.base.SccSpringITBase
+import club.staircrusher.testing.spring_it.mock.MockSccClock
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import java.time.temporal.ChronoUnit
 
 class GetAccessibilityActivityReportTest : SccSpringITBase() {
+    @Autowired
+    lateinit var clock: MockSccClock
 
     @Test
     fun `오늘, 이번달, 이번주 정복량을 내려준다`() {
-        val now = SccClock.instant()
+        val now = clock.instant()
         val startDayOfThisMonth = now.toStartOfMonth()
         val lastDayOfThisMonth = now.toEndOfMonth()
 

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityActivityReportTest.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityActivityReportTest.kt
@@ -18,14 +18,13 @@ class GetAccessibilityActivityReportTest : SccSpringITBase() {
     fun `오늘, 이번달, 이번주 정복량을 내려준다`() {
         val now = SccClock.instant()
         val startDayOfThisMonth = now.toStartOfMonth()
-
         val lastDayOfThisMonth = now.toEndOfMonth()
 
         val user = transactionManager.doInTransaction { testDataGenerator.createUser() }
-        transactionManager.doInTransaction {
-            // 매일 12시에 1개씩 등록
-            return@doInTransaction (0 until lastDayOfThisMonth.getDayOfMonth()).map { index ->
-                val createdAt = startDayOfThisMonth.plus(12L + index * 24L, ChronoUnit.HOURS)
+        (0 until lastDayOfThisMonth.getDayOfMonth()).map { index ->
+            // 매일 오후 6시에 1개씩 등록
+            transactionManager.doInTransaction {
+                val createdAt = startDayOfThisMonth.plus(18L + index * 24L, ChronoUnit.HOURS)
                 val place = testDataGenerator.createBuildingAndPlace()
                 val placeAccessibility =
                     testDataGenerator.registerPlaceAccessibility(place = place, user = user, at = createdAt)
@@ -35,7 +34,7 @@ class GetAccessibilityActivityReportTest : SccSpringITBase() {
                         user = user,
                         at = createdAt
                     )
-                return@map placeAccessibility to buildingAccessibility
+                return@doInTransaction placeAccessibility to buildingAccessibility
             }
         }
         val result = mvc

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/MockSccClock.kt
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/MockSccClock.kt
@@ -33,6 +33,10 @@ class MockSccClock private constructor() : SccClock() {
         instant = Instant.now()
     }
 
+    fun setTime(newInstant: Instant) {
+        instant = newInstant
+    }
+
     companion object {
         private lateinit var instance: MockSccClock
         private val monitor = Any()


### PR DESCRIPTION
- 테스트에서 이번달 전체에 대해서 매일 12시에 장소 정복을 하도록 테스트에서 세팅했는데,
- 실제 구현 로직에서 이번 주 마지막 날, 이번 달 마지막 날 등을 createdAt 의 쿼리 조건으로 넣어서 모든 데이터를 다 가져왔습니다
- 실제 앱에서는 createdAt 이 미래인 데이터가 없을테니 문제가 안되고 테스트에서만 터짐

## Checklist
- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 