### PR TITLE
어드민 접근 권한 문제 임시 해결

### DIFF
--- a/app-server/subprojects/bounded_context/external_accessibility/infra/src/main/kotlin/club/staircrusher/external_accessibility/infra/adapter/in/controller/ExternalAccessibilityController.kt
+++ b/app-server/subprojects/bounded_context/external_accessibility/infra/src/main/kotlin/club/staircrusher/external_accessibility/infra/adapter/in/controller/ExternalAccessibilityController.kt
@@ -8,6 +8,7 @@ import club.staircrusher.api.spec.dto.ToiletAccessibilityDetails
 import club.staircrusher.external_accessibility.application.port.`in`.ExternalAccessibilitySearchService
 import club.staircrusher.external_accessibility.application.port.`in`.ExternalAccessibilityService
 import club.staircrusher.external_accessibility.application.port.`in`.ToiletAccessibilitySyncUseCase
+import club.staircrusher.spring_web.security.admin.SccAdminAuthentication
 import club.staircrusher.stdlib.external_accessibility.ExternalAccessibilityCategory
 import club.staircrusher.stdlib.geography.Length
 import club.staircrusher.stdlib.geography.Location
@@ -46,7 +47,9 @@ class ExternalAccessibilityController(
     }
 
     @PostMapping("/admin/syncWithDataSource")
-    fun syncWithDataSource(): String {
+    fun syncWithDataSource(
+        @Suppress("UnusedPrivateMember") authentication: SccAdminAuthentication
+    ): String {
         toiletAccessibilitySyncUseCase.load()
         return "OK"
     }

--- a/app-server/subprojects/bounded_context/external_accessibility/infra/src/main/kotlin/club/staircrusher/external_accessibility/infra/adapter/in/security/ExternalAccessibilityBoundedContextSecurityConfig.kt
+++ b/app-server/subprojects/bounded_context/external_accessibility/infra/src/main/kotlin/club/staircrusher/external_accessibility/infra/adapter/in/security/ExternalAccessibilityBoundedContextSecurityConfig.kt
@@ -3,15 +3,16 @@ package club.staircrusher.external_accessibility.infra.adapter.`in`.security
 import club.staircrusher.spring_web.security.SccSecurityConfig
 import club.staircrusher.stdlib.di.annotation.Component
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.RequestMatcher
 
 @Component
 class ExternalAccessibilityBoundedContextSecurityConfig : SccSecurityConfig {
     override fun requestMatchers() = listOf(
         "/searchExternalAccessibilities",
         "/getExternalAccessibility",
+
+        "/admin/syncWithDataSource",
     ).map { AntPathRequestMatcher(it) }
 
-    override fun identifiedUserOnlyRequestMatchers() = listOf(
-        "/admin/syncWithDataSource"
-    ).map { AntPathRequestMatcher(it) }
+    override fun identifiedUserOnlyRequestMatchers() = emptyList<RequestMatcher>()
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AdminAccessibilityAllowedRegionController.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AdminAccessibilityAllowedRegionController.kt
@@ -5,6 +5,7 @@ import club.staircrusher.admin_api.spec.dto.AccessibilityAllowedRegionDTO
 import club.staircrusher.admin_api.spec.dto.CreateAccessibilityAllowedRegionRequestDTO
 import club.staircrusher.place.application.port.`in`.accessibility.CreateAccessibilityAllowedRegionUseCase
 import club.staircrusher.place.application.port.out.accessibility.persistence.AccessibilityAllowedRegionRepository
+import club.staircrusher.spring_web.security.admin.SccAdminAuthentication
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,23 +19,34 @@ class AdminAccessibilityAllowedRegionController(
     private val accessibilityAllowedRegionRepository: AccessibilityAllowedRegionRepository,
 ) {
     @PostMapping("/admin/accessibilityAllowedRegions")
-    fun createAccessibilityAllowedRegion(@RequestBody request: CreateAccessibilityAllowedRegionRequestDTO) {
+    fun createAccessibilityAllowedRegion(
+        @RequestBody request: CreateAccessibilityAllowedRegionRequestDTO,
+        @Suppress("UnusedPrivateMember") authentication: SccAdminAuthentication,
+    ) {
         createAccessibilityAllowedRegionUseCase.handle(request.name, request.boundaryVertices.map { it.toModel() })
     }
 
     @GetMapping("/admin/accessibilityAllowedRegions")
-    fun listAllAccessibilityAllowedRegions(): List<AccessibilityAllowedRegionDTO> {
+    fun listAllAccessibilityAllowedRegions(
+        @Suppress("UnusedPrivateMember") authentication: SccAdminAuthentication,
+    ): List<AccessibilityAllowedRegionDTO> {
         return accessibilityAllowedRegionRepository.findAll().sortedByDescending { it.createdAt }
             .map { it.toDTO() }
     }
 
     @GetMapping("/admin/accessibilityAllowedRegions/{regionId}")
-    fun getAccessibilityAllowedRegion(@PathVariable regionId: String): AccessibilityAllowedRegionDTO {
+    fun getAccessibilityAllowedRegion(
+        @PathVariable regionId: String,
+        @Suppress("UnusedPrivateMember") authentication: SccAdminAuthentication,
+    ): AccessibilityAllowedRegionDTO {
         return accessibilityAllowedRegionRepository.findById(regionId).get().toDTO()
     }
 
     @DeleteMapping("/admin/accessibilityAllowedRegions/{regionId}")
-    fun deleteAccessibilityAllowedRegion(@PathVariable regionId: String) {
+    fun deleteAccessibilityAllowedRegion(
+        @PathVariable regionId: String,
+        @Suppress("UnusedPrivateMember") authentication: SccAdminAuthentication,
+    ) {
         return accessibilityAllowedRegionRepository.deleteById(regionId)
     }
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/security/PlaceBoundedContextSecurityConfig.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/security/PlaceBoundedContextSecurityConfig.kt
@@ -13,6 +13,8 @@ class PlaceBoundedContextSecurityConfig : SccSecurityConfig {
         "/getPlaceWithBuilding",
         "/listSearchKeywordsOfPlaceCategory",
         "/getAccessibilityLeaderboard",
+
+        "/admin/accessibilityAllowedRegions",
     ).map { AntPathRequestMatcher(it) }
 
     override fun identifiedUserOnlyRequestMatchers() = listOf(
@@ -30,7 +32,5 @@ class PlaceBoundedContextSecurityConfig : SccSecurityConfig {
         "/reportAccessibility",
         "/getImageUploadUrls",
         "/getAccessibilityActivityReport",
-
-        "/admin/accessibilityAllowedRegions",
-        ).map { AntPathRequestMatcher(it) }
+    ).map { AntPathRequestMatcher(it) }
 }


### PR DESCRIPTION
## Checklist
- admin 에는 login 해서 사용하기 때문에 엔드포인트를 identifiedUserRequestMatcher 쪽으로 넣어놨는데, SccAdminAuthentication 은 `IDENTIFIED` 라는 role 이 없기 때문에 403 이 뜨고 있음
- 배포까지 된 상태라 일단 임시 방편으로 그냥 request matcher 에 넣은 뒤 SccAdminAuthentication 을 메소드에서 확인하는 방법으로 처리
- 하지만 #496 에 적은 것처럼 admin 엔드포인트는 따로 관리할 필요가 있어 보입니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 