### PR TITLE
dependabot 에서 coroutine 업데이트 제외

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,7 @@ updates:
     ignore:
       - dependency-name: "org.jetbrains.kotlin:*"
       - dependency-name: "org.springframework.boot"
+      - dependency-name: "org.jetbrains.kotlinx:kotlinx-coroutines-*"
       - dependency-name: "io.gitlab.arturbosch.detekt"
       - dependency-name: "org.jetbrains.kotlin:kotlin-reflect"
       - dependency-name: "org.jetbrains.kotlin:kotlin-stdlib-jdk8"


### PR DESCRIPTION
## Checklist
- coroutine 의 버전은 spring-bom 에 포함되어 있어서 dependabot 에서 제외합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 