### PR TITLE
폐업 추정 장소 확정할 때 접근성 정보가 등록되어 있다면 삭제하기

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/AcceptClosedPlaceCandidateUseCase.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/AcceptClosedPlaceCandidateUseCase.kt
@@ -1,5 +1,7 @@
 package club.staircrusher.place.application.port.`in`.place
 
+import club.staircrusher.place.application.port.`in`.accessibility.DeleteAccessibilityAplService
+import club.staircrusher.place.application.port.out.accessibility.persistence.PlaceAccessibilityRepository
 import club.staircrusher.place.application.port.out.place.persistence.ClosedPlaceCandidateRepository
 import club.staircrusher.place.application.port.out.place.persistence.PlaceRepository
 import club.staircrusher.place.application.result.NamedClosedPlaceCandidate
@@ -12,16 +14,20 @@ class AcceptClosedPlaceCandidateUseCase(
     private val transactionManager: TransactionManager,
     private val closedPlaceCandidateRepository: ClosedPlaceCandidateRepository,
     private val placeRepository: PlaceRepository,
+    private val placeAccessibilityRepository: PlaceAccessibilityRepository,
+    private val deleteAccessibilityAplService: DeleteAccessibilityAplService,
 ) {
     fun handle(candidateId: String) = transactionManager.doInTransaction {
         val candidate = closedPlaceCandidateRepository.findByIdOrNull(candidateId)
             ?: throw IllegalArgumentException("closed place candidate with id($candidateId) not found")
         val place = placeRepository.findByIdOrNull(candidate.placeId)!!
+        val placeAccessibility = placeAccessibilityRepository.findFirstByPlaceIdAndDeletedAtIsNull(place.id)
 
         candidate.accept()
         closedPlaceCandidateRepository.save(candidate)
         place.setIsClosed(true)
         placeRepository.save(place)
+        placeAccessibility?.let { deleteAccessibilityAplService.deletePlaceAccessibility(it, place) }
 
         return@doInTransaction NamedClosedPlaceCandidate(
             candidateId = candidate.id,


### PR DESCRIPTION
## Checklist
- 폐업처리 + 정보 삭제를 함께 합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 