### PR TITLE
[서버 이벤트] 데이터 중복 제거

### DIFF
--- a/app-server/subprojects/cross_cutting_concern/application/server_event/src/main/kotlin/club/staircrusher/application/server_event/port/in/SccServerPersistentEventRecorder.kt
+++ b/app-server/subprojects/cross_cutting_concern/application/server_event/src/main/kotlin/club/staircrusher/application/server_event/port/in/SccServerPersistentEventRecorder.kt
@@ -20,7 +20,7 @@ class SccServerPersistentEventRecorder(
         val serverEvent = try {
             ServerEvent(
                 id = EntityIdGenerator.generateRandom(),
-                type = payload.type,
+                type = payload.getType(),
                 payload = payload,
                 createdAt = SccClock.instant(),
             )

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/NewsletterSubscribedOnSignupPayload.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/NewsletterSubscribedOnSignupPayload.kt
@@ -3,5 +3,5 @@ package club.staircrusher.domain.server_event
 data class NewsletterSubscribedOnSignupPayload(
     val userId: String,
 ) : ServerEventPayload {
-    override val type = ServerEventType.NEWSLETTER_SUBSCRIBED_ON_SIGN_UP
+    override fun getType() = ServerEventType.NEWSLETTER_SUBSCRIBED_ON_SIGN_UP
 }

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEvent.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEvent.kt
@@ -9,6 +9,6 @@ data class ServerEvent(
     val createdAt: Instant,
 ) {
     init {
-        check(type == payload.type)
+        check(type == payload.getType())
     }
 }

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEventPayload.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEventPayload.kt
@@ -1,5 +1,5 @@
 package club.staircrusher.domain.server_event
 
 interface ServerEventPayload {
-    val type: ServerEventType
+    fun getType(): ServerEventType
 }


### PR DESCRIPTION
- babo issue 로 그냥 print 찍어봤을 때 안나와서 val 로 냅뒀는데
- json 으로 변현될 때 constructor 에 없는 val 도 포함되기 때문에 메소드로 수정합니다

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 