### PR TITLE
cd 시 k8s rollout 타임아웃 걸기

### DIFF
--- a/.github/workflows/dev-ci-cd.yaml
+++ b/.github/workflows/dev-ci-cd.yaml
@@ -111,6 +111,7 @@ jobs:
           kubectl rollout restart deploy/scc-server -n dev
 
       - name: Wait for scc-server rollout
+        timeout-minutes: 10
         run: |
           kubectl rollout status deployment scc-server -n dev
 

--- a/.github/workflows/prod-ci-cd.yaml
+++ b/.github/workflows/prod-ci-cd.yaml
@@ -119,6 +119,7 @@ jobs:
           helm upgrade --install --namespace scc -f values-prod.yaml scc-server ./
 
       - name: Wait for scc-server rollout
+        timeout-minutes: 10
         run: |
           kubectl rollout status deployment scc-server -n scc
 


### PR DESCRIPTION
## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 