### PR TITLE
feat: update base image

### DIFF
--- a/app-server/subprojects/deploying_apps/scc_server/build.gradle.kts
+++ b/app-server/subprojects/deploying_apps/scc_server/build.gradle.kts
@@ -36,7 +36,7 @@ jib {
         permissions.put("/app/run-java.sh", "755")
     }
     from {
-        image = "openjdk:19"
+        image = "eclipse-temurin:17"
         platforms {
             platform {
                 architecture = "amd64"


### PR DESCRIPTION
## Checklist
- openjdk docker 레포가 (꽤 예전부터) depreacte 되어 있어서 jib 에서 default 로 사용하는 eclipse-temurin 으로 base 이미지를 변경했습니다
  - https://github.com/GoogleContainerTools/jib/blob/master/docs/default_base_image.md
- 그리고 개발환경과 컴파일 target 은 jdk 17 로 되어 있는데, base image 가 19 로 되어 있길래 이것도 맞췄습니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 