### PR TITLE
[FIX] Accessibility 가 지워진 경우 Blur 가 동작하지 않는 문제 수정

### DIFF
--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/AccessibilityImageFaceBlurringHistoryRepository.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/AccessibilityImageFaceBlurringHistoryRepository.kt
@@ -4,8 +4,10 @@ import club.staircrusher.accessibility.domain.model.AccessibilityImageFaceBlurri
 import org.springframework.data.repository.CrudRepository
 
 interface AccessibilityImageFaceBlurringHistoryRepository : CrudRepository<AccessibilityImageFaceBlurringHistory, String> {
-    fun findFirstByPlaceAccessibilityIdIsNotNullOrderByCreatedAtDesc(): AccessibilityImageFaceBlurringHistory?
-    fun findFirstByBuildingAccessibilityIdIsNotNullOrderByCreatedAtDesc(): AccessibilityImageFaceBlurringHistory?
+    fun findTop5ByPlaceAccessibilityIdIsNotNullOrderByCreatedAtDesc(): List<AccessibilityImageFaceBlurringHistory>
+    fun findTop5ByBuildingAccessibilityIdIsNotNullOrderByCreatedAtDesc(): List<AccessibilityImageFaceBlurringHistory>
     fun findByPlaceAccessibilityId(placeAccessibilityId: String): List<AccessibilityImageFaceBlurringHistory>
+    fun findByPlaceAccessibilityIdIn(placeAccessibilityIds: Collection<String>): List<AccessibilityImageFaceBlurringHistory>
     fun findByBuildingAccessibilityId(buildingAccessibilityId: String): List<AccessibilityImageFaceBlurringHistory>
+    fun findByBuildingAccessibilityIdIn(buildingAccessibilityIds: Collection<String>): List<AccessibilityImageFaceBlurringHistory>
 }

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/BuildingAccessibilityRepository.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/BuildingAccessibilityRepository.kt
@@ -8,10 +8,11 @@ import org.springframework.data.repository.CrudRepository
 import java.time.Instant
 
 interface BuildingAccessibilityRepository : CrudRepository<BuildingAccessibility, String> {
+    fun findByIdIn(ids: Collection<String>): List<BuildingAccessibility>
     fun findByBuildingIdInAndDeletedAtIsNull(buildingIds: Collection<String>): List<BuildingAccessibility>
     fun findFirstByBuildingIdAndDeletedAtIsNull(buildingId: String): BuildingAccessibility?
     fun findByUserIdAndCreatedAtBetweenAndDeletedAtIsNull(userId: String, from: Instant, to: Instant): List<BuildingAccessibility>
-    fun findFirstByCreatedAtAfterAndDeletedAtIsNullOrderByCreatedAtAscIdDesc(createdAt: Instant): BuildingAccessibility?
+    fun findTop5ByCreatedAtAfterAndDeletedAtIsNullOrderByCreatedAtAscIdDesc(createdAt: Instant): List<BuildingAccessibility>
     fun countByUserIdAndCreatedAtBetweenAndDeletedAtIsNull(userId: String, from: Instant, to: Instant): Int
 
     data class CreateParams(

--- a/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/PlaceAccessibilityRepository.kt
+++ b/app-server/subprojects/bounded_context/accessibility/application/src/main/kotlin/club/staircrusher/accessibility/application/port/out/persistence/PlaceAccessibilityRepository.kt
@@ -10,11 +10,12 @@ import java.time.Instant
 
 @Suppress("TooManyFunctions")
 interface PlaceAccessibilityRepository : CrudRepository<PlaceAccessibility, String> {
+    fun findByIdIn(ids: Collection<String>): List<PlaceAccessibility>
     fun findByPlaceIdInAndDeletedAtIsNull(placeIds: Collection<String>): List<PlaceAccessibility>
     fun findFirstByPlaceIdAndDeletedAtIsNull(placeId: String): PlaceAccessibility?
     fun findByUserIdAndDeletedAtIsNull(userId: String): List<PlaceAccessibility>
     fun findByUserIdAndCreatedAtBetweenAndDeletedAtIsNull(userId: String, from: Instant, to: Instant): List<PlaceAccessibility>
-    fun findFirstByCreatedAtAfterAndDeletedAtIsNullOrderByCreatedAtAscIdDesc(createdAt: Instant): PlaceAccessibility?
+    fun findTop5ByCreatedAtAfterAndDeletedAtIsNullOrderByCreatedAtAscIdDesc(createdAt: Instant): List<PlaceAccessibility>
     fun countByUserIdAndDeletedAtIsNull(userId: String): Int
     fun countByUserIdAndCreatedAtBetweenAndDeletedAtIsNull(userId: String, from: Instant, to: Instant): Int
     @Query("""

--- a/app-server/subprojects/bounded_context/accessibility/domain/src/main/kotlin/club/staircrusher/accessibility/domain/model/AccessibilityImageFaceBlurringHistory.kt
+++ b/app-server/subprojects/bounded_context/accessibility/domain/src/main/kotlin/club/staircrusher/accessibility/domain/model/AccessibilityImageFaceBlurringHistory.kt
@@ -2,10 +2,10 @@ package club.staircrusher.accessibility.domain.model
 
 import club.staircrusher.stdlib.persistence.jpa.IntListToTextAttributeConverter
 import club.staircrusher.stdlib.persistence.jpa.StringListToTextAttributeConverter
+import club.staircrusher.stdlib.persistence.jpa.TimeAuditingBaseEntity
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
-import java.time.Instant
 
 @Entity
 class AccessibilityImageFaceBlurringHistory(
@@ -19,9 +19,7 @@ class AccessibilityImageFaceBlurringHistory(
     val blurredImageUrls: List<String>,
     @Convert(converter = IntListToTextAttributeConverter::class)
     val detectedPeopleCounts: List<Int>,
-    val createdAt: Instant,
-    val updatedAt: Instant
-) {
+) : TimeAuditingBaseEntity() {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/base/BlurFacesITBase.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/integrationTest/kotlin/club/staircrusher/accesssibility/infra/adapter/in/controller/base/BlurFacesITBase.kt
@@ -1,4 +1,4 @@
-package club.staircrusher.accessibility.application.port.`in`
+package club.staircrusher.accesssibility.infra.adapter.`in`.controller.base
 
 import club.staircrusher.accessibility.application.port.`in`.image.ImageProcessor
 import club.staircrusher.accessibility.application.port.out.DetectFacesResponse

--- a/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityImagePostProcessController.kt
+++ b/app-server/subprojects/bounded_context/accessibility/infra/src/main/kotlin/club/staircrusher/accessibility/infra/adapter/in/controller/AccessibilityImagePostProcessController.kt
@@ -2,6 +2,8 @@ package club.staircrusher.accessibility.infra.adapter.`in`.controller
 
 import club.staircrusher.accessibility.application.port.`in`.BlurFacesInLatestBuildingAccessibilityImagesUseCase
 import club.staircrusher.accessibility.application.port.`in`.BlurFacesInLatestPlaceAccessibilityImagesUseCase
+import club.staircrusher.spring_web.security.InternalIpAddressChecker
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -11,14 +13,14 @@ class AccessibilityImagePostProcessController(
     private val blurFacesInLatestBuildingAccessibilityImagesUseCase: BlurFacesInLatestBuildingAccessibilityImagesUseCase
 ) {
     @PostMapping("/blurFacesInLatestPlaceAccessibilityImages")
-    fun blurFacesInLatestPlaceAccessibilityImages() {
-        // TODO: UpdateChallengeRank 처럼 IP 체크
+    fun blurFacesInLatestPlaceAccessibilityImages(request: HttpServletRequest) {
+        InternalIpAddressChecker.check(request)
         blurFacesInLatestPlaceAccessibilityImagesUseCase.handleAsync()
     }
 
     @PostMapping("/blurFacesInLatestBuildingAccessibilityImages")
-    fun blurFacesInLatestBuildingAccessibilityImages() {
-        // TODO: UpdateChallengeRank 처럼 IP 체크
+    fun blurFacesInLatestBuildingAccessibilityImages(request: HttpServletRequest) {
+        InternalIpAddressChecker.check(request)
         blurFacesInLatestBuildingAccessibilityImagesUseCase.handleAsync()
     }
 }


### PR DESCRIPTION
## Checklist

- 현재 blurring 로직
  - 가장 최근 blur history 를 가져와서 해당하는 accessibility 를 가져온다
  - 가장 최근에 blur 된 accessibility 의 createdAt 를 가져와서 그 이후에 생성된 accessibility 중 가장 오래된 것을 들고 와서 blur 한다
- 이와 별개로 place accessibility 를 지울 때는 hard delete 를 합니다
- 현재 accessibility image face blurring history 에 가장 최근에 저장된 accessibility id 에 해당하는 것이 hard delete 되어서, 이미 blur 시킨 accessibility 를 계속 가져오고 있었습니다
  - 이러면 alreadyBlurred 에 해당해서 그냥 return
- 벌크로 가져와서 체크하도록 해서 몇개 지워져도 의도대로 동작하도록 했습니다

- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 