### PR TITLE
서버 이벤트 저장할 때 type 이 두번 들어가지 않도록 하기

### DIFF
--- a/app-server/subprojects/cross_cutting_concern/application/server_event/src/main/kotlin/club/staircrusher/application/server_event/port/in/SccServerPersistentEventRecorder.kt
+++ b/app-server/subprojects/cross_cutting_concern/application/server_event/src/main/kotlin/club/staircrusher/application/server_event/port/in/SccServerPersistentEventRecorder.kt
@@ -20,7 +20,7 @@ class SccServerPersistentEventRecorder(
         val serverEvent = try {
             ServerEvent(
                 id = EntityIdGenerator.generateRandom(),
-                type = payload.type(),
+                type = payload.type,
                 payload = payload,
                 createdAt = SccClock.instant(),
             )

--- a/app-server/subprojects/cross_cutting_concern/application/server_event/src/main/kotlin/club/staircrusher/application/server_event/port/in/SccServerPersistentEventRecorder.kt
+++ b/app-server/subprojects/cross_cutting_concern/application/server_event/src/main/kotlin/club/staircrusher/application/server_event/port/in/SccServerPersistentEventRecorder.kt
@@ -20,7 +20,7 @@ class SccServerPersistentEventRecorder(
         val serverEvent = try {
             ServerEvent(
                 id = EntityIdGenerator.generateRandom(),
-                type = payload.getType(),
+                type = payload.type(),
                 payload = payload,
                 createdAt = SccClock.instant(),
             )

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/build.gradle.kts
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/build.gradle.kts
@@ -2,6 +2,9 @@ dependencies {
     val kotlinxSerializationVersion: String by project
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 
+    val jacksonModuleKotlinVersion: String by project
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonModuleKotlinVersion")
+
     val jUnitJupiterVersion: String by project
     testImplementation("org.junit.jupiter:junit-jupiter-api:$jUnitJupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jUnitJupiterVersion")

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/NewsletterSubscribedOnSignupPayload.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/NewsletterSubscribedOnSignupPayload.kt
@@ -3,5 +3,5 @@ package club.staircrusher.domain.server_event
 data class NewsletterSubscribedOnSignupPayload(
     val userId: String,
 ) : ServerEventPayload {
-    override fun type() = ServerEventType.NEWSLETTER_SUBSCRIBED_ON_SIGN_UP
+    override val type = ServerEventType.NEWSLETTER_SUBSCRIBED_ON_SIGN_UP
 }

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/NewsletterSubscribedOnSignupPayload.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/NewsletterSubscribedOnSignupPayload.kt
@@ -3,5 +3,5 @@ package club.staircrusher.domain.server_event
 data class NewsletterSubscribedOnSignupPayload(
     val userId: String,
 ) : ServerEventPayload {
-    override fun getType() = ServerEventType.NEWSLETTER_SUBSCRIBED_ON_SIGN_UP
+    override fun type() = ServerEventType.NEWSLETTER_SUBSCRIBED_ON_SIGN_UP
 }

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEvent.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEvent.kt
@@ -9,6 +9,6 @@ data class ServerEvent(
     val createdAt: Instant,
 ) {
     init {
-        check(type == payload.getType())
+        check(type == payload.type())
     }
 }

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEvent.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEvent.kt
@@ -9,6 +9,6 @@ data class ServerEvent(
     val createdAt: Instant,
 ) {
     init {
-        check(type == payload.type())
+        check(type == payload.type)
     }
 }

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEventPayload.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEventPayload.kt
@@ -1,6 +1,8 @@
 package club.staircrusher.domain.server_event
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+
 interface ServerEventPayload {
-    // getType 으로 이름을 붙이면 jackson 에서 getter 로 인식하면서 함께 직렬화가 된다
-    fun type(): ServerEventType
+    @get:JsonIgnore
+    val type: ServerEventType
 }

--- a/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEventPayload.kt
+++ b/app-server/subprojects/cross_cutting_concern/domain/server_event/src/main/kotlin/club/staircrusher/domain/server_event/ServerEventPayload.kt
@@ -1,5 +1,6 @@
 package club.staircrusher.domain.server_event
 
 interface ServerEventPayload {
-    fun getType(): ServerEventType
+    // getType 으로 이름을 붙이면 jackson 에서 getter 로 인식하면서 함께 직렬화가 된다
+    fun type(): ServerEventType
 }


### PR DESCRIPTION
- 증상 슬랙 [링크](https://agnica-coworkingspace.slack.com/archives/C0515M1HMFG/p1721315643691999)
- type 이 칼럼에 있는데 payload 에 json 형식으로도 들어가고 있어서 제외해줍니다

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 