### PR TITLE
썸네일 생성 로직 일시적으로 비활성화

### DIFF
--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
@@ -141,7 +141,7 @@ class AccessibilityApplicationService(
         taskExecutor.execute {
             try {
                 accessibilityImageService.migrateImageUrlsToImagesIfNeeded(placeId)
-                accessibilityImageService.generateThumbnailsIfNeeded(placeId)
+                // accessibilityImageService.generateThumbnailsIfNeeded(placeId)
             } catch (t: Throwable) {
                 logger.error(t) { "Failed to migrate images or generate thumbnails for $placeId" }
             }

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityTest.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
@@ -253,6 +254,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
             }
     }
 
+    @Disabled("정복 활동에 방해될 것 같아서 잠시 비활성화")
     @Test
     fun `썸네일이 없으면 생성한다`() {
         val imageUrl = "resources/example.jpg"


### PR DESCRIPTION
- 규모가 꽤 되는 정복활동에 방해가 될 것 같아서 일시적으로 비활성화 합니다
- server-internal 같은 것으로 따로 빼야할 듯
- 슬랙 링크) https://agnica-coworkingspace.slack.com/archives/C052R57TZDW/p1725451754539429

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 