### PR TITLE
서버 이벤트 안남는 문제 해결

### DIFF
--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
@@ -148,11 +148,9 @@ class UserApplicationService(
 
         logger.info("isNewsLetterSubscriptionAgreed value $isNewsLetterSubscriptionAgreed for user id ${user.id}")
         if (isNewsLetterSubscriptionAgreed) {
-            transactionManager.doAfterCommit {
-                user.email?.let {
-                    logger.info("subscribe to news letter called for user id ${user.id}")
-                    subscribeToNewsLetter(user.id, it, user.nickname)
-                }
+            user.email?.let {
+                logger.info("subscribe to news letter called for user id ${user.id}")
+                subscribeToNewsLetter(user.id, it, user.nickname)
             }
         }
 

--- a/app-server/subprojects/cross_cutting_concern/application/server_event/src/main/kotlin/club/staircrusher/application/server_event/port/in/SccServerPersistentEventRecorder.kt
+++ b/app-server/subprojects/cross_cutting_concern/application/server_event/src/main/kotlin/club/staircrusher/application/server_event/port/in/SccServerPersistentEventRecorder.kt
@@ -7,17 +7,15 @@ import club.staircrusher.domain.server_event.ServerEventPayload
 import club.staircrusher.stdlib.clock.SccClock
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
-import club.staircrusher.stdlib.persistence.TransactionManager
 import mu.KotlinLogging
 
 @Component
-internal class SccServerPersistentEventRecorder(
-    private val transactionManager: TransactionManager,
+class SccServerPersistentEventRecorder(
     private val serverEventRepository: ServerEventRepository,
 ) : SccServerEventRecorder {
     private val logger = KotlinLogging.logger { }
 
-    override fun record(payload: ServerEventPayload) = transactionManager.doInTransaction {
+    override fun record(payload: ServerEventPayload) {
         try {
             logger.info("save server event: $payload")
             val serverEvent = ServerEvent(
@@ -27,9 +25,8 @@ internal class SccServerPersistentEventRecorder(
                 createdAt = SccClock.instant(),
             )
             serverEventRepository.save(RdbServerEvent(serverEvent))
-        } catch (e: Exception){
-            logger.error(e) { "Failed to create server event of payload: $payload" }
+        } catch (t: Throwable){
+            logger.error(t) { "Failed to save server event of payload: $payload" }
         }
-        Unit
     }
 }


### PR DESCRIPTION
- doAfterCommit 안에서 transaction 을 또 열면서 문제가 됨 (테스트로 확인)
- 타다 코드처럼 Do.afterCommit 을 따로 만들어야 하나 싶네요

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 