### PR TITLE
폐업 추정 장소 생성 rate limit

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/place/application/build.gradle.kts
@@ -2,4 +2,5 @@ dependencies {
     implementation(projects.apiSpecification.domainEvent)
     implementation(libs.kotlin.logging)
     implementation(libs.jts.core)
+    implementation(libs.guava)
 }


### PR DESCRIPTION
## Checklist
- DB CPU 가 11시에만 92%까지 치솟아서 rate limit 을 겁니다
- 매시간 update ranking cronjob 이 돌고 11시에 폐업 추정 장소 생성 cronjob 이 도는데, 11시 cpu 지표만 튀어서 폐업추정에만 달아줍니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

<img width="781" alt="image" src="https://github.com/user-attachments/assets/3e012f32-c3ab-4596-abfa-e3c6139f32ab" />
<img width="886" alt="image" src="https://github.com/user-attachments/assets/84b47db1-9ee3-4371-998a-874e7b6bfbb9" />
