### PR TITLE
리대시 자원 조절

### DIFF
--- a/infra/helm/scc-redash/values.yaml
+++ b/infra/helm/scc-redash/values.yaml
@@ -321,10 +321,10 @@ redash:
     # server.resources -- Server resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
     resources:
       limits:
-        cpu: 300m
+        cpu: 400m
         memory: 1024Mi
       requests:
-        cpu: 300m
+        cpu: 400m
         memory: 1024Mi
 
     # server.podSecurityContext -- Security contexts for server pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
@@ -404,10 +404,10 @@ redash:
     # adhocWorker.resources -- Ad-hoc worker resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
     resources:
       limits:
-        cpu: 100m
+        cpu: 200m
         memory: 512Mi
       requests:
-        cpu: 100m
+        cpu: 200m
         memory: 512Mi
 
     # adhocWorker.podSecurityContext -- Security contexts for ad-hoc worker pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
@@ -549,10 +549,10 @@ redash:
     # genericWorker.resources -- Generic worker resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
     resources:
       limits:
-        cpu: 300m
+        cpu: 100m
         memory: 512Mi
       requests:
-        cpu: 300m
+        cpu: 100m
         memory: 512Mi
 
     # genericWorker.podSecurityContext -- Security contexts for generic worker pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)


### PR DESCRIPTION
## Checklist
- generic worker - 쿼리와 관련 없는 작업에 사용
- adhoc worker - adhoc 성으로 실행하는 쿼리에 사용
- adhoc worker 의 자원이 훨씬 중요해서 조절합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 