### PR TITLE
회원 탈퇴시 3p 연결 정보 끊기

### DIFF
--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/UserApplicationService.kt
@@ -13,7 +13,6 @@ import club.staircrusher.stdlib.time.getYear
 import club.staircrusher.stdlib.validation.email.EmailValidator
 import club.staircrusher.user.application.port.out.persistence.UserAccountConnectionRepository
 import club.staircrusher.user.application.port.out.persistence.UserAccountRepository
-import club.staircrusher.user.application.port.out.persistence.UserAuthInfoRepository
 import club.staircrusher.user.domain.model.AuthTokens
 import club.staircrusher.user.application.port.out.persistence.UserProfileRepository
 import club.staircrusher.user.application.port.out.web.subscription.StibeeSubscriptionService
@@ -43,7 +42,6 @@ class UserApplicationService(
     private val userAccountConnectionRepository: UserAccountConnectionRepository,
     private val userAuthService: UserAuthService,
     private val passwordEncryptor: PasswordEncryptor,
-    private val userAuthInfoRepository: UserAuthInfoRepository,
     private val stibeeSubscriptionService: StibeeSubscriptionService,
     private val sccServerEventRecorder: SccServerEventRecorder,
     private val pushService: PushService,
@@ -234,9 +232,7 @@ class UserApplicationService(
         return@doInTransaction userProfile
     }
 
-    fun deleteUser(
-        userId: String,
-    ) = transactionManager.doInTransaction(TransactionIsolationLevel.REPEATABLE_READ) {
+    fun deleteUser(userId: String) {
         val userAccount = userAccountRepository.findByIdOrNull(userId)
         val userProfile = userProfileRepository.findFirstByUserId(userId)
 
@@ -249,8 +245,6 @@ class UserApplicationService(
             it.delete(now)
             userProfileRepository.save(it)
         }
-
-        userAuthInfoRepository.removeByUserId(userId)
     }
 
     fun connectToIdentifiedAccount(anonymousUserId: String, identifiedUserId: String, reason: UserConnectionReason) {

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/DeleteUserUseCase.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/DeleteUserUseCase.kt
@@ -1,0 +1,52 @@
+package club.staircrusher.user.application.port.`in`.use_case
+
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
+import club.staircrusher.stdlib.persistence.TransactionManager
+import club.staircrusher.user.application.port.`in`.UserApplicationService
+import club.staircrusher.user.application.port.out.persistence.UserAuthInfoRepository
+import club.staircrusher.user.application.port.out.web.login.apple.AppleLoginService
+import club.staircrusher.user.application.port.out.web.login.kakao.KakaoLoginService
+import club.staircrusher.user.domain.model.UserAuthProviderType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import mu.KotlinLogging
+
+@Component
+class DeleteUserUseCase(
+    private val transactionManager: TransactionManager,
+    private val userApplicationService: UserApplicationService,
+    private val appleLoginService: AppleLoginService,
+    private val kakaoLoginService: KakaoLoginService,
+    private val userAuthInfoRepository: UserAuthInfoRepository,
+) {
+    private val logger = KotlinLogging.logger {}
+
+    fun handle(userId: String) = transactionManager.doInTransaction(TransactionIsolationLevel.REPEATABLE_READ) {
+        userApplicationService.deleteUser(userId)
+
+        val userAuthInfo = userAuthInfoRepository.findByUserId(userId).maxByOrNull { it.createdAt }
+        userAuthInfo?.let {
+            revokeExternalConnectionAfterCommit(userId, userAuthInfo.externalId, userAuthInfo.authProviderType)
+            userAuthInfoRepository.removeByUserId(userId)
+        }
+    }
+
+    private fun revokeExternalConnectionAfterCommit(userId: String, externalId: String, authProviderType: UserAuthProviderType) {
+        transactionManager.doAfterCommit {
+            CoroutineScope(Dispatchers.IO).launch {
+                val revokeResult = when (authProviderType) {
+                    UserAuthProviderType.APPLE -> appleLoginService.revoke(externalId)
+                    UserAuthProviderType.KAKAO -> kakaoLoginService.disconnect(externalId)
+                }
+
+                if (!revokeResult) {
+                    logger.error {
+                        "Failed to revoke token for user($userId) with externalId($externalId) and provider(${authProviderType})"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/DeleteUserUseCase.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/DeleteUserUseCase.kt
@@ -28,7 +28,7 @@ class DeleteUserUseCase(
 
         val userAuthInfo = userAuthInfoRepository.findByUserId(userId).maxByOrNull { it.createdAt }
         userAuthInfo?.let {
-            revokeExternalConnectionAfterCommit(userId, userAuthInfo.externalId, userAuthInfo.authProviderType)
+            revokeExternalConnectionAfterCommit(userId, it.externalId, it.authProviderType)
             userAuthInfoRepository.removeByUserId(userId)
         }
     }

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/DeleteUserUseCase.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/DeleteUserUseCase.kt
@@ -28,16 +28,16 @@ class DeleteUserUseCase(
 
         val userAuthInfo = userAuthInfoRepository.findByUserId(userId).maxByOrNull { it.createdAt }
         userAuthInfo?.let {
-            revokeExternalConnectionAfterCommit(userId, it.externalId, it.authProviderType)
+            revokeExternalConnectionAfterCommit(userId, it.externalId, it.externalRefreshToken, it.authProviderType)
             userAuthInfoRepository.removeByUserId(userId)
         }
     }
 
-    private fun revokeExternalConnectionAfterCommit(userId: String, externalId: String, authProviderType: UserAuthProviderType) {
+    private fun revokeExternalConnectionAfterCommit(userId: String, externalId: String, refreshToken: String, authProviderType: UserAuthProviderType) {
         transactionManager.doAfterCommit {
             CoroutineScope(Dispatchers.IO).launch {
                 val revokeResult = when (authProviderType) {
-                    UserAuthProviderType.APPLE -> appleLoginService.revoke(externalId)
+                    UserAuthProviderType.APPLE -> appleLoginService.revoke(refreshToken)
                     UserAuthProviderType.KAKAO -> kakaoLoginService.disconnect(externalId)
                 }
 

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/out/web/login/apple/AppleLoginService.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/out/web/login/apple/AppleLoginService.kt
@@ -2,4 +2,5 @@ package club.staircrusher.user.application.port.out.web.login.apple
 
 interface AppleLoginService {
     suspend fun getAppleLoginTokens(authorizationCode: String): AppleLoginTokens
+    suspend fun revoke(token: String): Boolean
 }

--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/out/web/login/kakao/KakaoLoginService.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/out/web/login/kakao/KakaoLoginService.kt
@@ -2,4 +2,5 @@ package club.staircrusher.user.application.port.out.web.login.kakao
 
 interface KakaoLoginService {
     fun parseIdToken(idToken: String): KakaoIdToken
+    suspend fun disconnect(kakaoSyncUserId: String): Boolean
 }

--- a/app-server/subprojects/bounded_context/user/infra/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/user/infra/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(projects.apiSpecification.api)
     implementation(projects.crossCuttingConcern.infra.persistenceModel)
     implementation(projects.crossCuttingConcern.application.serverEvent)
+    implementation(projects.crossCuttingConcern.infra.network)
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework:spring-webflux")

--- a/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/DeleteUserTest.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/integrationTest/kotlin/club/staircrusher/user/infra/adapter/in/controller/DeleteUserTest.kt
@@ -174,16 +174,16 @@ class DeleteUserTest : UserITBase() {
     @Test
     fun `애플 로그인으로 가입한 유저의 경우 애플에 연결 해제 요청을 한다`() {
         // given - 소셜 로그인으로 회원가입
-        val deletedUserExternalId = "appleLoginUserId"
+        val deletedUserRefreshToken = "refreshToken"
         val appleLoginTokens = AppleLoginTokens(
             accessToken = "",
             expiresAt = SccClock.instant() + Duration.ofHours(1),
-            refreshToken = "refreshToken",
+            refreshToken = deletedUserRefreshToken,
             idToken = AppleIdToken(
                 issuer = "https://appleid.apple.com",
                 audience = "clientId",
                 expiresAtEpochSecond = SccClock.instant().epochSecond + 10,
-                appleLoginUserId = deletedUserExternalId,
+                appleLoginUserId = "appleLoginUserId",
             ),
         )
         doReturn(appleLoginTokens).wheneverBlocking(appleLoginService) { getAppleLoginTokens(eq("dummy")) }
@@ -222,7 +222,7 @@ class DeleteUserTest : UserITBase() {
                     assertNotNull(deletedUserProfile)
                     assertTrue(deletedUserProfile!!.isDeleted)
 
-                    verifyBlocking(appleLoginService, times(1)) { revoke(eq(deletedUserExternalId)) }
+                    verifyBlocking(appleLoginService, times(1)) { revoke(eq(deletedUserRefreshToken)) }
 
                     val userAuthInfo = userAuthInfoRepository.findByUserId(user.id).find { it.authProviderType == UserAuthProviderType.APPLE }
                     assertNull(userAuthInfo)

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/in/controller/UserController.kt
@@ -12,6 +12,7 @@ import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import club.staircrusher.stdlib.domain.SccDomainException
 import club.staircrusher.stdlib.env.SccEnv
 import club.staircrusher.user.application.port.`in`.UserApplicationService
+import club.staircrusher.user.application.port.`in`.use_case.DeleteUserUseCase
 import club.staircrusher.user.application.port.`in`.use_case.GetUserProfileUseCase
 import club.staircrusher.user.infra.adapter.`in`.converter.toDTO
 import club.staircrusher.user.infra.adapter.`in`.converter.toModel
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 class UserController(
     private val userApplicationService: UserApplicationService,
     private val getUserProfileUseCase: GetUserProfileUseCase,
+    private val deleteUserUseCase: DeleteUserUseCase,
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -90,7 +92,7 @@ class UserController(
 
     @PostMapping("/deleteUser")
     fun deleteUser(authentication: SccAppAuthentication): ResponseEntity<Unit> {
-        userApplicationService.deleteUser(authentication.principal)
+        deleteUserUseCase.handle(authentication.principal)
         return ResponseEntity.noContent().build()
     }
 

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/apple/AppleLoginServiceImpl.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/apple/AppleLoginServiceImpl.kt
@@ -36,6 +36,17 @@ internal class AppleLoginServiceImpl(
         }
     }
 
+    override suspend fun revoke(token: String): Boolean {
+        val response = appleLoginApiClient.revoke(
+            client_id = appleLoginProperties.serviceId,
+            client_secret = appleLoginProperties.clientSecret,
+            token = token,
+            token_type_hint = AppleLoginApiClient.TokenType.REFRESH_TOKEN.externalName,
+        ).awaitFirst()
+
+        return response.statusCode.is2xxSuccessful
+    }
+
     private fun parseIdToken(idToken: String): AppleIdToken {
         val decodedJWT = JWT.decode(idToken)
         val appleIdToken = AppleIdToken(

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/apple/client/AppleLoginApiClient.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/apple/client/AppleLoginApiClient.kt
@@ -1,5 +1,6 @@
 package club.staircrusher.user.infra.adapter.out.web.login.apple.client
 
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.service.annotation.PostExchange
 import reactor.core.publisher.Mono
@@ -21,8 +22,27 @@ internal interface AppleLoginApiClient {
         @RequestParam(required = false) redirect_uri: String? = null,
     ): Mono<GetAppleLoginTokensResponseDto>
 
+    @Suppress("FunctionParameterNaming")
+    @PostExchange(
+        url = "/auth/revoke",
+        contentType = "application/x-www-form-urlencoded",
+        accept = ["application/json"],
+    )
+    fun revoke(
+        @RequestParam client_id: String,
+        @RequestParam client_secret: String,
+        @RequestParam token: String,
+        @RequestParam(required = false) token_type_hint: String,
+    ): Mono<ResponseEntity<Unit>>
+
     enum class GrantType(val externalName: String) {
         AUTHORIZATION_CODE("authorization_code"),
+        REFRESH_TOKEN("refresh_token"),
+        ;
+    }
+
+    enum class TokenType(val externalName: String) {
+        ACCESS_TOKEN("access_token"),
         REFRESH_TOKEN("refresh_token"),
         ;
     }

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/apple/client/AppleLoginApiClient.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/apple/client/AppleLoginApiClient.kt
@@ -22,6 +22,7 @@ internal interface AppleLoginApiClient {
         @RequestParam(required = false) redirect_uri: String? = null,
     ): Mono<GetAppleLoginTokensResponseDto>
 
+    // https://developer.apple.com/documentation/signinwithapplerestapi/revoke_tokens
     @Suppress("FunctionParameterNaming")
     @PostExchange(
         url = "/auth/revoke",

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/KakaoLoginProperties.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/KakaoLoginProperties.kt
@@ -5,4 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("scc.kakao-login")
 data class KakaoLoginProperties(
     val oauthClientId: String,
+    val adminKey: String,
 )

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/KakaoLoginServiceImpl.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/KakaoLoginServiceImpl.kt
@@ -1,16 +1,32 @@
 package club.staircrusher.user.infra.adapter.out.web.login.kakao
 
+import club.staircrusher.infra.network.createExternalApiService
 import club.staircrusher.stdlib.clock.SccClock
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.user.application.port.out.web.login.kakao.InvalidKakaoIdTokenException
 import club.staircrusher.user.application.port.out.web.login.kakao.KakaoIdToken
 import club.staircrusher.user.application.port.out.web.login.kakao.KakaoLoginService
+import club.staircrusher.user.infra.adapter.out.web.login.kakao.client.KakaoLoginApiClient
 import com.auth0.jwt.JWT
+import kotlinx.coroutines.reactive.awaitFirst
+import org.springframework.http.HttpHeaders
 
 @Component
 class KakaoLoginServiceImpl(
     private val kakaoLoginProperties: KakaoLoginProperties,
 ) : KakaoLoginService {
+    private val kakaoLoginApiClient = createExternalApiService<KakaoLoginApiClient>(
+        baseUrl = "https://kapi.kakao.com",
+        // TODO: admin key 사용하지 않기
+        defaultHeadersBlock = { it.add(HttpHeaders.AUTHORIZATION, "KakaoAK ${kakaoLoginProperties.adminKey}") },
+        defaultErrorHandler = { response ->
+            response
+                .bodyToMono(String::class.java)
+                .map { RuntimeException(it) }
+                .onErrorResume { response.createException() }
+        }
+    )
+
     override fun parseIdToken(idToken: String): KakaoIdToken {
         // TODO: 정말 카카오 서버에서 sign한 토큰이 맞는지 검증 필요
         val decodedJWT = JWT.decode(idToken)
@@ -26,6 +42,15 @@ class KakaoLoginServiceImpl(
         return kakaoIdToken
     }
 
+    override suspend fun disconnect(kakaoSyncUserId: String): Boolean {
+        val syncId = kakaoSyncUserId.toLongOrNull() ?: return false
+        val response = kakaoLoginApiClient.unlink(
+            target_id_type = KakaoLoginApiClient.TargetIdType.USER_ID.externalName,
+            target_id = syncId,
+        ).awaitFirst()
+
+        return response.id == syncId
+    }
 
     // 검증 로직은 https://developers.kakao.com/docs/latest/ko/kakaologin/common#oidc 를 참고.
     @Suppress("ThrowsCount")

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/client/KakaoLoginApiClient.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/client/KakaoLoginApiClient.kt
@@ -1,0 +1,27 @@
+package club.staircrusher.user.infra.adapter.out.web.login.kakao.client
+
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.service.annotation.PostExchange
+import reactor.core.publisher.Mono
+
+internal interface KakaoLoginApiClient {
+    @Suppress("FunctionParameterNaming")
+    @PostExchange(
+        url = "/v1/user/unlink",
+        contentType = "application/x-www-form-urlencoded",
+        accept = ["application/json"],
+    )
+    fun unlink(
+        @RequestParam target_id_type: String,
+        @RequestParam target_id: Long,
+    ): Mono<UnlinkKakaoAccountResponseDto>
+
+    enum class TargetIdType(val externalName: String) {
+        USER_ID("user_id"),
+        ;
+    }
+
+    data class UnlinkKakaoAccountResponseDto(
+        val id: Long,
+    )
+}

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/client/KakaoLoginApiClient.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/client/KakaoLoginApiClient.kt
@@ -5,6 +5,7 @@ import org.springframework.web.service.annotation.PostExchange
 import reactor.core.publisher.Mono
 
 internal interface KakaoLoginApiClient {
+    // https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink
     @Suppress("FunctionParameterNaming")
     @PostExchange(
         url = "/v1/user/unlink",

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/integrationTest/resources/application.yaml
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/integrationTest/resources/application.yaml
@@ -48,6 +48,7 @@ scc:
 
   kakao-login:
     oauth-client-id: test
+    admin-key: test
 
   apple-login:
     service-id: test

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/MockAppleLoginService.kt
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/MockAppleLoginService.kt
@@ -24,4 +24,8 @@ class MockAppleLoginService : AppleLoginService {
             ),
         )
     }
+
+    override suspend fun revoke(token: String): Boolean {
+        return true
+    }
 }

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/MockKakaoLoginService.kt
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/kotlin/club/staircrusher/testing/spring_it/mock/MockKakaoLoginService.kt
@@ -13,4 +13,8 @@ class MockKakaoLoginService : KakaoLoginService {
             kakaoSyncUserId = "dummy",
         )
     }
+
+    override suspend fun disconnect(externalId: String): Boolean {
+        return true
+    }
 }

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/resources/application.yaml
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/resources/application.yaml
@@ -54,6 +54,7 @@ scc:
 
   kakao-login:
     oauth-client-id: test
+    admin-key: test
 
   apple-login:
     service-id: test

--- a/app-server/subprojects/deploying_apps/scc_server/src/main/resources/application.yaml
+++ b/app-server/subprojects/deploying_apps/scc_server/src/main/resources/application.yaml
@@ -54,6 +54,7 @@ scc:
 
   kakao-login:
     oauth-client-id: test
+    admin-key: test
 
   naver:
     open-api:

--- a/infra/helm/scc-server/files/dev/secret.yaml
+++ b/infra/helm/scc-server/files/dev/secret.yaml
@@ -8,6 +8,7 @@ scc:
         apiKey: ENC[AES256_GCM,data:3XULZW2dZmDj4ioPhjB22wVX9QyQb5ChtHuE4NowhGw=,iv:lB/3YKD7drfR20Hqpma+SLHZ21nl7dkX+wkfFfFAduA=,tag:6jpZL/Dm+/dwHHNAzeRvTw==,type:str]
     kakao-login:
         oauth-client-id: ENC[AES256_GCM,data:JyQdF6YwxjssGLE+xFIXTBJRT8UrcneMz0uwzVUurjQ=,iv:CuzFVR28UBQzl1yEq23EnMt9tMHSPTvM8ini8P3gMmg=,tag:fTCAxQulDFSk7zwi/tuRIA==,type:str]
+        admin-key: ENC[AES256_GCM,data:smfhJ66NgpA/mgpEwBdl42H1gRYVVTTGiW5610h59QE=,iv:ELFqKk1XRouc1bYHSWuAoEa9XjPlmHQktOncUUGIAAU=,tag:qxVZXCtQ9VhcJs9fh2YkKQ==,type:str]
     admin:
         password: ENC[AES256_GCM,data:GioxlA==,iv:2XV4FiCqpxZT9kuE4lJ+oRx/Obcppt9HHdddpwHuFOA=,tag:287gQaVK+u9DfWtiYbbLfQ==,type:str]
     apple-login:
@@ -40,8 +41,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-01-16T16:05:22Z"
-    mac: ENC[AES256_GCM,data:KkHemaQqGt8r5aC70nqoUd8VFSyq/QYnqX7e2qT0zT+wuJNsmyXS3KBkEKOJ5DOdt/8eO/pR17mFWPgFipMkVmvFAk90wpnTe+bIH9/846TFWQjiGmtcJAdWcjAjgi/r6U5rHaN8ie2E7ByHuJX2dB2XOEhcFLQwPEiOIZqDkjI=,iv:saOc9LUeg9pJKyMZtLdghyg+rNdyJrAQAvFfae7qVpY=,tag:nrOYTfJHVUHE2883Is/CiA==,type:str]
+    lastmodified: "2025-03-11T01:16:52Z"
+    mac: ENC[AES256_GCM,data:FlHx0ZOce88sPtN9HAhjP1LpC+Ad+uPqUbIgnsjOtHhFBfhgPzAIREzAOcKRDzdnCEGnXBQBFhMLAS5RIDJyng9sMwYf3ZpnNm0SUqyCJ/MD/ykA/sBuZVj2Go/Pd9M2+7yO7RAOmm3xOdWJ6JujXhv3KZhBF+2oMOhqh1iSEJQ=,iv:gkWLDy77NO7zC0T/fT3bHCHy8qQzhnYWI6gwu+8/30c=,tag:VjiLKbSjGAOnYliXBVy3cg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.9.3
+    version: 3.9.4

--- a/infra/helm/scc-server/files/prod/secret.yaml
+++ b/infra/helm/scc-server/files/prod/secret.yaml
@@ -8,6 +8,7 @@ scc:
         apiKey: ENC[AES256_GCM,data:AWS2hzoPX4WsMQUDC02qNT1k6+M3RMBiw1df/cOEBLs=,iv:y6v6IVIbFn80EzBOsW37ARUL0lrwhbbQfespxduJt54=,tag:ibxSBY2+Vuu2lypB8q4E4g==,type:str]
     kakao-login:
         oauth-client-id: ENC[AES256_GCM,data:IA3i5xloGUeZasjRvB5Za09eOeR5Z1Zq3AuyBCftYkU=,iv:1AvpV9G+JyenX4G5OZfP4J/jZzbD/0OnELDR2Ot2tyk=,tag:YqL2TtIrZ0HRD1BNetnnaw==,type:str]
+        admin-key: ENC[AES256_GCM,data:zS7LW4EfVVqqWfEqjCUTuJnW21GkulPR2n2gA79c0Yc=,iv:cQyldGLlBQWTo+xGgAKN9yEI76MTR+lpasL9jRmsRt0=,tag:wzAe45CsKP8kZqjbPnlvLg==,type:str]
     admin:
         password: ENC[AES256_GCM,data:nxQSfCYrS2dpHw==,iv:LYZe//z2/aYVUBqjPPLDEi9TlqlHGaJ8FfhLcYcv2Cs=,tag:g9D/3brOdBmoESFEDiQj6Q==,type:str]
     apple-login:
@@ -40,8 +41,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-01-16T15:10:16Z"
-    mac: ENC[AES256_GCM,data:tNT6sN9W4LVuc/uGqo+eMZiZkjVihog2fFLraHtf08I66fkOjLUZeKfuNEiBtSwrk+NmDslZQyyj44m+FFQeD9JR8ouuDpJqSekjgppdK0T1T0bSGqJlJZt8CnOuPB6n0fVNUMhG4ERKIt7b9YHGPC083gRtdp4s6bKnoYK787Y=,iv:vnqIdW5MWFnGgkfb/HTqefYdP9ZoOnvPWfq0VE0ae5c=,tag:rx9cw+TtLerlOxm6eYTHAA==,type:str]
+    lastmodified: "2025-03-11T01:17:20Z"
+    mac: ENC[AES256_GCM,data:/QLFYyfD3ExNbFdsZw8GUYrh+4ZQLgAbpUjX1Y3/9Y9uDyPceLlVg1y3utNDw9FCf8Qm4UCiFbhsmwqGMyWS3frTdDu7oznTOdkkOrHbGXWYWJg2Nb1tFTcXBDRXWMgKV2V1n534L0D+bQK1hl9JTWkuRH9zEmZWYw6ItlSuv3U=,iv:mPptB/MEsj6zQyNwZT4QcG3GE5AhU6sa+QG2oeOsOxY=,tag:N/HGjTO+cfzj+4gCib474w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.9.3
+    version: 3.9.4


### PR DESCRIPTION
## Checklist

- 회원 탈퇴 시 소셜 로그인 제공사에 연결 해제 요청을 날립니다

- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 