### PR TITLE
Fix: 장소 크롤링 시 기존 place row에 대해서 location_for_query가 채워지도록 수정

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/PlaceApplicationService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/PlaceApplicationService.kt
@@ -156,8 +156,20 @@ class PlaceApplicationService(
     private fun List<Place>.mergeLocalDatabases(): List<Place> {
         val existingPlaceById = placeRepository.findAllById(this.map { it.id })
             .associateBy { it.id }
-        return this.map {
-            existingPlaceById[it.id] ?: it
+        return this.map { searchedPlace ->
+            existingPlaceById[searchedPlace.id]?.also { existingPlace ->
+                Place.of(
+                    id = searchedPlace.id,
+                    name = searchedPlace.name,
+                    location = searchedPlace.location,
+                    building = searchedPlace.building,
+                    siGunGuId = searchedPlace.siGunGuId,
+                    eupMyeonDongId = searchedPlace.eupMyeonDongId,
+                    category = searchedPlace.category,
+                    isClosed = existingPlace.isClosed,
+                    isNotAccessible = existingPlace.isNotAccessible,
+                )
+            } ?: searchedPlace
         }
     }
 }


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

## Proposed Changes
- https://agnica-coworkingspace.slack.com/archives/C052R57TZDW/p1727589887831669 <- 미리 크롤링된 장소가 퀘스트 생성 시 잘 안 보여서 확인해보니, 이미 로컬 DB에 location_for_query 컬럼 값이 비어 있는 기존 place가 존재하는 경우 location_for_query가 영원히 채워지지 않는 문제가 있습니다. 이 문제를 해결합니다.