### PR TITLE
docker-compose 파일 Apple silicon 대응

### DIFF
--- a/app-server/docker-compose.yml
+++ b/app-server/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   postgres:
+    platform: linux/amd64
     image: postgis/postgis:14-3.4-alpine
     restart: always
     ports:
@@ -9,6 +10,7 @@ services:
       POSTGRES_PASSWORD: test
       POSTGRES_DB: scc_test
   postgres-local:
+    platform: linux/amd64
     image: postgis/postgis:14-3.4-alpine
     restart: always
     ports:


### PR DESCRIPTION
- postgis 이미지가 arm64 아키텍처를 지원하지 않아서 m1 맥에서 오류가 납니다
- amd64 로 플랫폼을 제한합니다

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 