### PR TITLE
장소 검색에 database 에 있는 정보도 사용하기

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/place/persistence/PlaceRepository.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/place/persistence/PlaceRepository.kt
@@ -33,4 +33,7 @@ interface PlaceRepository : CrudRepository<Place, String> {
 
     @EntityGraph(attributePaths = ["building"])
     fun findAllByIdIn(ids: List<String>): List<Place>
+
+    @EntityGraph(attributePaths = ["building"])
+    fun findAllByNameStartsWith(name: String): List<Place>
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/KakaoMapsService.kt
@@ -222,17 +222,17 @@ class KakaoMapsService(
             return result
         }
 
-        (2..pageablePage)
-            .map { page -> fetchPageBlock(page) }
+        val chunkedResult = (2..pageablePage).map { fetchPageBlock(it) }
             .chunked(FETCH_CHUNK_SIZE)
-            .forEach { chunkedMonos ->
-                val searchedPlaces = Mono
-                    .zip(chunkedMonos) {
-                        it.flatMap { (it as SearchResult).convertToModel() }
-                    }
-                    .awaitFirstOrNull()
-                searchedPlaces?.let { result += it }
-            }
+
+        chunkedResult.forEach { chunkedMonos ->
+            val searchedPlaces = Mono.zip(chunkedMonos) {
+                it.flatMap { (it as SearchResult).convertToModel() }
+            }.awaitFirstOrNull()
+
+            searchedPlaces?.let { result += it }
+        }
+
         return result.removeDuplicates()
     }
 

--- a/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/resources/db/migration/V42__place_name_index.sql
+++ b/app-server/subprojects/cross_cutting_concern/infra/persistence_model/src/main/resources/db/migration/V42__place_name_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_place_3 ON place(name);


### PR DESCRIPTION
## Checklist
- place 테이블 name 칼럼에 index 추가
- keyword search 일 때만 rdb 를 함께 검색합니다
  - category 검색도 가능하긴 한데 반경 지정을 해줘야 함 - 조금 더 헤비한 작업이 될 가능성이 매우 높음
  - 현재 문제 상황과 연관은 없다고 판단해서 일단은 키워드만 적용
- `(db 검색 + 지도 검색).removeDuplicate()` 을 하게 되는데
- associate 는 같은 id 값으로 더 나중에 들어오는 값을 최종 적용하기 때문에
- `db 에는 있는데 지도 api 에서 못받아온 장소` + `지도 검색 결과` 순서대로 리스트가 형성 될 것
- 최종적으로 sorting 로직을 넣어야 할지는 잘 모르겠습니다
  - 별로 필요 없어 보이기도..
- https://www.notion.so/agnica/1-1d9c9499b060807382d3dbd05f6c1665?pvs=4
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 