### PR TITLE
이미지 얼굴 블러링 에러 로깅

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/AccessibilityImageProcessor.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/AccessibilityImageProcessor.kt
@@ -27,6 +27,7 @@ class AccessibilityImageProcessor : ImageProcessor {
                             blurredMat.apply(position.toMatRect())
                         } catch (t: Throwable) {
                             logger.error { "Failed to apply face region: $position for image size (${originalImageMat.size().width()}, ${originalImageMat.size().height()})" }
+                            logger.error { t.message }
                             continue
                         }
                         GaussianBlur(

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/AwsRekognitionService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/AwsRekognitionService.kt
@@ -41,7 +41,7 @@ internal class AwsRekognitionService(
             imageBytes = imageBytes,
             imageSize = imageSize,
             positions = detected.faceDetails().map {
-                calculateFacePosition(getImageSize(imageBytes), it.boundingBox())
+                calculateFacePosition(imageSize, it.boundingBox())
             },
         )
     }
@@ -60,13 +60,13 @@ internal class AwsRekognitionService(
     private fun calculateFacePosition(imageSize: Size, boundingBox: BoundingBox): DetectedFacePosition {
         val startX = (boundingBox.left() * imageSize.width).toInt()
         val startY = (boundingBox.top() * imageSize.height).toInt()
-        val endX = (startX + boundingBox.width() * imageSize.width).toInt()
-        val endY = (startY + boundingBox.height() * imageSize.height).toInt()
+        val width = (boundingBox.width() * imageSize.width).toInt()
+        val height = (boundingBox.height() * imageSize.height).toInt()
         return DetectedFacePosition(
             x = startX,
             y = startY,
-            width = endX - startX,
-            height = endY - startY,
+            width = width,
+            height = height,
         )
     }
 


### PR DESCRIPTION
## Checklist
- 이미지 블러링 중에 아래와 같은 에러가 가끔 떠서 로깅을 찍어봅니다
- 블러 중에 사용되는 Mat 와 BytePointer 에 try-with-resource 를 적용합니다
  - 가끔 pod restart 되는게 이쪽에서 문제가 되는거라고 의심하고 있어서 해당 PR 적용 이후 restart 빈도 체크 예정

```
java.lang.RuntimeException: OpenCV(4.7.0) /__w/javacpp-presets/javacpp-presets/opencv/cppbuild/linux-x86_64/opencv-4.7.0/modules/core/src/matrix.cpp:808: error: (-215:Assertion failed) 0 <= roi.x && 0 <= roi.width && roi.x + roi.width <= m.cols && 0 <= roi.y && 0 <= roi.height && roi.y + roi.height <= m.rows in function 'Mat'\n\n\tat org.bytedeco.opencv.opencv_core.Mat.apply(Native Method)\n\tat club.staircrusher.accessibility.application.port.in.AccessibilityImageProcessor.blur(AccessibilityImageProcessor.kt:22)
```

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 