### PR TITLE
실섭 deployment max replica 줄이기

### DIFF
--- a/infra/helm/scc-server/values-prod.yaml
+++ b/infra/helm/scc-server/values-prod.yaml
@@ -69,8 +69,8 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 60
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70
   # targetMemoryUtilizationPercentage: 80
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
## Checklist
- 어차피 노드 자원이 부족해서 더 뜨지 못합니다
- threshold 도 60 정도일 필요까진 없는 것 같아서 70 으로 수정
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 