### PR TITLE
[검색 고도화] 카테고리 검색과 키워드 검색 구분하기

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
@@ -63,6 +63,8 @@ class PlaceApplicationService(
     ): List<Place> {
         val places = mapsService.findAllByCategory(category, option)
             .mergeLocalDatabases()
+            .filterClosed()
+
         eventPublisher.publishEvent(PlaceSearchEvent(places.map(Place::toPlaceDTO)))
         return places
     }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
@@ -60,10 +60,13 @@ class PlaceApplicationService(
     suspend fun findAllByCategory(
         category: PlaceCategory,
         option: MapsService.SearchByCategoryOption,
+        shouldFilterClosed: Boolean = false,
     ): List<Place> {
         val places = mapsService.findAllByCategory(category, option)
             .mergeLocalDatabases()
-            .filterClosed()
+            .let {
+                if (shouldFilterClosed) it.filterClosed() else it
+            }
 
         eventPublisher.publishEvent(PlaceSearchEvent(places.map(Place::toPlaceDTO)))
         return places

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceCrawler.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceCrawler.kt
@@ -107,7 +107,10 @@ class PlaceCrawler(
                                             leftBottomLocation = leftBottomLocation,
                                             rightTopLocation = rightTopLocation,
                                         ),
-                                    )
+                                    ),
+                                    // 여기서 획득한 장소들의 건물 주소로 키워드 검색을 하게 되는데
+                                    // 장소가 폐업한 경우에도 그 건물에 있는 다른 장소는 폐업을 하지 않았을테니까 그 장소들을 가져오기 위해
+                                    shouldFilterClosed = false,
                                 )
                             }
                         }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceCrawler.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceCrawler.kt
@@ -34,6 +34,7 @@ class PlaceCrawler(
 
         return (placesByCategorySearch + placesByBuildingAddressSearch)
             .removeDuplicates { it.id }
+            .filterClosed()
     }
 
     suspend fun crawlPlacesInPolygon(points: List<Location>): List<Place> {
@@ -45,6 +46,7 @@ class PlaceCrawler(
 
         return (placesByCategorySearch + placesByBuildingAddressSearch)
             .removeDuplicates { it.id }
+            .filterClosed()
     }
 
     suspend fun crossValidatePlaces(places: List<Place>): List<Boolean> = coroutineScope {
@@ -145,6 +147,13 @@ class PlaceCrawler(
             lng = l1.lng * (1 - l2LngRatio) + l2.lng * l2LngRatio,
             lat = l1.lat * (1 - l2LatRatio) + l2.lat * l2LatRatio,
         )
+    }
+
+    private fun List<Place>.filterClosed(): List<Place> {
+        val closedPlaceIds = placeApplicationService.findAllByIds(this.map { it.id })
+            .filter { it.isClosed }
+            .map { it.id }
+        return this.filter { it.id !in closedPlaceIds }
     }
 
     private fun <T, ID> List<T>.removeDuplicates(idGetter: (T) -> ID): List<T> {

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/search/PlaceSearchService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/search/PlaceSearchService.kt
@@ -86,6 +86,7 @@ class PlaceSearchService(
                     sort = MapsService.SearchByCategoryOption.CircleRegion.Sort.DISTANCE,
                 )
             ),
+            shouldFilterClosed = true,
         )
     }
 

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/search/PlaceSearchService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/search/PlaceSearchService.kt
@@ -11,6 +11,7 @@ import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.geography.Length
 import club.staircrusher.stdlib.geography.Location
 import club.staircrusher.stdlib.geography.LocationUtils
