### PR TITLE
검색 고도화 2차 시도

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
@@ -41,8 +41,7 @@ class PlaceApplicationService(
             return@coroutineScope emptyList()
         }
 
-        val combinedSearchResult = (findFromDatabase(keyword) + mapsService.findAllByKeyword(keyword, option)).removeDuplicates()
-        val places = combinedSearchResult
+        val places = mapsService.findAllByKeyword(keyword, option)
             .mergeLocalDatabases()
             .filterClosed()
             .let {
@@ -68,17 +67,6 @@ class PlaceApplicationService(
         return places
     }
 
-    private fun findFromDatabase(keyword: String): List<Place> {
-        if (keyword.isBlank() || keyword.length < MIN_KEYWORD_LENGTH) {
-            return emptyList()
-        }
-        // DB 에서 장소를 검색하는 것은 키워드와 일치하는데 지도 API 의 결과에 나오지 않는 문제를 해결하기 위한 것이다
-        // 따라서 10 개만 검색하더라도 충분하다
-        val pageRequest = PageRequest.of(0, 10)
-        return placeRepository.findAllByNameStartsWith(keyword, pageRequest)
-            .sortedBy { it.name.getSimilarityWith(keyword) }
-    }
-
     private fun List<Place>.filterClosed(): List<Place> {
         val closedPlaceIds = placeRepository.findAllById(this.map { it.id })
             .filter { it.isClosed }
@@ -92,6 +80,17 @@ class PlaceApplicationService(
 
     fun findByBuildingId(buildingId: String): List<Place> {
         return placeRepository.findByBuildingId(buildingId)
+    }
+
+    fun findByNameLike(keyword: String): List<Place> {
+        if (keyword.isBlank() || keyword.length < MIN_KEYWORD_LENGTH) {
+            return emptyList()
+        }
+        // DB 에서 장소를 검색하는 것은 키워드와 일치하는데 지도 API 의 결과에 나오지 않는 문제를 해결하기 위한 것이다
+        // 따라서 10 개만 검색하더라도 충분하다
+        val pageRequest = PageRequest.of(0, 10)
+        return placeRepository.findAllByNameStartsWith(keyword, pageRequest)
+            .sortedBy { it.name.getSimilarityWith(keyword) }
     }
 
     /**

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
@@ -166,10 +166,6 @@ class PlaceApplicationService(
         return placeFavoriteRepository.countByPlaceIdAndDeletedAtIsNull(placeId)
     }
 
-   private fun List<Place>.removeDuplicates(): List<Place> {
-        return associateBy { it.id }.values.toList()
-    }
-
     private fun List<Place>.mergeLocalDatabases(): List<Place> {
         val existingPlaceById = placeRepository.findAllById(this.map { it.id })
             .associateBy { it.id }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/search/PlaceSearchService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/search/PlaceSearchService.kt
@@ -186,7 +186,7 @@ class PlaceSearchService(
 
     companion object {
         private const val PLACE_SEARCH_MAX_RADIUS = 20000
-        // Threshold for ~2 km^2 area
-        private const val BOUNDING_BOX_AREA_THRESHOLD = 2_000_000
+        // Threshold for 9km^2 area
+        private const val BOUNDING_BOX_AREA_THRESHOLD = 9_000_000
     }
 }


### PR DESCRIPTION
## Checklist
- db 에서 이름으로 검색하는 장소는 bounding box 에 포함시키지 않는다
  - 전국 곳곳에 있는 프랜차이즈의 첫 부분만 검색하면 2km^2 면적 안에 들어올때까지 제거하다 보니 1개만 검색됨
  - bounding box 면적 threshold 키우기
- 필요하면 db 에서 이름으로 검색하는 부분에도 현 위치 주변 spatial index 쿼리를 달아야 할 것 같기도..
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 