### PR TITLE
인증 과정에서 UserAccount 사용하기

### DIFF
--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccSecurityConfigTest.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/integrationTest/kotlin/club/staircrusher/spring_web/security/SccSecurityConfigTest.kt
@@ -93,10 +93,16 @@ class SccSecurityConfigTest {
     }
 
     private fun getUser(): UserProfile {
+        userAccountRepository.save(
+            UserAccount(
+                id = userId,
+                accountType = UserAccountType.IDENTIFIED,
+            )
+        )
         return userProfileRepository.save(
             UserProfile(
                 id = userId,
-                userId = "",
+                userId = userId,
                 nickname = "",
                 encryptedPassword = "",
                 instagramId = null,

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthenticationProvider.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthenticationProvider.kt
@@ -4,9 +4,7 @@ import club.staircrusher.spring_web.security.BeforeAuthSccAuthentication
 import club.staircrusher.stdlib.auth.AuthUser
 import club.staircrusher.user.application.port.`in`.UserApplicationService
 import club.staircrusher.user.application.port.`in`.UserAuthApplicationService
-import club.staircrusher.user.domain.model.UserProfile
 import club.staircrusher.user.domain.exception.UserAuthenticationException
-import club.staircrusher.user.domain.model.UserAccountType
 import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.core.Authentication
@@ -26,21 +24,19 @@ class SccAppAuthenticationProvider(
             throw BadCredentialsException("Invalid access token.", e)
         }
 
-        val user: UserProfile = userApplicationService.getUserProfile(userId)
+        val user = userApplicationService.getUser(userId)
             ?: throw BadCredentialsException("No User found with given credentials.")
         if (user.isDeleted) {
             throw BadCredentialsException("No User found with given credentials.")
         }
-
-        val userAccount = userApplicationService.getUser(userId)
-        val type = userAccount?.accountType?.name ?: UserAccountType.IDENTIFIED.name
+        val userProfile = userApplicationService.getUserProfile(userId)
 
         return SccAppAuthentication(
             AuthUser(
                 id = user.id,
-                type = type,
-                nickname = user.nickname,
-                instagramId = user.instagramId,
+                type = user.accountType.name,
+                nickname = userProfile?.nickname,
+                instagramId = userProfile?.instagramId,
             ),
         )
     }

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/ITDataGenerator.kt
@@ -39,7 +39,10 @@ import club.staircrusher.stdlib.geography.Location
 import club.staircrusher.stdlib.geography.eupMyeonDongById
 import club.staircrusher.stdlib.geography.siGunGuById
 import club.staircrusher.stdlib.testing.SccRandom
+import club.staircrusher.user.application.port.out.persistence.UserAccountRepository
 import club.staircrusher.user.application.port.out.persistence.UserProfileRepository
+import club.staircrusher.user.domain.model.UserAccount
+import club.staircrusher.user.domain.model.UserAccountType
 import club.staircrusher.user.domain.model.UserProfile
 import club.staircrusher.user.domain.model.UserMobilityTool
 import club.staircrusher.user.domain.service.PasswordEncryptor
@@ -55,6 +58,9 @@ class ITDataGenerator {
 
     @Autowired
     private lateinit var passwordEncryptor: PasswordEncryptor
+
+    @Autowired
+    private lateinit var userAccountRepository: UserAccountRepository
 
     @Autowired
     private lateinit var userProfileRepository: UserProfileRepository
@@ -102,10 +108,18 @@ class ITDataGenerator {
         instagramId: String? = null,
         mobilityTools: List<UserMobilityTool> = emptyList(),
     ): UserProfile {
+        val userId = EntityIdGenerator.generateRandom()
+        userAccountRepository.save(
+            UserAccount(
+                id = userId,
+                accountType = UserAccountType.IDENTIFIED,
+            )
+        )
+
         return userProfileRepository.save(
             UserProfile(
-                id = EntityIdGenerator.generateRandom(),
-                userId = "",
+                id = userId,
+                userId = userId,
                 nickname = nickname,
                 encryptedPassword = passwordEncryptor.encrypt(password.trim()),
                 instagramId = instagramId?.trim()?.takeIf { it.isNotEmpty() },


### PR DESCRIPTION
## Checklist

- 기존에 하위 호환성을 지켜주기 위해서 UserProfile 을 사용했는데, 이제 모든 UserProfile 을 UserAccount 로 마이그레이션 했기 때문에 UserAccount 를 사용하도록 합니다
- UserProfile -> UserAccount 를 사용하도록 전체적인 코드 마이그레이션 작업은 따로 진행중에 있습니다
- Anonymous User 의 경우 UserProfile 이 없어서 401 이 떨어지고 있었음

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 