### PR TITLE
챌린지 랭크 업데이트 배치잡 오류 수정

### DIFF
--- a/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/UpdateChallengeRanksUseCase.kt
+++ b/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/UpdateChallengeRanksUseCase.kt
@@ -41,7 +41,7 @@ class UpdateChallengeRanksUseCase(
 
                 val ranks = (contributions.groupBy { it.userId } + userWithNoContribution)
                     .map { (userId, contributions) ->
-                        val challengeRank = challengeRankRepository.findFirstByChallengeIdAndUserId(challenge.id, userId) ?: ChallengeRank(
+                        ChallengeRank(
                             id = EntityIdGenerator.generateRandom(),
                             challengeId = challenge.id,
                             userId = userId,
@@ -50,11 +50,6 @@ class UpdateChallengeRanksUseCase(
                             createdAt = now,
                             updatedAt = now,
                         )
-
-                        challengeRank.apply {
-                            contributionCount = contributions.size.toLong()
-                            updatedAt = now
-                        }
                     }
 
                 var nextRank = 1L

--- a/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/out/persistence/ChallengeRankRepository.kt
+++ b/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/out/persistence/ChallengeRankRepository.kt
@@ -1,6 +1,7 @@
 package club.staircrusher.challenge.application.port.out.persistence
 
 import club.staircrusher.challenge.domain.model.ChallengeRank
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 
@@ -24,5 +25,12 @@ interface ChallengeRankRepository : CrudRepository<ChallengeRank, String> {
         LIMIT 1
     """)
     fun findNextRank(challengeId: String, rank: Long): ChallengeRank?
+
+    @Query("""
+        DELETE
+        FROM ChallengeRank r
+        WHERE r.challengeId = :challengeId
+    """)
+    @Modifying
     fun deleteByChallengeId(challengeId: String)
 }


### PR DESCRIPTION
```
org.springframework.dao.InvalidDataAccessApiUsageException: org.hibernate.ObjectDeletedException: deleted instance passed to merge: [club.staircrusher.challenge.domain.model.ChallengeRank#<null>]
```
- 이런 오류가 뜨고 있음
1. JPA 에서 transaction 안에 delete 쿼리가 있을 때, 코드 상 언제 trigger 되는 것과 관계 없이 무조건 db 쿼리는 마지막에 날아간다
  - 즉, delete 한 뒤에 saveAll 하면 아무것도 안남을 수 있음 (delete 가 가장 마지막에 실행돼서)
  - JPQL 은 실행될때 즉시 flush 되기 때문에 JPQL 로 바꿨습니다
2. JPA 는 id 가 없으면 새로운 엔티티로 인식한다
  - 물론 저희는 id 를 non-null 로 넣어주고 있지만, 암튼 ChallengeRank 를 먼저 find 할 경우 persistence context 에 의해 관리되기 때문에 위에서 말한 delete 쿼리를 flush 할 때 휘말릴 수 있음
  - 그래서 항상 새로운 엔티티를 생성해서 마지막에 saveAll 하도록 했습니다

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 