### PR TITLE
얼굴 블러 런타임 에러 수정

### DIFF
--- a/app-server/gradle/libs.versions.toml
+++ b/app-server/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ thumbnailator = "0.4.20"
 webpImageio = "0.1.0"
 javaCv = "1.5.9"
 openCv = "4.7.0-1.5.9"
+javaCpp = "1.5.9"
 bucket4j = "8.10.1"
 
 [libraries]
@@ -72,6 +73,7 @@ thumbnailator = { group = "net.coobird", name = "thumbnailator", version.ref = "
 webp-imageio = { group = "org.sejda.webp-imageio", name = "webp-imageio-sejda", version.ref = "webpImageio" }
 java-cv = { group = "org.bytedeco", name = "javacv", version.ref = "javaCv" }
 open-cv = { group = "org.bytedeco", name = "opencv", version.ref = "openCv" }
+java-cpp = { group = "org.bytedeco", name = "javacpp", version.ref = "javaCpp"}
 bucket4j-core = { group = "com.bucket4j", name = "bucket4j-core", version.ref = "bucket4j" }
 
 [bundles]

--- a/app-server/subprojects/bounded_context/place/application/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/place/application/build.gradle.kts
@@ -6,9 +6,11 @@ dependencies {
 
     implementation(libs.thumbnailator)
     implementation(libs.webp.imageio)
-    implementation(libs.java.cv)
-    runtimeOnly(variantOf(libs.open.cv){ classifier("linux-x86_64") })
     implementation(libs.kotlin.logging)
     implementation(libs.jts.core)
     implementation(libs.guava)
+    implementation(libs.java.cv)
+
+    runtimeOnly(variantOf(libs.open.cv) { classifier("linux-x86_64") })
+    runtimeOnly(variantOf(libs.java.cpp) { classifier("linux-x86_64") })
 }


### PR DESCRIPTION
## Checklist
- #503 에서 빌드 이미지 사이즈를 줄이는 작업을 했는데, java-cv 에서 필요로 하는 java-cpp native 라이브러리를 넣어주지 않아서 에러가 나고 있습니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 