### PR TITLE
노드 taint & toleration

### DIFF
--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -115,9 +115,9 @@ openobserve-collector:
   agent:
     enabled: true
     tolerations:
-      - key: "exampleKey1"
+      - key: "dedicated"
         operator: "Equal"
-        value: "true"
+        value: "monitoring"
         effect: "NoSchedule"
     resources:
       limits:
@@ -410,7 +410,11 @@ openobserve-collector:
       enabled: true
     affinity: {}
     nodeSelector: {}
-    tolerations: []
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "monitoring"
+        effect: "NoSchedule"
     resources:
       # We usually recommend not to specify default resources and to leave this as a conscious
       # choice for the user. This also increases chances charts run on environments with little

--- a/infra/helm/scc-redash/values.yaml
+++ b/infra/helm/scc-redash/values.yaml
@@ -335,7 +335,11 @@ redash:
     nodeSelector: { }
 
     # server.tolerations -- Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-    tolerations: [ ]
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "redash"
+        effect: "NoSchedule"
 
     # server.affinity -- Affinity for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     affinity: { }
@@ -413,7 +417,11 @@ redash:
     nodeSelector: { }
 
     # adhocWorker.tolerations -- Tolerations for ad-hoc worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-    tolerations: [ ]
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "redash"
+        effect: "NoSchedule"
 
     # adhocWorker.affinity -- Affinity for ad-hoc worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     affinity: { }
@@ -457,7 +465,11 @@ redash:
     nodeSelector: { }
 
     # scheduledWorker.tolerations -- Tolerations for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-    tolerations: [ ]
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "redash"
+        effect: "NoSchedule"
 
     # scheduledWorker.affinity -- Affinity for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     affinity: { }
@@ -499,7 +511,11 @@ redash:
     nodeSelector: { }
 
     # scheduler.tolerations -- Tolerations for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-    tolerations: [ ]
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "redash"
+        effect: "NoSchedule"
 
     # scheduler.affinity -- Affinity for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     affinity: { }
@@ -543,7 +559,11 @@ redash:
     nodeSelector: { }
 
     # genericWorker.tolerations -- Tolerations for generic worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-    tolerations: [ ]
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "redash"
+        effect: "NoSchedule"
 
     # genericWorker.affinity -- Affinity for generic worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
     affinity: { }


### PR DESCRIPTION
- monitoring 과 redash 를 각각 dataplane 0 과 dataplane 1 에 할당하려 합니다
- 아래는 node toleration 상황

```
{
  "name": "ip-172-26-44-25",
  "taints": null
}
{
  "name": "ip-172-26-10-251",
  "taints": [
    {
      "effect": "NoSchedule",
      "key": "dedicated",
      "value": "monitoring"
    }
  ]
}
{
  "name": "ip-172-26-15-200",
  "taints": null
}
{
  "name": "ip-172-26-5-244",
  "taints": null
}
{
  "name": "ip-172-26-38-96",
  "taints": [
    {
      "effect": "NoSchedule",
      "key": "dedicated",
      "value": "redash"
    }
  ]
}
{
  "name": "ip-172-26-9-4",
  "taints": [
    {
      "effect": "NoSchedule",
      "key": "node.kubernetes.io/unschedulable",
      "timeAdded": "2024-04-26T03:41:44Z"
    }
  ]
}

```

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 