### PR TITLE
Kotlin 버전 업

### DIFF
--- a/app-server/detekt-config.yml
+++ b/app-server/detekt-config.yml
@@ -18,6 +18,8 @@ style:
     active: false
   ReturnCount:
     active: false
+  UseRequire:
+    active: false
 naming:
   PackageNaming:
     active: false

--- a/app-server/gradle/libs.versions.toml
+++ b/app-server/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
 # plugins
-kotlin = "1.8.20"
+kotlin = "2.0.21"
 springBoot = "3.0.5"
 springDependencyManagement = "1.1.0"
-detekt = "1.21.0"
-ksp = "1.8.20-1.0.10"
+detekt = "1.23.8"
+ksp = "2.0.21-1.0.28"
 jib = "3.4.1"
 openapiGenerator = "6.0.1"
 
 # libraries
 kotlinLogging = "3.0.5"
-kotlinSerialization = "1.5.1"
-coroutine = "1.6.4"
+kotlinSerialization = "1.7.3"
+coroutine = "1.9.0"
 geoTools = "26.5"
 jts = "1.19.0"
 proj4j = "1.3.0"

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -222,17 +222,17 @@ class KakaoMapsService(
             return result
         }
 
-        (2..pageablePage)
-            .map { page -> fetchPageBlock(page) }
+        val chunkedResult = (2..pageablePage)
+            .map { fetchPageBlock(it) }
             .chunked(FETCH_CHUNK_SIZE)
-            .forEach { chunkedMonos ->
-                val searchedPlaces = Mono
-                    .zip(chunkedMonos) {
-                        it.flatMap { (it as SearchResult).convertToModel() }
-                    }
-                    .awaitFirstOrNull()
-                searchedPlaces?.let { result += it }
-            }
+
+        chunkedResult.forEach { chunkedMonos ->
+            val searchedPlaces = Mono.zip(chunkedMonos) {
+                it.flatMap { (it as SearchResult).convertToModel() }
+            }.awaitFirstOrNull()
+            searchedPlaces?.let { result += it }
+        }
+
         return result.removeDuplicates()
     }
 


### PR DESCRIPTION
## Checklist
- 2.0.21 버전으로 올립니다 (빌드 속도가 좀 빨라지는지 볼 예정)
- 2.1.20 버전도 있는데 왜 2.0.21 버전인가? 하면 detekt 가 2.0.21 버전까지만 지원합니다
  - 2.1.20 버전을 지원하는 작업은 완료를 했는데 아직 release 를 안하고 있다네요
  - 그런데 detekt 2 를 개발하느라 바빠서 언제 release 될지는 모른답니다
  - https://github.com/detekt/detekt/issues/8067#issuecomment-2777438437
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 