### PR TITLE
CV 관련 라이브러리 implementation 으로 들고 오기

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/build.gradle.kts
+++ b/app-server/subprojects/bounded_context/place/application/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
     implementation(libs.jts.core)
     implementation(libs.guava)
     implementation(libs.java.cv)
-
-    runtimeOnly(variantOf(libs.open.cv) { classifier("linux-x86_64") })
-    runtimeOnly(variantOf(libs.java.cpp) { classifier("linux-x86_64") })
+    implementation(variantOf(libs.open.cv) { classifier("linux-x86_64") })
+    implementation(variantOf(libs.java.cpp) { classifier("linux-x86_64") })
 }


### PR DESCRIPTION
## Checklist
- 여전히 NoClassDefFound 오류가 뜨길래 runtimeOnly 대신 implementation 으로 들고 옵니다
- runtimeOnly 로 들고 오면 jib 으로 빌드할 때 native binary 들이 포함이 안될 수도 있다네요
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 