### PR TITLE
feat: detekt auto-correct github action

### DIFF
--- a/.github/workflows/dev-ci-cd.yaml
+++ b/.github/workflows/dev-ci-cd.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 19
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 19
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -63,3 +63,33 @@ jobs:
           name: test report
           path: "**/build/reports"
           retention-days: 1
+
+  detekt-auto-correct:
+    runs-on: ubuntu-latest
+    needs: backend-ci
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: adopt
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Detekt Auto Correct
+        run: ./gradlew detekt --auto-correct
+
+      - name: Commit and push changes if any
+        run: |
+          git config --global user.email "staircrusherclub.dev@gmail.com"
+          git config --global user.name "Stair-Crusher-Club"
+          
+          if ! git diff --quiet; then
+            git add .
+            git commit -m "fix: auto-correct detekt issues"
+            git push origin HEAD:${{ github.head_ref }}
+          fi

--- a/.github/workflows/prod-ci-cd.yaml
+++ b/.github/workflows/prod-ci-cd.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 19
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
## Checklist
- https://autofix.ci/ 에서 영감을 얻었습니다
- pr-ci 에서 check 에 실패했다면 detekt --auto-correct 를 시도해서 diff 가 있을 시 commit & push 합니다
- 물론 detekt 에 주로 걸리는 애들이 import 문 같은거라 auto-correct 가 안되긴 할텐데 그래도 혹시 쓸데가 있을까 싶어서 추가했습니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 