### PR TITLE
monitoring + redash + system 쪽 Node 그룹 함께 관리하기

### DIFF
--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -117,7 +117,7 @@ openobserve-collector:
     tolerations:
       - key: "dedicated"
         operator: "Equal"
-        value: "monitoring"
+        value: "internal"
         effect: "NoSchedule"
     resources:
       limits:
@@ -410,11 +410,11 @@ openobserve-collector:
       enabled: true
     affinity: {}
     nodeSelector:
-      dedicated: monitoring
+      dedicated: internal
     tolerations:
       - key: "dedicated"
         operator: "Equal"
-        value: "monitoring"
+        value: "internal"
         effect: "NoSchedule"
     resources:
       # We usually recommend not to specify default resources and to leave this as a conscious

--- a/infra/helm/scc-redash/values.yaml
+++ b/infra/helm/scc-redash/values.yaml
@@ -321,10 +321,10 @@ redash:
     # server.resources -- Server resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
     resources:
       limits:
-        cpu: 800m
+        cpu: 500m
         memory: 1024Mi
       requests:
-        cpu: 800m
+        cpu: 500m
         memory: 1024Mi
 
     # server.podSecurityContext -- Security contexts for server pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
@@ -333,13 +333,13 @@ redash:
 
     # server.nodeSelector -- Node labels for server pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
     nodeSelector:
-      dedicated: redash
+      dedicated: internal
 
     # server.tolerations -- Tolerations for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
     tolerations:
       - key: "dedicated"
         operator: "Equal"
-        value: "redash"
+        value: "internal"
         effect: "NoSchedule"
 
     # server.affinity -- Affinity for server pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
@@ -416,13 +416,13 @@ redash:
 
     # adhocWorker.nodeSelector -- Node labels for ad-hoc worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
     nodeSelector:
-      dedicated: redash
+      dedicated: internal
 
     # adhocWorker.tolerations -- Tolerations for ad-hoc worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
     tolerations:
       - key: "dedicated"
         operator: "Equal"
-        value: "redash"
+        value: "internal"
         effect: "NoSchedule"
 
     # adhocWorker.affinity -- Affinity for ad-hoc worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
@@ -465,13 +465,13 @@ redash:
 
     # scheduledWorker.nodeSelector -- Node labels for scheduled worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
     nodeSelector:
-      dedicated: redash
+      dedicated: internal
 
     # scheduledWorker.tolerations -- Tolerations for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
     tolerations:
       - key: "dedicated"
         operator: "Equal"
-        value: "redash"
+        value: "internal"
         effect: "NoSchedule"
 
     # scheduledWorker.affinity -- Affinity for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
@@ -512,13 +512,13 @@ redash:
 
     # scheduler.nodeSelector -- Node labels for scheduler pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
     nodeSelector:
-      dedicated: redash
+      dedicated: internal
 
     # scheduler.tolerations -- Tolerations for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
     tolerations:
       - key: "dedicated"
         operator: "Equal"
-        value: "redash"
+        value: "internal"
         effect: "NoSchedule"
 
     # scheduler.affinity -- Affinity for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
@@ -561,13 +561,13 @@ redash:
 
     # genericWorker.nodeSelector -- Node labels for generic worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
     nodeSelector:
-      dedicated: redash
+      dedicated: internal
 
     # genericWorker.tolerations -- Tolerations for generic worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
     tolerations:
       - key: "dedicated"
         operator: "Equal"
-        value: "redash"
+        value: "internal"
         effect: "NoSchedule"
 
     # genericWorker.affinity -- Affinity for generic worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)


### PR DESCRIPTION
- redash 따로, monitoring 따로 각각 노드에 관리하려 했는데
- redash 가 자원을 많이 먹어서 한 노드에 띄우기 애매하기 때문에 data-plane 0 과 1 을 internal 용 node group 으로 사용하도록 합니다
- system 관련된 팟들도 저기로 보낼듯

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 