### PR TITLE
카카오 refresh token 최신화 잡 수정

### DIFF
--- a/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/UpdateExternalRefreshTokensUseCase.kt
+++ b/app-server/subprojects/bounded_context/user/application/src/main/kotlin/club/staircrusher/user/application/port/in/use_case/UpdateExternalRefreshTokensUseCase.kt
@@ -37,6 +37,7 @@ class UpdateExternalRefreshTokensUseCase(
         }
 
         val updatedTokens = userAuthIdToExpiringKakaoAuthTokens.mapNotNull { (id, token) ->
+            @Suppress("UnstableApiUsage")
             rateLimiter.acquire()
 
             val kakaoLoginTokens = runBlocking { kakaoLoginService.refreshToken(token) } ?: return@mapNotNull null

--- a/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/KakaoLoginServiceImpl.kt
+++ b/app-server/subprojects/bounded_context/user/infra/src/main/kotlin/club/staircrusher/user/infra/adapter/out/web/login/kakao/KakaoLoginServiceImpl.kt
@@ -70,7 +70,9 @@ class KakaoLoginServiceImpl(
                 KakaoLoginTokens(
                     accessToken = access_token,
                     accessTokenExpiresAt = SccClock.instant().plusSeconds(expires_in.toLong()),
-                    idToken = id_token?.let { parseIdToken(it) },
+                    // idToken 이 존재하지만 필요 없기 때문에 null 로 처리한다
+                    // 만약 사용하고 싶다면, 위에서 client_id 를 restApiKey 로 넣어줬기 때문에 jwt 토큰을 까봤을 때 aud 가 restApiKey 로 오는지 확인해야 한다
+                    idToken = null,
                     refreshToken = refresh_token,
                     refreshTokenExpiresAt = refresh_token_expires_in?.let { SccClock.instant().plusSeconds(it.toLong()) },
                 )


### PR DESCRIPTION
## Checklist
- refresh token 을 새로 요청할 때는 rest api key 를 사용하기 때문에 id_token 의 jwt audience 가 restApiKey 로 오게 됩니다
- 하지만 기존에 정의되어 있던 메소드는 oauth_client_id 를 사용하도록 되어 있기 때문에 에러가 나면서 업데이트가 안되고 있었습니다
- id token 이 필요한건 아니어서 일단 null 을 넣게 해뒀고, 만약에 나중에 사용한다면 audience 를 검증하는 로직에 분기를 태워야 할 듯 합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 