### PR TITLE
[chore] dependabot 에서 kotlin 과 detekt 묶어서 관리하기

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,10 @@ updates:
     allow:
       - dependency-type: direct
     groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin:*"
+          - "io.gitlab.arturbosch.detekt"
       cv:
         patterns:
           - "org.bytedeco:*"


### PR DESCRIPTION
## Checklist
- detekt 는 kotlin compiler 버전과 강결합되어 있어서 함께 관리하도록 합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 