+import club.staircrusher.stdlib.place.PlaceCategory
 
 @Component
 class PlaceSearchService(
@@ -31,40 +32,15 @@ class PlaceSearchService(
         limit: Int?,
         userId: String? = null,
     ): List<SearchPlacesResult> {
-        val places = placeApplicationService.findAllByKeyword(
-            searchText,
-            option = MapsService.SearchByKeywordOption(
-                region = currentLocation?.let {
-                    MapsService.SearchByKeywordOption.CircleRegion(
-                        centerLocation = it,
-                        radiusMeters = minOf(distanceMetersLimit.meter.toInt(), PLACE_SEARCH_MAX_RADIUS),
-                        sort = sort
-                            ?.let { MapsService.SearchByKeywordOption.CircleRegion.Sort.valueFrom(it) }
-                            ?: MapsService.SearchByKeywordOption.CircleRegion.Sort.ACCURACY
-                    )
-                }
-            ),
-        ).let {
-            if (it.isEmpty() && currentLocation != null) {
-                // Kakao 지도 API의 경우, 최대 검색 반경이 25km밖에 되지 않는다.
-                // 그래서 서울에서 제주 스타벅스를 검색하는 경우 검색 결과가 안뜨는 등의 이슈가 있다.
-                // 이러한 문제를 우회하기 위해, 검색 결과가 없는 경우에는 currentLocation을 빼고 검색을 다시 시도해본다.
-                placeApplicationService.findAllByKeyword(
-                    keyword = searchText,
-                    option = MapsService.SearchByKeywordOption(),
-                )
-            } else {
-                it
-            }
+        val placeCategory = PlaceCategory.valueOfOrNull(searchText)
+        val places = if (placeCategory != null && currentLocation != null) {
+            findByCategory(placeCategory, currentLocation, distanceMetersLimit)
+        } else {
+            findByKeyword(searchText, currentLocation, distanceMetersLimit, sort)
         }
+        val placeIdToIsFavoriteMap = userId?.let { uid -> placeApplicationService.isFavoritePlaces(places.map { it.id }, uid) } ?: emptyMap()
 
-        val clusteredPlaces = filterPlacesByBoundingBox(places, currentLocation)
-        val placesInPersistence = placeApplicationService.findByNameLike(searchText)
-
-        val combinedPlaces = (placesInPersistence + clusteredPlaces).removeDuplicates()
-        val placeIdToIsFavoriteMap = userId?.let { uid -> placeApplicationService.isFavoritePlaces(combinedPlaces.map { it.id }, uid) } ?: emptyMap()
-
-        return combinedPlaces.toSearchPlacesResult(currentLocation = currentLocation, placeIdToIsFavoriteMap = placeIdToIsFavoriteMap)
+        return places.toSearchPlacesResult(currentLocation = currentLocation, placeIdToIsFavoriteMap = placeIdToIsFavoriteMap)
             .filterWith(maxAccessibilityScore, hasSlope, isAccessibilityRegistered, limit)
             .let { if (sort == "ACCESSIBILITY_SCORE") it.sortedBy { it.accessibilityScore } else it }
     }
@@ -94,6 +70,60 @@ class PlaceSearchService(
         val places = placeApplicationService.findAllByIds(placeIds)
         val placeIdToIsFavoriteMap = userId?.let { placeApplicationService.isFavoritePlaces(placeIds, it) } ?: emptyMap()
         return places.toSearchPlacesResult(currentLocation = null, placeIdToIsFavoriteMap)
+    }
+
+    private suspend fun findByCategory(
+        category: PlaceCategory,
+        currentLocation: Location,
+        distanceMetersLimit: Length,
+    ): List<Place> {
+        return placeApplicationService.findAllByCategory(
+            category = category,
+            option = MapsService.SearchByCategoryOption(
+                region = MapsService.SearchByCategoryOption.CircleRegion(
+                    centerLocation = currentLocation,
+                    radiusMeters = minOf(distanceMetersLimit.meter.toInt(), PLACE_SEARCH_MAX_RADIUS),
+                    sort = MapsService.SearchByCategoryOption.CircleRegion.Sort.DISTANCE,
+                )
+            ),
+        )
+    }
+
+    private suspend fun findByKeyword(
+        searchText: String,
+        currentLocation: Location?,
+        distanceMetersLimit: Length,
+        sort: String?,
+    ): List<Place> {
+        val places = placeApplicationService.findAllByKeyword(
+            searchText,
+            option = MapsService.SearchByKeywordOption(
+                region = currentLocation?.let {
+                    MapsService.SearchByKeywordOption.CircleRegion(
+                        centerLocation = it,
+                        radiusMeters = minOf(distanceMetersLimit.meter.toInt(), PLACE_SEARCH_MAX_RADIUS),
+                        sort = sort
+                            ?.let { MapsService.SearchByKeywordOption.CircleRegion.Sort.valueFrom(it) }
+                            ?: MapsService.SearchByKeywordOption.CircleRegion.Sort.ACCURACY
+                    )
+                }
+            ),
+        ).let {
+            if (it.isEmpty() && currentLocation != null) {
+                // Kakao 지도 API의 경우, 최대 검색 반경이 25km밖에 되지 않는다.
+                // 그래서 서울에서 제주 스타벅스를 검색하는 경우 검색 결과가 안뜨는 등의 이슈가 있다.
+                // 이러한 문제를 우회하기 위해, 검색 결과가 없는 경우에는 currentLocation을 빼고 검색을 다시 시도해본다.
+                placeApplicationService.findAllByKeyword(
+                    keyword = searchText,
+                    option = MapsService.SearchByKeywordOption(),
+                )
+            } else {
+                it
+            }
+        }
+        val placesInPersistence = placeApplicationService.findByNameLike(searchText)
+
+        return (placesInPersistence + places).removeDuplicates()
     }
 
     private fun List<Place>.toSearchPlacesResult(currentLocation: Location?, placeIdToIsFavoriteMap: Map<String, Boolean>): List<SearchPlacesResult> {
@@ -135,58 +165,7 @@ class PlaceSearchService(
         return associateBy { it.id }.values.toList()
     }
 
-    private fun filterPlacesByBoundingBox(places: List<Place>, currentLocation: Location?): List<Place> {
-        if (places.isEmpty()) return places
-
-        val boundingBox = getBoundingBox(places)
-        if (boundingBox.area <= BOUNDING_BOX_AREA_THRESHOLD) {
-            return places
-        }
-
-        val mutablePlaces = places.toMutableList()
-        var area = boundingBox.area
-        while (area > BOUNDING_BOX_AREA_THRESHOLD && mutablePlaces.size > 1) {
-            val center = currentLocation ?: boundingBox.center
-            val farthestPlace = mutablePlaces.maxByOrNull { place ->
-                val distance = LocationUtils.calculateDistance(center, place.location)
-                distance.meter
-            } ?: break
-            mutablePlaces.remove(farthestPlace)
-            val newBoundingBox = getBoundingBox(mutablePlaces)
-            area = newBoundingBox.area
-        }
-
-        return mutablePlaces.toList()
-    }
-
-    private fun getBoundingBox(places: List<Place>): BoundingBox {
-        val minLat = places.minOf { it.location.lat }
-        val maxLat = places.maxOf { it.location.lat }
-        val minLon = places.minOf { it.location.lng }
-        val maxLon = places.maxOf { it.location.lng }
-        return BoundingBox(minLat, maxLat, minLon, maxLon)
-    }
-
-    private data class BoundingBox(
-        val minLat: Double,
-        val maxLat: Double,
-        val minLng: Double,
-        val maxLng: Double
-    ) {
-        val center: Location
-            get() = Location((minLng + maxLng) / 2, (minLat + maxLat) / 2)
-
-        val area: Double
-            get() {
-                val height = LocationUtils.calculateDistance(Location(minLng, minLat), Location(minLng, maxLat))
-                val width = LocationUtils.calculateDistance(Location(minLng, minLat), Location(maxLng, minLat))
-                return height.meter * width.meter
-            }
-    }
-
     companion object {
         private const val PLACE_SEARCH_MAX_RADIUS = 20000
-        // Threshold for 9km^2 area
-        private const val BOUNDING_BOX_AREA_THRESHOLD = 9_000_000
     }
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/SearchPlacesTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/SearchPlacesTest.kt
@@ -441,7 +441,7 @@ class SearchPlacesTest : PlaceSearchITBase() {
         mvc.sccRequest("/searchPlaces", params, user)
             .getResult(SearchPlacesPost200Response::class)
             .apply {
-                verifyBlocking(placeApplicationService, times(1)) { findAllByCategory(placeCategory, option) }
+                verifyBlocking(placeApplicationService, times(1)) { findAllByCategory(placeCategory, option, true) }
                 verify(placeApplicationService, never()).findByNameLike(eq(placeCategory.humanReadableName))
 
                 assertEquals(1, items!!.size)

--- a/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/place/PlaceCategory.kt
+++ b/app-server/subprojects/cross_cutting_concern/stdlib/src/main/kotlin/club/staircrusher/stdlib/place/PlaceCategory.kt
@@ -19,4 +19,11 @@ enum class PlaceCategory(val humanReadableName: String) {
     CAFE(humanReadableName = "카페"),
     HOSPITAL(humanReadableName = "병원"),
     PHARMACY(humanReadableName = "약국"),
+    ;
+
+    companion object {
+        fun valueOfOrNull(text: String): PlaceCategory? {
+            return values().firstOrNull { it.name == text || it.humanReadableName == text }
+        }
+    }
 }


### PR DESCRIPTION
## Checklist
- 예약어를 두어서 카테고리 검색과 키워드 검색을 구분합니다
- 카테고리 검색 - 주변 장소만 검색
  - 아직은 db 에서 이름 매칭해서 가져올 필요 없음
  - 실제로 존재하는 장소인데 카카오 api 에서 안나오는 문제가 너무 많다 싶으면 db 에 spatial index 쿼리해서 가져올 수 있을 듯
- 키워드 검색은 db 까지 조회해서 이름 매칭해서 가져옴
- bounding box 가 우리의 문제를 잘 해결해주는지 잘 모르겠어서 일단 지웠습니다
  - Ex) 미루꾸커피의 경우 부산과 고양에 지점이 있는데 "미루꾸커피"를 검색하면 이 두개의 장소 모두 나오는게 기대값
  - 그러면 "스타벅스" 를 검색했을 때 제주 지점이 검색 결과에 포함되는 것이 문제인가..?

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 