### PR TITLE
대형 프랜차이즈 장소 로직 수정

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
@@ -87,13 +87,13 @@ class PlaceApplicationService(
         return placeRepository.findByBuildingId(buildingId)
     }
 
-    fun findByNameLike(keyword: String): List<Place> {
+    fun findByNameLike(keyword: String, limit: Int? = null): List<Place> {
         if (keyword.isBlank() || keyword.length < MIN_KEYWORD_LENGTH) {
             return emptyList()
         }
         // DB 에서 장소를 검색하는 것은 키워드와 일치하는데 지도 API 의 결과에 나오지 않는 문제를 해결하기 위한 것이다
         // 따라서 10 개만 검색하더라도 충분하다
-        val pageRequest = PageRequest.of(0, 10)
+        val pageRequest = PageRequest.of(0, limit ?: DEFAULT_PLACE_KEYWORD_SEARCH_LIMIT)
         return placeRepository.findAllByNameStartsWith(keyword, pageRequest)
             .sortedBy { it.name.getSimilarityWith(keyword) }
     }
@@ -193,5 +193,6 @@ class PlaceApplicationService(
 
     companion object {
         private const val MIN_KEYWORD_LENGTH = 3
+        private const val DEFAULT_PLACE_KEYWORD_SEARCH_LIMIT = 10
     }
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/SearchPlacesTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/SearchPlacesTest.kt
@@ -442,7 +442,7 @@ class SearchPlacesTest : PlaceSearchITBase() {
             .getResult(SearchPlacesPost200Response::class)
             .apply {
                 verifyBlocking(placeApplicationService, times(1)) { findAllByCategory(placeCategory, option, true) }
-                verify(placeApplicationService, never()).findByNameLike(eq(placeCategory.humanReadableName))
+                verify(placeApplicationService, never()).findByNameLike(eq(placeCategory.humanReadableName), any())
 
                 assertEquals(1, items!!.size)
                 assertEquals(place.id, items!![0].place.id)

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/SearchPlacesTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/SearchPlacesTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -442,7 +442,7 @@ class SearchPlacesTest : PlaceSearchITBase() {
             .getResult(SearchPlacesPost200Response::class)
             .apply {
                 verifyBlocking(placeApplicationService, times(1)) { findAllByCategory(placeCategory, option, true) }
-                verify(placeApplicationService, never()).findByNameLike(eq(placeCategory.humanReadableName), any())
+                verify(placeApplicationService, never()).findByNameLike(eq(placeCategory.humanReadableName), anyOrNull())
 
                 assertEquals(1, items!!.size)
                 assertEquals(place.id, items!![0].place.id)


### PR DESCRIPTION
## Checklist
- 지도를 매우 줌인한 상태에서 "스타벅스"를 검색할 경우, 해당 줌인된 지역 안에 스타벅스가 2개 정도 있는 경우가 있다
- 그러면 threshold 보다 개수가 작기 때문에 기본 로직을 타게 되는데, 이때 db 에서 가져오는 장소 정보가 합쳐져 보여진다
  - 이때 기본 로직은 db 에서 가져오는 장소에 대해 max distance 필터링을 걸지 않기 때문에 매우 먼 곳에 있는 스타벅스와 지도 내 스타벅스 2개가 함께 보여진다 => 매우 어색
- 따라서 대형 프랜차이즈인지 아닌지 확인할 때 지도 검색의 결과에 의존하는 것이 아닌, 지도 검색 + db 검색의 결과물에서 같은 string 으로 시작하는 장소가 몇개인지 보고 판단한다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 