### PR TITLE
이미지 사이즈 줄이기

### DIFF
--- a/app-server/gradle/libs.versions.toml
+++ b/app-server/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ mockitoKotlin = "5.1.0"
 thumbnailator = "0.4.20"
 webpImageio = "0.1.0"
 javaCv = "1.5.9"
+openCv = "4.7.0-1.5.9"
 bucket4j = "8.10.1"
 
 [libraries]
@@ -69,7 +70,8 @@ java-jwt = { group = "com.auth0", name = "java-jwt", version.ref = "jwt" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlin" }
 thumbnailator = { group = "net.coobird", name = "thumbnailator", version.ref = "thumbnailator" }
 webp-imageio = { group = "org.sejda.webp-imageio", name = "webp-imageio-sejda", version.ref = "webpImageio" }
-java-cv = { group = "org.bytedeco", name = "javacv-platform", version.ref = "javaCv" }
+java-cv = { group = "org.bytedeco", name = "javacv", version.ref = "javaCv" }
+open-cv = { group = "org.bytedeco", name = "opencv", version.ref = "openCv" }
 bucket4j-core = { group = "com.bucket4j", name = "bucket4j-core", version.ref = "bucket4j" }
 
 [bundles]

--- a/app-server/subprojects/bounded_context/place/application/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/place/application/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation(libs.thumbnailator)
     implementation(libs.webp.imageio)
     implementation(libs.java.cv)
+    runtimeOnly(variantOf(libs.open.cv){ classifier("linux-x86_64") })
     implementation(libs.kotlin.logging)
     implementation(libs.jts.core)
     implementation(libs.guava)


### PR DESCRIPTION
## Checklist
- bytedeco:javacv-platform 라이브러리를 추가하면서 jib 으로 마는 이미지 사이즈가 300 -> 1000 MB 로 매우 커졌는데,
- javacv-platform 라이브러리 안에 windows, macos, linux + x86_64, arm64 등 모든 경우의 수에 대한 binary 를 들고 있어서 그렇다고 합니다
- 그래서 javacv-platform 대신 javacv 라이브러리를 사용하고 (인터페이스)
- 버전이 맞는 opencv 의 linux-x86_64 만 runtimeOnly 로 들고 와서 빌드 이미지 사이즈를 좀 줄여봅니다
- javacv 가 고차원으로 추상화된 라이브러리로 opencv, ffmpeg, tesseract 등에 대한 추상화 레이어를 제공하고, opencv 는 실제 아키텍처에 맞는 cpp 코드로의 포팅을 제공한다고 하네요 (javacv-platform 은 이걸 그냥 싹다 합쳐 놓은 것)
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 