### PR TITLE
User 컨트롤러 auth 필요한 endpoint security 설정

### DIFF
--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/security/UserBoundedContextSecurityConfig.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/security/UserBoundedContextSecurityConfig.kt
@@ -6,5 +6,10 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 
 @Component
 class UserBoundedContextSecurityConfig : SccSecurityConfig {
-    override fun requestMatchers() = listOf("/updateUserInfo").map { AntPathRequestMatcher(it) }
+    override fun requestMatchers() = listOf(
+        "/getUserInfo",
+        "/updateUserInfo",
+        "/updatePushToken",
+        "/deleteUser",
+    ).map { AntPathRequestMatcher(it) }
 }


### PR DESCRIPTION
## Checklist

- deleteUser 에 authentication 이 null 로 들어왔다 로그가 떠서 500 보다는 400 이 뜨도록 합니다
- 그 외에 authentication 이 non-null 이어야 하는 endpoint 도 추가했습니다

```
{"timestamp":"2025-01-30 08:32:15.663Z","level":"INFO","thread":"http-nio-8080-exec-4","mdc":{"request_id":"3413c3f2"},"logger":"club.staircrusher.spring_web.logging.SccLoggingInterceptor","message":"[POST /deleteUser 500 INTERNAL_SERVER_ERROR] Request: null, Response: 알 수 없는 에러가 발생했습니다. 다시 시도해주세요."}
scc-server-5848d7dd96-9rs5l scc-server {"timestamp":"2025-01-30 08:32:17.974Z","level":"ERROR","thread":"http-nio-8080-exec-5","mdc":{"request_id":"a4f71327"},"logger":"club.staircrusher.spring_web.web.SccExceptionHandler","message":"Unexpected Error: Parameter specified as non-null is null: method club.staircrusher.user.infra.adapter.in.controller.UserController.deleteUser, parameter authentication","exception":"java.lang.NullPointerException: Parameter specified as non-null is null: method club.staircrusher.user.infra.adapter.in.controller.UserController.deleteUser, parameter authentication\n\tat club.staircrusher.user.infra.adapter.in.controller.UserController.deleteUser(UserController.kt)\n\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:578)
```

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 