### PR TITLE
[Fix] JPA Attribute converter 에서 null 케이스 처리하기

### DIFF
--- a/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/jpa/ListToTextAttributeConverter.kt
+++ b/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/jpa/ListToTextAttributeConverter.kt
@@ -11,7 +11,10 @@ abstract class ListToTextAttributeConverter<E> : AttributeConverter<List<E>, Str
         return attribute.joinToString(LEGACY_DELIMITER) { convertElementToTextColumn(it) }
     }
 
-    override fun convertToEntityAttribute(column: String): List<E> {
+    override fun convertToEntityAttribute(column: String?): List<E> {
+        if (column == null) {
+            return emptyList()
+        }
         return try {
             convertJsonColumnToEntityAttribute(column)
         } catch (e: JsonProcessingException) {

--- a/app-server/subprojects/cross_cutting_concern/stdlib/src/unitTest/kotlin/club/staircrusher/stdlib/persistence/ListToTextAttributeConverterUT.kt
+++ b/app-server/subprojects/cross_cutting_concern/stdlib/src/unitTest/kotlin/club/staircrusher/stdlib/persistence/ListToTextAttributeConverterUT.kt
@@ -3,6 +3,7 @@ package club.staircrusher.stdlib.persistence
 import club.staircrusher.stdlib.jpa.ListToTextAttributeConverter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class ListToTextAttributeConverterUT {
@@ -30,6 +31,12 @@ class ListToTextAttributeConverterUT {
 
         val serialized = sut.convertToEntityAttribute(deserialized)
         assertEquals(attribute, serialized)
+    }
+
+    @Test
+    fun `db 에 null 이 저장된 케이스도 잘 처리해준다`() {
+        val serialized = sut.convertToEntityAttribute(null)
+        assertTrue(serialized.isEmpty())
     }
 
     // FIXME: json으로 바꾸기


### PR DESCRIPTION
## Checklist
- 에러가 나서 수정합니다

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 