### PR TITLE
어드민 장소 크롤링 & 크롤링된 장소 기반 퀘스트 생성 관련 API spec 추가

### DIFF
--- a/api-admin/api-spec.yaml
+++ b/api-admin/api-spec.yaml
@@ -85,6 +85,11 @@ paths:
                   type: integer
                 maxPlaceCountPerQuest:
                   type: integer
+                useAlreadyCrawledPlace:
+                  type: boolean
+                  description: |
+                    지도 API 기반이 아닌, 이미 크롤링하여 계단정복지도 서버 DB에 캐싱해둔 장소를 기반으로 퀘스트를 생성할지 여부.
+                    지정되지 않은 경우, default는 false.
               required:
                 - clusterCount
                 - maxPlaceCountPerQuest
@@ -408,6 +413,19 @@ paths:
       responses:
         204:
           description: 삭제 성공
+
+  /places/startCrawling:
+    post:
+      operationId: startPlaceCrawling
+      summary: 지정된 지역 내의 장소를 지도 API를 통해 크롤링해서 계단정복지도 서버 DB에 캐싱한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartPlaceCrawlingRequestDTO'
+      responses:
+        '204': {}
 
 components:
   # Reusable schemas (data models)
@@ -883,3 +901,15 @@ components:
         - ONE
         - TWO_TO_FIVE
         - OVER_SIX
+
+    StartPlaceCrawlingRequestDTO:
+      properties:
+        name:
+          type: string
+        boundaryVertices:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationDTO'
+      required:
+        - name
+        - boundaryVertices

--- a/api-admin/api-spec.yaml
+++ b/api-admin/api-spec.yaml
@@ -904,12 +904,9 @@ components:
 
     StartPlaceCrawlingRequestDTO:
       properties:
-        name:
-          type: string
         boundaryVertices:
           type: array
           items:
             $ref: '#/components/schemas/LocationDTO'
       required:
-        - name
         - boundaryVertices


### PR DESCRIPTION
## Proposed Changes
- 현재 퀘스트 생성 시 너무 넓은 면적을 잡는 경우, 면적 내에 존재하는 장소를 크롤링하는 것이 오래 걸려서 클라 - 서버 socket timeout으로 인해 퀘스트 생성에 실패하는 문제가 있습니다.
- 이 문제를 해결하기 위해 퀘스트 생성 스텝 중 장소 크롤링만 분리해서 처리할 수 있도록 변경합니다. 구체적으로, 어드민에 아래 두 가지 기능을 추가합니다.
  1. 면적 내의 장소를 크롤링해서 로컬 DB에 캐싱할 수 있는 기능 추가
  2. 퀘스트 생성 시에 1에서 로컬 DB에 저장된 장소를 기반으로 퀘스트를 생성할 수 있는 옵션 추가
- 1번 기능의 경우, 크롤링 시작 & 성공/실패 여부를 슬랙으로 알림을 주려고 합니다. 더 잘 하려면 progress를 어드민에 표시해줘야 할 것 같은데, 일정이 좀 빠듯해서... ㅋㅋ