### PR TITLE
[PoC] Abstract Domain Model 정의

### DIFF
--- a/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/ClosedPlaceCandidate.kt
+++ b/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/ClosedPlaceCandidate.kt
@@ -10,7 +10,7 @@ import java.time.Instant
 @Entity
 class ClosedPlaceCandidate(
     @Id
-    val id: String,
+    override val id: String,
 
     @Column(nullable = false)
     val placeId: String,
@@ -39,23 +39,5 @@ class ClosedPlaceCandidate(
 
     fun ignore() {
         ignoredAt = SccClock.instant()
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ClosedPlaceCandidate
-
-        return id == other.id
-    }
-
-    override fun hashCode(): Int {
-        return id.hashCode()
-    }
-
-    override fun toString(): String {
-        return "ClosedPlaceCandidate(id='$id', placeId='$placeId', externalId='$externalId', " +
-            "acceptedAt='$acceptedAt', ignoredAt='$ignoredAt' createdAt=$createdAt, updatedAt=$updatedAt)"
     }
 }

--- a/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/Place.kt
+++ b/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/Place.kt
@@ -19,7 +19,7 @@ import org.locationtech.jts.geom.Point
 @Entity
 class Place private constructor(
     @Id
-    val id: String,
+    override val id: String,
     val name: String,
     @AttributeOverrides(
         AttributeOverride(name = "lng", column = Column(name = "location_x")),
@@ -59,24 +59,6 @@ class Place private constructor(
     fun isUpdated(maybeUpdated: Place): Boolean {
         check(this.id == maybeUpdated.id)
         return this.locationForQuery == null && maybeUpdated.locationForQuery != null
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Place
-
-        return id == other.id
-    }
-
-    override fun hashCode(): Int {
-        return id.hashCode()
-    }
-
-    override fun toString(): String {
-        return "Place(id='$id', name='$name', location=$location, building=$building, siGunGuId=$siGunGuId, " +
-            "eupMyeonDongId=$eupMyeonDongId, category=$category, isClosed=$isClosed, isNotAccessible=$isNotAccessible)"
     }
 
     companion object {

--- a/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/AbstractDomainModel.kt
+++ b/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/AbstractDomainModel.kt
@@ -1,0 +1,64 @@
+package club.staircrusher.stdlib.persistence
+
+import org.hibernate.Hibernate
+import org.hibernate.proxy.HibernateProxy
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+abstract class AbstractDomainModel {
+    abstract val id: String
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AbstractDomainModel
+
+        return this.id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+
+    override fun toString(): String {
+        val properties = this::class.memberProperties
+            .filter { it.name != "id" }
+            .mapNotNull { prop ->
+                try {
+                    prop.isAccessible = true
+                    val value = prop.getter.call(this)
+
+                    // Exclude uninitialized Hibernate proxy collections
+                    if (!isInitialized(value)) return@mapNotNull null
+
+                    val displayValue = if (prop.findAnnotation<Sensitive>() != null || prop.name in sensitiveFields) {
+                        "<redacted>"
+                    } else {
+                        value.toString()
+                    }
+
+                    "${prop.name}='$displayValue'"
+                } catch (t: Throwable) {
+                    null
+                }
+            }
+
+        return "${this::class.simpleName}(id='$id', ${properties.joinToString(", ")})"
+    }
+
+    private fun isInitialized(value: Any?): Boolean {
+        return when (value) {
+            null -> true
+            is Collection<*> -> Hibernate.isInitialized(value)
+            is HibernateProxy -> !value.hibernateLazyInitializer.isUninitialized
+            else -> true
+        }
+    }
+
+    companion object {
+        private val sensitiveFields = setOf("password", "secretKey", "apiKey", "token")
+    }
+}

--- a/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/Sensitive.kt
+++ b/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/Sensitive.kt
@@ -1,0 +1,5 @@
+package club.staircrusher.stdlib.persistence
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Sensitive

--- a/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/jpa/TimeAuditingBaseEntity.kt
+++ b/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/persistence/jpa/TimeAuditingBaseEntity.kt
@@ -1,5 +1,6 @@
 package club.staircrusher.stdlib.persistence.jpa
 
+import club.staircrusher.stdlib.persistence.AbstractDomainModel
 import jakarta.persistence.Column
 import jakarta.persistence.MappedSuperclass
 import org.hibernate.annotations.CreationTimestamp
@@ -7,7 +8,7 @@ import org.hibernate.annotations.UpdateTimestamp
 import java.time.Instant
 
 @MappedSuperclass
-class TimeAuditingBaseEntity {
+abstract class TimeAuditingBaseEntity : AbstractDomainModel() {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     lateinit var createdAt: Instant

--- a/app-server/subprojects/cross_cutting_concern/stdlib/src/unitTest/kotlin/club/staircrusher/stdlib/persistence/AbstractDomainModelUT.kt
+++ b/app-server/subprojects/cross_cutting_concern/stdlib/src/unitTest/kotlin/club/staircrusher/stdlib/persistence/AbstractDomainModelUT.kt
@@ -1,0 +1,83 @@
+package club.staircrusher.stdlib.persistence
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AbstractDomainModelUT {
+    @Test
+    fun `정의된 필드가 toString 메소드에 포함된다`() {
+        val some = SomeDomainModel(
+            id = "id",
+            name = "name",
+            password = "password",
+            age = 10,
+            someSensitiveField = "sensitive",
+            isClosed = false
+        )
+
+        val str = some.toString()
+        assertEquals(true, str.contains("id="))
+        assertEquals(true, str.contains("name="))
+        assertEquals(true, str.contains("password="))
+        assertEquals(true, str.contains("age="))
+        assertEquals(true, str.contains("someSensitiveField="))
+    }
+
+    @Test
+    fun `확실한 민감정보는 toString 에서 마스킹된다`() {
+        val some = SomeDomainModel(
+            id = "id",
+            name = "name",
+            password = "password",
+            age = 10,
+            someSensitiveField = "sensitive",
+            isClosed = false,
+        )
+
+        val str = some.toString()
+        assertEquals(true, str.contains("password='<redacted>'"))
+    }
+
+    @Test
+    fun `Sensitive 어노테이션이 붙은 필드는 toString 에서 마스킹된다`() {
+        val some = SomeDomainModel(
+            id = "id",
+            name = "name",
+            password = "password",
+            age = 10,
+            someSensitiveField = "sensitive",
+            isClosed = false,
+        )
+
+        val str = some.toString()
+        assertEquals(true, str.contains("someSensitiveField='<redacted>'"))
+    }
+
+    @Test
+    fun `contructor 에 정의되지 않은 필드도 toString 에 포함된다`() {
+        val some = SomeDomainModel(
+            id = "id",
+            name = "name",
+            password = "password",
+            age = 10,
+            someSensitiveField = "sensitive",
+            isClosed = false
+        )
+
+        val str = some.toString()
+        assertEquals(true, str.contains("isClosed='false'"))
+    }
+
+    class SomeDomainModel(
+        override val id: String,
+        val name: String,
+        val password: String,
+        val age: Int,
+        @Sensitive
+        val someSensitiveField: String,
+        isClosed: Boolean
+    ) : AbstractDomainModel() {
+        var isClosed: Boolean = isClosed
+            private set
+    }
+}


### PR DESCRIPTION
## Checklist

- 이슈들 보다가 해볼만 한 것 같아서 구현해봤습니다
- toString, hashCode, equals 를 따로 구현하지 않아도 되도록합니다
- toString 은 reflection 을 사용해서 성능이 조금 떨어지긴 할텐데, 어차피 toString 을 사용하는 곳이 별로 없을거라.. 그냥 조금 더 편한 길로 가봅니다 ㅎㅎ
- 독립적인 abstract class 로 관리하고 싶었는데, 코틀린에서 abstract class 는 한개밖에 상속을 받지 못해서 TimeAuditingBaseEntity 가 상속받도록 했습니다
  - hierarchy 상 AbstractDomainModel (커스텀 도메인 모델) 보다는 jpa 에 종속적인 TimeAuditingBaseEntity 가 조금 더 higher level 인 느낌?
- 만약 `TimeAuditingBaseEntity` 를 상속받는 모델이면 두 기능 (`createdAt`, `updatedAt` 이 트래킹되는 기능과, toString 이 다이나믹하게 구현되는 기능) 을 사용하게 되고, 만약 `TimeAuditingBaseEntity` 를 사용하지 않는다면, `AbstractDomainModel` 만 가져다가 쓰면 될 것 같습니다
- resolves #75 

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 