### PR TITLE
HikariCP 커넥션 타임아웃 늘리기

### DIFF
--- a/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/integrationTest/resources/application.yaml
+++ b/app-server/subprojects/cross_cutting_concern/infra/spring_web/src/integrationTest/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     url: jdbc:postgresql://localhost:15432/scc_test
     driver-class-name: org.postgresql.Driver
     hikari:
-      connection-timeout: 2000
+      connection-timeout: 25000
       data-source-properties.cachePrepStmts: true
       data-source-properties.prepStmtCacheSize: 250
       data-source-properties.prepStmtCacheSqlLimit: 2048

--- a/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/resources/application.yaml
+++ b/app-server/subprojects/cross_cutting_concern/test/spring_it/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     url: jdbc:postgresql://localhost:15432/scc_test
     driver-class-name: org.postgresql.Driver
     hikari:
-      connection-timeout: 2000
+      connection-timeout: 25000
       data-source-properties.cachePrepStmts: true
       data-source-properties.prepStmtCacheSize: 250
       data-source-properties.prepStmtCacheSqlLimit: 2048

--- a/app-server/subprojects/deploying_apps/scc_server/src/main/resources/application.yaml
+++ b/app-server/subprojects/deploying_apps/scc_server/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ spring:
     url: jdbc:postgresql://localhost:15433/scc
     driver-class-name: org.postgresql.Driver
     hikari:
-      connection-timeout: 2000
+      connection-timeout: 25000
       data-source-properties.cachePrepStmts: true
       data-source-properties.prepStmtCacheSize: 250
       data-source-properties.prepStmtCacheSqlLimit: 2048

--- a/infra/helm/scc-server/files/dev/application.yaml
+++ b/infra/helm/scc-server/files/dev/application.yaml
@@ -14,7 +14,7 @@ spring:
     url: jdbc:postgresql://scc-rds.ch28o2ai2p5m.ap-northeast-2.rds.amazonaws.com:5432/scc_dev
     driver-class-name: org.postgresql.Driver
     hikari:
-      connection-timeout: 2000
+      connection-timeout: 25000
       data-source-properties.cachePrepStmts: true
       data-source-properties.prepStmtCacheSize: 250
       data-source-properties.prepStmtCacheSqlLimit: 2048

--- a/infra/helm/scc-server/files/prod/application.yaml
+++ b/infra/helm/scc-server/files/prod/application.yaml
@@ -14,7 +14,7 @@ spring:
     url: jdbc:postgresql://scc-rds.ch28o2ai2p5m.ap-northeast-2.rds.amazonaws.com:5432/scc
     driver-class-name: org.postgresql.Driver
     hikari:
-      connection-timeout: 2000
+      connection-timeout: 25000
       data-source-properties.cachePrepStmts: true
       data-source-properties.prepStmtCacheSize: 250
       data-source-properties.prepStmtCacheSqlLimit: 2048


### PR DESCRIPTION
## Checklist
- 작년 크러셔 데이때 2초로 줄였었는데, DB 설정 (30초)에 맞게 적절히 25초로 설정합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 