### PR TITLE
폐업 추정 장소 placeId 도 이미 존재하는지 체크하기

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/CreateClosedPlaceCandidatesUseCase.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/CreateClosedPlaceCandidatesUseCase.kt
@@ -35,7 +35,7 @@ class CreateClosedPlaceCandidatesUseCase(
         transactionManager.doInTransaction {
             val (placeIds ,externalIds) = closedPlaceCandidates.map { it.placeId to it.externalId }.unzip()
 
-            val alreadyExistingPlaceIds = closedPlaceCandidateRepository.findByExternalIdIn(placeIds).map { it.placeId}
+            val alreadyExistingPlaceIds = closedPlaceCandidateRepository.findByPlaceIdIn(placeIds).map { it.placeId }
             val alreadyExistingExternalIds = closedPlaceCandidateRepository.findByExternalIdIn(externalIds).map { it.externalId }
             val filteredCandidates = closedPlaceCandidates
                 .filter { it.externalId !in alreadyExistingExternalIds && it.placeId !in alreadyExistingPlaceIds }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/CreateClosedPlaceCandidatesUseCase.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/CreateClosedPlaceCandidatesUseCase.kt
@@ -33,9 +33,12 @@ class CreateClosedPlaceCandidatesUseCase(
         }
 
         transactionManager.doInTransaction {
-            val externalIds = closedPlaceCandidates.map { it.externalId }
+            val (placeIds ,externalIds) = closedPlaceCandidates.map { it.placeId to it.externalId }.unzip()
+
+            val alreadyExistingPlaceIds = closedPlaceCandidateRepository.findByExternalIdIn(placeIds).map { it.placeId}
             val alreadyExistingExternalIds = closedPlaceCandidateRepository.findByExternalIdIn(externalIds).map { it.externalId }
-            val filteredCandidates = closedPlaceCandidates.filter { it.externalId !in alreadyExistingExternalIds }
+            val filteredCandidates = closedPlaceCandidates
+                .filter { it.externalId !in alreadyExistingExternalIds && it.placeId !in alreadyExistingPlaceIds }
 
             closedPlaceCandidateRepository.saveAll(filteredCandidates)
         }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/persistence/ClosedPlaceCandidateRepository.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/persistence/ClosedPlaceCandidateRepository.kt
@@ -25,6 +25,6 @@ interface ClosedPlaceCandidateRepository : CrudRepository<ClosedPlaceCandidate, 
     ): Page<ClosedPlaceCandidate>
 
     fun findByExternalIdIn(externalIds: List<String>): List<ClosedPlaceCandidate>
-
+    fun findByPlaceIdIn(placeIds: List<String>): List<ClosedPlaceCandidate>
     fun findByPlaceId(placeId: String): ClosedPlaceCandidate?
 }


### PR DESCRIPTION
- 문서에는 primary key 라고 적혀 있는게 사실은 pk 가 아니고 하루 단위의 멱등성을 보장해주는 키 같습니다
- 한 장소에 대해서 여러개의 closedPlaceCandidate 가 생겨서 확인해보니 externalId 가 모두 다르네요..
- 그래서 place id 도 함께 확인해줍니다

| id | place\_id | external\_id | accepted\_at | ignored\_at | created\_at | updated\_at |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 3be80f51-6d2c-4f33-97b0-a06e52b3ba89 | 911346565 | 3210000-101-2024-00486;07\_24\_04\_P | null | null | 2024-10-16 14:00:45.439745 +00:00 | 2024-10-16 14:00:45.439759 +00:00 |
| c6eea013-9910-45c7-ba9d-390bdb36f0f5 | 911346565 | 3210000-101-2024-00501;07\_24\_04\_P | null | null | 2024-10-19 14:00:08.056908 +00:00 | 2024-10-19 14:00:08.056918 +00:00 |
| 44a12b24-e42d-4ae5-ba3d-efd0e91b9783 | 911346565 | 3210000-104-2024-00363;07\_24\_05\_P | null | null | 2024-10-19 14:00:08.062410 +00:00 | 2024-10-19 14:00:08.062481 +00:00 |


## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 