### PR TITLE
data plane 용 노드 하나 더 띄우기

### DIFF
--- a/infra/terraform/k3s/lightsail.tf
+++ b/infra/terraform/k3s/lightsail.tf
@@ -155,7 +155,7 @@ resource "aws_lightsail_instance_public_ports" "k3s_data_planes" {
 }
 
 resource "aws_lightsail_instance" "k3s_data_planes_v1_27_3" {
-  for_each = { for i in range(3) : i => i }
+  for_each = { for i in range(4) : i => i }
 
   name              = "k3s_data_plane_v1_27_3_${each.value}"
   availability_zone = element(["ap-northeast-2a", "ap-northeast-2c"], each.value % 2)
@@ -210,7 +210,7 @@ resource "aws_lightsail_instance_public_ports" "k3s_data_planes_v1_27_3" {
 
   lifecycle {
     replace_triggered_by = [
-      aws_lightsail_instance.k3s_data_planes[each.key].id
+      aws_lightsail_instance.k3s_data_planes_v1_27_3[each.key].id
     ]
   }
 }


### PR DESCRIPTION
## Checklist
- public port 에 정의되어 있는 lifecycle 설정이 잘못되어 있는 것 같아서 수정합니다 (terraform plan 오류 남)
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 