### PR TITLE
Github action 에서 setup gradle 교체

### DIFF
--- a/.github/workflows/dev-ci-cd.yaml
+++ b/.github/workflows/dev-ci-cd.yaml
@@ -35,7 +35,7 @@ jobs:
           java-version: 19
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       # https://github.com/actions/cache/blob/main/examples.md#java---gradle
       - uses: actions/cache@v4

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -41,7 +41,7 @@ jobs:
           java-version: 19
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       # https://github.com/actions/cache/blob/main/examples.md#java---gradle
       - uses: actions/cache@v4

--- a/.github/workflows/prod-ci-cd.yaml
+++ b/.github/workflows/prod-ci-cd.yaml
@@ -39,7 +39,7 @@ jobs:
           java-version: 19
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       # https://github.com/actions/cache/blob/main/examples.md#java---gradle
       - uses: actions/cache@v4


### PR DESCRIPTION
## Checklist
- #516 에 나와있듯이 `gradle-build-action` 이 `gradle/actions/setup-gradle@v3` 로 바뀌었다고 합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 