### PR TITLE
인증 단계에서 캐시 추가

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/GivePlaceAccessibilityUpvoteUseCase.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/GivePlaceAccessibilityUpvoteUseCase.kt
@@ -5,56 +5,52 @@ import club.staircrusher.place.application.port.out.accessibility.persistence.Pl
 import club.staircrusher.place.application.port.out.accessibility.persistence.PlaceAccessibilityUpvoteRepository
 import club.staircrusher.place.application.port.out.place.persistence.PlaceRepository
 import club.staircrusher.place.domain.model.accessibility.PlaceAccessibilityUpvote
-import club.staircrusher.stdlib.auth.AuthUser
+import club.staircrusher.stdlib.clock.SccClock
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
 import club.staircrusher.stdlib.persistence.TransactionManager
-import mu.KotlinLogging
+import club.staircrusher.user.application.port.out.persistence.UserProfileRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.repository.findByIdOrNull
-import java.time.Clock
 
 @Component
 class GivePlaceAccessibilityUpvoteUseCase(
     private val transactionManager: TransactionManager,
     private val slackService: SlackService,
     private val placeRepository: PlaceRepository,
+    private val userProfileRepository: UserProfileRepository,
     private val placeAccessibilityRepository: PlaceAccessibilityRepository,
     private val placeAccessibilityUpvoteRepository: PlaceAccessibilityUpvoteRepository,
     @Value("\${scc.slack.channel.reportAccessibility:#scc-accessibility-report}") val accessibilityReportChannel: String,
-    private val clock: Clock,
 ) {
-    private val logger = KotlinLogging.logger {}
-
     fun handle(
-        user: AuthUser,
+        userId: String,
         placeAccessibilityId: String,
     ) = transactionManager.doInTransaction(TransactionIsolationLevel.REPEATABLE_READ) {
         val placeAccessibility = placeAccessibilityRepository.findByIdOrNull(placeAccessibilityId)
             ?: throw IllegalArgumentException("PlaceAccessibility of id $placeAccessibilityId does not exist.")
-        val existingUpvote = placeAccessibilityUpvoteRepository.findExistingUpvote(user.id, placeAccessibilityId)
+        val existingUpvote = placeAccessibilityUpvoteRepository.findExistingUpvote(userId, placeAccessibilityId)
         existingUpvote ?: placeAccessibilityUpvoteRepository.save(
             PlaceAccessibilityUpvote(
                 id = EntityIdGenerator.generateRandom(),
-                userId = user.id,
+                userId = userId,
                 placeAccessibilityId = placeAccessibilityId,
-                createdAt = clock.instant(),
+                createdAt = SccClock.instant(),
             )
         )
 
         val place = placeRepository.findByIdOrNull(placeAccessibility.placeId)
+        val userProfile = userProfileRepository.findFirstByUserId(userId)
         val content = """
             접근성 정보가 도움이 돼요
             - 접근성 정보 Id: ${placeAccessibility.id}
             - 장소명: ${place?.name}
             - 주소: ${place?.address}
-            - 신고자: ${user.nickname}
+            - 신고자: ${userProfile?.nickname ?: "익명"}
         """.trimIndent()
-        logger.info("Content that will be sent to slack: $content")
 
         transactionManager.doAfterCommit {
-            logger.info("Give place accessibility upvote after commit for $placeAccessibilityId")
             slackService.send(
                 accessibilityReportChannel,
                 content,

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/ReportAccessibilityUseCase.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/ReportAccessibilityUseCase.kt
@@ -2,25 +2,27 @@ package club.staircrusher.place.application.port.`in`.accessibility
 
 import club.staircrusher.place.application.port.`in`.place.PlaceApplicationService
 import club.staircrusher.place.application.port.out.accessibility.SlackService
-import club.staircrusher.stdlib.auth.AuthUser
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.persistence.TransactionManager
+import club.staircrusher.user.application.port.out.persistence.UserProfileRepository
 import org.springframework.beans.factory.annotation.Value
 
 @Component
 class ReportAccessibilityUseCase(
     private val transactionManager: TransactionManager,
     private val slackService: SlackService,
+    private val userProfileRepository: UserProfileRepository,
     private val placeApplicationService: PlaceApplicationService,
     private val accessibilityApplicationService: AccessibilityApplicationService,
     @Value("\${scc.slack.channel.reportAccessibility:#scc-accessibility-report}") val accessibilityReportChannel: String,
 ) {
-    fun handle(placeId: String, authUser: AuthUser, reason: String?) {
-        val (place, placeAccessibility) = transactionManager.doInTransaction {
+    fun handle(placeId: String, userId: String, reason: String?) {
+        val (place, placeAccessibility, userProfile) = transactionManager.doInTransaction {
             val place = placeApplicationService.findPlace(placeId)
             val placeAccessibility = accessibilityApplicationService.doGetAccessibility(placeId, null).placeAccessibility
+            val userProfile = userProfileRepository.findFirstByUserId(userId)
 
-            return@doInTransaction place to placeAccessibility
+            return@doInTransaction Triple(place, placeAccessibility, userProfile)
         }
 
         val content = """
@@ -29,7 +31,7 @@ class ReportAccessibilityUseCase(
             - 장소명: ${place?.name}
             - 주소: ${place?.address}
             - 신고 사유: ${reason ?: "사유 없음"}
-            - 신고자: ${authUser.nickname}
+            - 신고자: ${userProfile?.nickname ?: "익명"}
         """.trimIndent()
 
         slackService.send(

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityUpvoteController.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityUpvoteController.kt
@@ -53,7 +53,7 @@ class AccessibilityUpvoteController(
         authentication: SccAppAuthentication,
     ): ResponseEntity<Unit> {
         givePlaceAccessibilityUpvoteUseCase.handle(
-            user = authentication.details,
+            userId = authentication.principal,
             placeAccessibilityId = request.placeAccessibilityId
         )
         return ResponseEntity

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/ReportAccessibilityController.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/ReportAccessibilityController.kt
@@ -19,7 +19,7 @@ class ReportAccessibilityController(
     ): ResponseEntity<Unit> {
         reportAccessibilityUseCase.handle(
             request.placeId,
-            authentication.details,
+            authentication.principal,
             request.reason,
         )
         return ResponseEntity

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/build.gradle.kts
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     api("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.guava)
     implementation(libs.kotlin.logging)
     implementation(libs.jackson.module.kotlin)
     runtimeOnly(libs.coroutines.reactor)

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/persistence/LocalCacheBuilder.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/persistence/LocalCacheBuilder.kt
@@ -1,0 +1,25 @@
+package club.staircrusher.spring_web.persistence
+
+import club.staircrusher.stdlib.di.annotation.Component
+import com.google.common.cache.Cache
+import com.google.common.cache.CacheBuilder
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics
+import java.util.concurrent.TimeUnit
+
+@Component
+class LocalCacheBuilder(
+    private val meterRegistry: MeterRegistry,
+) {
+    fun <K, V> build(name:String, maxSize: Long, expiresAfterSeconds: Long): Cache<K, V> {
+        val localCache = CacheBuilder.newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(expiresAfterSeconds, TimeUnit.SECONDS)
+            .recordStats()
+            .build<K, V>()
+
+        GuavaCacheMetrics.monitor(meterRegistry, localCache, name)
+
+        return localCache
+    }
+}

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationFilter.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/SccAuthenticationFilter.kt
@@ -1,9 +1,11 @@
 package club.staircrusher.spring_web.security
 
+import club.staircrusher.spring_web.persistence.LocalCacheBuilder
 import club.staircrusher.spring_web.security.admin.AdminAuthenticationService
 import club.staircrusher.spring_web.security.admin.SccAdminAuthenticationProvider
 import club.staircrusher.spring_web.security.app.SccAppAuthenticationProvider
 import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.persistence.TransactionManager
 import club.staircrusher.user.application.port.`in`.UserApplicationService
 import club.staircrusher.user.application.port.`in`.UserAuthApplicationService
 import org.springframework.http.HttpHeaders
@@ -16,11 +18,15 @@ class SccAuthenticationFilter(
     userAuthApplicationService: UserAuthApplicationService,
     userApplicationService: UserApplicationService,
     adminAuthenticationService: AdminAuthenticationService,
+    transactionManager: TransactionManager,
+    localCacheBuilder: LocalCacheBuilder,
 ) : AuthenticationFilter(
     ProviderManager(
         SccAppAuthenticationProvider(
             userAuthApplicationService,
             userApplicationService,
+            transactionManager,
+            localCacheBuilder,
         ),
         SccAdminAuthenticationProvider(adminAuthenticationService),
     ),

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthenticationProvider.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthenticationProvider.kt
@@ -41,13 +41,10 @@ class SccAppAuthenticationProvider(
                 if (user.isDeleted) {
                     throw BadCredentialsException("No User found with given credentials.")
                 }
-                val userProfile = userApplicationService.getProfileByUserIdOrNull(userId)
 
                 AuthUser(
                     id = user.id,
                     type = user.accountType.name,
-                    nickname = userProfile?.nickname,
-                    instagramId = userProfile?.instagramId,
                 )
             }
         }

--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthenticationProvider.kt
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/main/kotlin/club/staircrusher/spring_web/security/app/SccAppAuthenticationProvider.kt
@@ -1,7 +1,9 @@
 package club.staircrusher.spring_web.security.app
 
+import club.staircrusher.spring_web.persistence.LocalCacheBuilder
 import club.staircrusher.spring_web.security.BeforeAuthSccAuthentication
 import club.staircrusher.stdlib.auth.AuthUser
+import club.staircrusher.stdlib.persistence.TransactionManager
 import club.staircrusher.user.application.port.`in`.UserApplicationService
 import club.staircrusher.user.application.port.`in`.UserAuthApplicationService
 import club.staircrusher.user.domain.exception.UserAuthenticationException
@@ -14,7 +16,15 @@ import org.springframework.stereotype.Component
 class SccAppAuthenticationProvider(
     private val userAuthApplicationService: UserAuthApplicationService,
     private val userApplicationService: UserApplicationService,
+    private val transactionManager: TransactionManager,
+    localCacheBuilder: LocalCacheBuilder,
 ) : AuthenticationProvider {
+    private val authUserCache = localCacheBuilder.build<String, AuthUser>(
+        name = "auth_user",
+        maxSize = 100L,
+        expiresAfterSeconds = 10 * 60L,
+    )
+
     override fun authenticate(authentication: Authentication): Authentication {
         val beforeAuthSccAuthentication = authentication as BeforeAuthSccAuthentication
         val accessToken = beforeAuthSccAuthentication.credentials
@@ -24,21 +34,25 @@ class SccAppAuthenticationProvider(
             throw BadCredentialsException("Invalid access token.", e)
         }
 
-        val user = userApplicationService.getAccountOrNull(userId)
-            ?: throw BadCredentialsException("No User found with given credentials.")
-        if (user.isDeleted) {
-            throw BadCredentialsException("No User found with given credentials.")
-        }
-        val userProfile = userApplicationService.getProfileByUserIdOrNull(userId)
+        val authUser = authUserCache.get(userId) {
+            transactionManager.doInTransaction(isReadOnly = true) {
+                val user = userApplicationService.getAccountOrNull(userId)
+                    ?: throw BadCredentialsException("No User found with given credentials.")
+                if (user.isDeleted) {
+                    throw BadCredentialsException("No User found with given credentials.")
+                }
+                val userProfile = userApplicationService.getProfileByUserIdOrNull(userId)
 
-        return SccAppAuthentication(
-            AuthUser(
-                id = user.id,
-                type = user.accountType.name,
-                nickname = userProfile?.nickname,
-                instagramId = userProfile?.instagramId,
-            ),
-        )
+                AuthUser(
+                    id = user.id,
+                    type = user.accountType.name,
+                    nickname = userProfile?.nickname,
+                    instagramId = userProfile?.instagramId,
+                )
+            }
+        }
+
+        return SccAppAuthentication(authUser)
     }
 
     override fun supports(authentication: Class<*>): Boolean {

--- a/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/auth/AuthUser.kt
+++ b/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/auth/AuthUser.kt
@@ -3,6 +3,4 @@ package club.staircrusher.stdlib.auth
 data class AuthUser(
     val id: String,
     val type: String,
-    val nickname: String?,
-    val instagramId: String?,
 )


### PR DESCRIPTION
## Checklist
- 부하 테스트를 하다 보니 유저 인증 과정에서 hikaricp 커넥션을 많이 사용하는 것을 관찰했습니다
- 비회원 기능이 들어가게 되면서 거의 모든 엔드포인트에 인증 로직이 들어간 만큼, 캐싱을 해보려고 합니다
- 캐시 관련 메트릭도 meterRegistry 로 export 합니다
- user account 와 profile 을 가져올 때 tx 가 안묶여있었길래 이것도 묶어줍니다 (커넥션이 여기서 필요 이상으로 쓰였겠네요)
- https://agnica-coworkingspace.slack.com/archives/C0515M1HMFG/p1744696703060739?thread_ts=1744106103.092749&cid=C0515M1HMFG
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 