### PR TITLE
장소 정보에 위경도 포함

### DIFF
--- a/app-server/subprojects/api_specification/api/scc-api/api-spec.yaml
+++ b/app-server/subprojects/api_specification/api/scc-api/api-spec.yaml
@@ -1703,6 +1703,9 @@ components:
         address:
           type: string
           description: 점포의 human-readable한 주소.
+        location:
+          $ref: '#/components/schemas/Location'
+          description: 점포의 위경도.
         category:
           type: PlaceCategoryDto
           description: 점포의 카테고리

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/Converters.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/Converters.kt
@@ -13,6 +13,7 @@ fun Place.toDTO(isFavorite: Boolean) = club.staircrusher.api.spec.dto.Place(
     id = id,
     name = name,
     address = address.toString(),
+    location = location.toDTO(),
     category = category?.toDto(),
     isFavorite = isFavorite
 )


### PR DESCRIPTION
## Checklist
- 현재 건물의 위경도를 기준으로 지도에 표기하고 있어 큰 건물의 경우 화면이 어색한 경우가 있다
- 마커를 장소 기준으로 찍도록 위치 정보를 포함한다
- https://agnica-coworkingspace.slack.com/archives/C052R57TZDW/p1746680360839909
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 