### PR TITLE
썸네일 생성 다시 활성화하기

### DIFF
--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/in/AccessibilityApplicationService.kt
@@ -139,7 +139,7 @@ class AccessibilityApplicationService(
         taskExecutor.execute {
             try {
                 accessibilityImageService.migrateImageUrlsToImagesIfNeeded(placeId)
-                // accessibilityImageService.generateThumbnailsIfNeeded(placeId)
+                accessibilityImageService.generateThumbnailsIfNeeded(placeId)
             } catch (t: Throwable) {
                 logger.error(t) { "Failed to migrate images or generate thumbnails for $placeId" }
             }

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityTest.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/GetAccessibilityTest.kt
@@ -252,7 +252,6 @@ class GetAccessibilityTest : AccessibilityITBase() {
             }
     }
 
-    @Disabled("정복 활동에 방해될 것 같아서 잠시 비활성화")
     @Test
     fun `썸네일이 없으면 생성한다`() {
         val imageUrl = "resources/example.jpg"


### PR DESCRIPTION
## Checklist
- 지난 9월 조금 큰 규모의 정복활동때 혹시 몰라 꺼뒀었는데
- 이제 모니터링 지표도 좀 설정해뒀으니까 테스트도 할 겸 다시 켭니다

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 