### PR TITLE
feat: delete building accessibility

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/DeleteBuildingAccessibilityUseCase.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/DeleteBuildingAccessibilityUseCase.kt
@@ -1,0 +1,31 @@
+package club.staircrusher.place.application.port.`in`.accessibility
+
+import club.staircrusher.place.application.port.`in`.place.BuildingService
+import club.staircrusher.place.application.port.out.accessibility.persistence.BuildingAccessibilityRepository
+import club.staircrusher.stdlib.di.annotation.Component
+import club.staircrusher.stdlib.domain.SccDomainException
+import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
+import club.staircrusher.stdlib.persistence.TransactionManager
+import org.springframework.data.repository.findByIdOrNull
+
+@Component
+class DeleteBuildingAccessibilityUseCase(
+    private val transactionManager: TransactionManager,
+    private val deleteAccessibilityAplService: DeleteAccessibilityAplService,
+    private val buildingAccessibilityRepository: BuildingAccessibilityRepository,
+    private val buildingService: BuildingService,
+) {
+    fun handle(
+        userId: String,
+        buildingAccessibilityId: String,
+    ) : Unit = transactionManager.doInTransaction(TransactionIsolationLevel.SERIALIZABLE) {
+        val buildingAccessibility = buildingAccessibilityRepository.findByIdOrNull(buildingAccessibilityId)
+            ?: throw SccDomainException("삭제 가능한 건물 정보가 아닙니다.")
+        if (!buildingAccessibility.isDeletable(userId)) {
+            throw SccDomainException("삭제 가능한 건물 정보가 아닙니다.")
+        }
+
+        val building = buildingService.getById(buildingAccessibility.buildingId)!!
+        deleteAccessibilityAplService.deleteBuildingAccessibility(buildingAccessibility, building)
+    }
+}

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/DeletePlaceAccessibilityUseCase.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/DeletePlaceAccessibilityUseCase.kt
@@ -1,40 +1,31 @@
 package club.staircrusher.place.application.port.`in`.accessibility
 
 import club.staircrusher.place.application.port.`in`.place.PlaceApplicationService
-import club.staircrusher.place.application.port.out.accessibility.persistence.BuildingAccessibilityRepository
 import club.staircrusher.place.application.port.out.accessibility.persistence.PlaceAccessibilityRepository
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.domain.SccDomainException
 import club.staircrusher.stdlib.persistence.TransactionIsolationLevel
 import club.staircrusher.stdlib.persistence.TransactionManager
+import org.springframework.data.repository.findByIdOrNull
 
 @Component
-class DeleteAccessibilityUseCase(
+class DeletePlaceAccessibilityUseCase(
     private val transactionManager: TransactionManager,
     private val placeAccessibilityRepository: PlaceAccessibilityRepository,
     private val deleteAccessibilityAplService: DeleteAccessibilityAplService,
-    private val buildingAccessibilityRepository: BuildingAccessibilityRepository,
     private val placeApplicationService: PlaceApplicationService,
 ) {
     fun handle(
         userId: String,
         placeAccessibilityId: String,
     ) : Unit = transactionManager.doInTransaction(TransactionIsolationLevel.SERIALIZABLE) {
-        val placeAccessibility = placeAccessibilityRepository.findById(placeAccessibilityId).get()
+        val placeAccessibility = placeAccessibilityRepository.findByIdOrNull(placeAccessibilityId)
+            ?: throw SccDomainException("삭제 가능한 장소 정보가 아닙니다.")
         if (!placeAccessibility.isDeletable(userId)) {
             throw SccDomainException("삭제 가능한 장소 정보가 아닙니다.")
         }
 
         val place = placeApplicationService.findPlace(placeAccessibility.placeId)!!
         deleteAccessibilityAplService.deletePlaceAccessibility(placeAccessibility, place)
-
-        val building = place.building
-        val placeIds = placeApplicationService.findByBuildingId(building.id)
-            .map { it.id }
-            .toSet()
-        if (placeAccessibilityRepository.findByPlaceIdInAndDeletedAtIsNull(placeIds).isEmpty()) {
-            val buildingAccessibility = buildingAccessibilityRepository.findFirstByBuildingIdAndDeletedAtIsNull(building.id) ?: return@doInTransaction
-            deleteAccessibilityAplService.deleteBuildingAccessibility(buildingAccessibility, building)
-        }
     }
 }

--- a/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/accessibility/BuildingAccessibility.kt
+++ b/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/accessibility/BuildingAccessibility.kt
@@ -61,6 +61,10 @@ class BuildingAccessibility(
         this.elevatorImageUrls = images.map { it.imageUrl }
     }
 
+    fun isDeletable(uid: String?): Boolean {
+        return uid != null && uid == userId
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/DeleteAccessibilityTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/DeleteAccessibilityTest.kt
@@ -2,6 +2,7 @@ package club.staircrusher.place.infra.adapter.`in`.controller.accessibility
 
 import club.staircrusher.api.spec.dto.AccessibilityInfoDto
 import club.staircrusher.api.spec.dto.DeleteAccessibilityPostRequest
+import club.staircrusher.api.spec.dto.DeleteBuildingAccessibilityPostRequest
 import club.staircrusher.api.spec.dto.GetAccessibilityPostRequest
 import club.staircrusher.domain_event.PlaceAccessibilityDeletedEvent
 import club.staircrusher.domain_event.PlaceAccessibilityCommentDeletedEvent
@@ -9,7 +10,6 @@ import club.staircrusher.domain_event.BuildingAccessibilityDeletedEvent
 import club.staircrusher.domain_event.BuildingAccessibilityCommentDeletedEvent
 import club.staircrusher.place.application.port.out.accessibility.persistence.BuildingAccessibilityRepository
 import club.staircrusher.place.application.port.out.accessibility.persistence.PlaceAccessibilityRepository
-import club.staircrusher.place.domain.model.accessibility.PlaceAccessibility
 import club.staircrusher.place.infra.adapter.`in`.controller.accessibility.base.AccessibilityITBase
 import club.staircrusher.stdlib.domain.event.DomainEventPublisher
 import kotlinx.coroutines.runBlocking
@@ -24,7 +24,6 @@ import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.repository.findByIdOrNull
-import java.time.Duration
 
 class DeleteAccessibilityTest : AccessibilityITBase() {
 
@@ -38,19 +37,15 @@ class DeleteAccessibilityTest : AccessibilityITBase() {
     lateinit var domainEventPublisher: DomainEventPublisher
 
     @Test
-    fun `전반적인 테스트`() {
-        // given: 한 건물에 두 개의 장소 정보를 등록한다.
-        val (user, place1, placeAccessibility1, buildingAccessibility) = registerAccessibility()
-        val building = place1.building
-        val (_, place2, placeAccessibility2) = registerAccessibility(overridingUser = user, overridingBuilding = building)
+    fun `장소 정보를 삭제하는 경우`() {
+        val (user, place, placeAccessibility, buildingAccessibility) = registerAccessibility()
 
-        // when: 첫 번째 장소 정보를 삭제한다.
-        val deleteAccessibilityParams1 = DeleteAccessibilityPostRequest(placeAccessibilityId = placeAccessibility1.id)
+        val deletePlaceAccessibilityParams = DeleteAccessibilityPostRequest(placeAccessibilityId = placeAccessibility.id)
         mvc
-            .sccRequest("/deleteAccessibility", deleteAccessibilityParams1, userAccount = user)
+            .sccRequest("/deletePlaceAccessibility", deletePlaceAccessibilityParams, userAccount = user)
             .apply {
                 transactionManager.doInTransaction {
-                    assertNull(placeAccessibilityRepository.findByIdOrNull(placeAccessibility1.id))
+                    assertNull(placeAccessibilityRepository.findByIdOrNull(placeAccessibility.id))
                     assertNotNull(buildingAccessibilityRepository.findByIdOrNull(buildingAccessibility.id))
                 }
             }
@@ -61,9 +56,9 @@ class DeleteAccessibilityTest : AccessibilityITBase() {
             verify(domainEventPublisher, times(0)).publishEvent(any<BuildingAccessibilityDeletedEvent>())
             verify(domainEventPublisher, times(0)).publishEvent(any<BuildingAccessibilityCommentDeletedEvent>())
         }
-        val getAccessibilityParams1 = GetAccessibilityPostRequest(placeId = place1.id)
+        val getAccessibilityParams = GetAccessibilityPostRequest(placeId = place.id)
         mvc
-            .sccRequest("/getAccessibility", getAccessibilityParams1)
+            .sccRequest("/getAccessibility", getAccessibilityParams)
             .apply {
                 val result = getResult(AccessibilityInfoDto::class)
                 assertNull(result.placeAccessibility)
@@ -71,34 +66,35 @@ class DeleteAccessibilityTest : AccessibilityITBase() {
                 assertNotNull(result.buildingAccessibility)
                 assertTrue(result.buildingAccessibilityComments.isNotEmpty())
             }
+    }
 
-        // when: 마지막 남은 장소 정보를 삭제한다
-        reset(domainEventPublisher) // 메소드 호출 횟수를 리셋해준다.
-        val deleteAccessibilityParams2 = DeleteAccessibilityPostRequest(placeAccessibilityId = placeAccessibility2.id)
+    @Test
+    fun `건물 정보를 삭제하는 경우`() {
+        val (user, place, placeAccessibility, buildingAccessibility) = registerAccessibility()
+
+        val deleteBuildingAccessibilityParams = DeleteBuildingAccessibilityPostRequest(buildingAccessibilityId = buildingAccessibility.id)
         mvc
-            .sccRequest("/deleteAccessibility", deleteAccessibilityParams2, userAccount = user)
+            .sccRequest("/deleteBuildingAccessibility", deleteBuildingAccessibilityParams, userAccount = user)
             .apply {
                 transactionManager.doInTransaction {
-                    assertNull(placeAccessibilityRepository.findByIdOrNull(placeAccessibility2.id))
-                    // 건물의 마지막 장소 정보가 삭제되면 건물 정보도 삭제된다.
+                    assertNotNull(placeAccessibilityRepository.findByIdOrNull(placeAccessibility.id))
                     assertNull(buildingAccessibilityRepository.findByIdOrNull(buildingAccessibility.id))
                 }
             }
 
         runBlocking {
-            verify(domainEventPublisher, times(1)).publishEvent(any<PlaceAccessibilityDeletedEvent>())
-            verify(domainEventPublisher, times(1)).publishEvent(any<PlaceAccessibilityCommentDeletedEvent>())
-            // 건물 정보는 이중으로 등록되지 않으므로 1개만 삭제되고, 건물 코멘트는 이중 등록이 되므로 2개가 삭제된다.
+            verify(domainEventPublisher, times(0)).publishEvent(any<PlaceAccessibilityDeletedEvent>())
+            verify(domainEventPublisher, times(0)).publishEvent(any<PlaceAccessibilityCommentDeletedEvent>())
             verify(domainEventPublisher, times(1)).publishEvent(any<BuildingAccessibilityDeletedEvent>())
-            verify(domainEventPublisher, times(2)).publishEvent(any<BuildingAccessibilityCommentDeletedEvent>())
+            verify(domainEventPublisher, times(1)).publishEvent(any<BuildingAccessibilityCommentDeletedEvent>())
         }
-        val getAccessibilityParams2 = GetAccessibilityPostRequest(placeId = place1.id)
+        val getAccessibilityParams = GetAccessibilityPostRequest(placeId = place.id)
         mvc
-            .sccRequest("/getAccessibility", getAccessibilityParams2)
+            .sccRequest("/getAccessibility", getAccessibilityParams)
             .apply {
                 val result = getResult(AccessibilityInfoDto::class)
-                assertNull(result.placeAccessibility)
-                assertTrue(result.placeAccessibilityComments.isEmpty())
+                assertNotNull(result.placeAccessibility)
+                assertTrue(result.placeAccessibilityComments.isNotEmpty())
                 assertNull(result.buildingAccessibility)
                 assertTrue(result.buildingAccessibilityComments.isEmpty())
             }
@@ -113,13 +109,13 @@ class DeleteAccessibilityTest : AccessibilityITBase() {
 
         val params = DeleteAccessibilityPostRequest(placeAccessibilityId = placeAccessibility.id)
         mvc
-            .sccRequest("/deleteAccessibility", params, userAccount = otherUser)
+            .sccRequest("/deletePlaceAccessibility", params, userAccount = otherUser)
             .andExpect {
                 status { isBadRequest() }
             }
 
         mvc
-            .sccRequest("/deleteAccessibility", params)
+            .sccRequest("/deletePlaceAccessibility", params)
             .andExpect {
                 status { isUnauthorized() }
             }

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/GetAccessibilityTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/GetAccessibilityTest.kt
@@ -23,7 +23,6 @@ import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.springframework.boot.test.mock.mockito.SpyBean
-import java.time.Duration
 
 class GetAccessibilityTest : AccessibilityITBase() {
 
@@ -74,7 +73,6 @@ class GetAccessibilityTest : AccessibilityITBase() {
                 assertEquals(placeAccessibility.isFirstFloor, result.placeAccessibility!!.isFirstFloor)
                 assertEquals(placeAccessibility.stairInfo, result.placeAccessibility!!.stairInfo.toModel())
                 assertEquals(placeAccessibility.hasSlope, result.placeAccessibility!!.hasSlope)
-                assertTrue(result.placeAccessibility!!.deletionInfo!!.isLastInBuilding)
 
                 assertEquals(user.profile.nickname, result.placeAccessibility!!.registeredUserName)
                 assertEquals(1, result.placeAccessibilityComments.size)
@@ -100,7 +98,6 @@ class GetAccessibilityTest : AccessibilityITBase() {
             .sccRequest("/getAccessibility", params, userAccount = user.account)
             .apply {
                 val result = getResult(AccessibilityInfoDto::class)
-                assertTrue(result.placeAccessibility!!.deletionInfo!!.isLastInBuilding)
                 assertTrue(result.hasOtherPlacesToRegisterInBuilding)
             }
     }
@@ -120,7 +117,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
             }
             .apply {
                 val result = getResult(AccessibilityInfoDto::class)
-                assertNull(result.placeAccessibility!!.deletionInfo)
+                assertFalse(result.placeAccessibility!!.isDeletable)
             }
     }
 
@@ -143,11 +140,12 @@ class GetAccessibilityTest : AccessibilityITBase() {
             .apply {
                 val result = getResult(AccessibilityInfoDto::class)
                 assertNull(result.placeAccessibility!!.deletionInfo)
+                assertFalse(result.placeAccessibility!!.isDeletable)
             }
     }
 
     @Test
-    fun `한 건물에 두 개 이상의 장소 정보가 존재하면 삭제는 가능하지만 isLastInBuilding은 false이다`() {
+    fun `본인이 등록한 건물은 삭제가 가능하다`() {
         val (user, place1) = registerAccessibility()
         val building = place1.building
         registerAccessibility(overridingBuilding = building)
@@ -163,7 +161,7 @@ class GetAccessibilityTest : AccessibilityITBase() {
             }
             .apply {
                 val result = getResult(AccessibilityInfoDto::class)
-                assertFalse(result.placeAccessibility!!.deletionInfo!!.isLastInBuilding)
+                assertTrue(result.buildingAccessibility!!.isDeletable)
             }
     }
 

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/Converters.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/Converters.kt
@@ -40,6 +40,7 @@ fun BuildingAccessibility.toDTO(
     isUpvoted: Boolean,
     totalUpvoteCount: Int,
     registeredUserName: String?,
+    authUser: AuthUser?,
     challengeCrusherGroup: ChallengeCrusherGroup?
 ) = club.staircrusher.api.spec.dto.BuildingAccessibility(
     id = id,
@@ -58,6 +59,7 @@ fun BuildingAccessibility.toDTO(
     isUpvoted = isUpvoted,
     totalUpvoteCount = totalUpvoteCount,
     registeredUserName = registeredUserName,
+    isDeletable = isDeletable(authUser?.id),
     challengeCrusherGroup = challengeCrusherGroup?.toDTO(),
     createdAt = EpochMillisTimestamp(createdAt.toEpochMilli())
 )
@@ -69,6 +71,7 @@ fun GetAccessibilityResult.toDTO(authUser: AuthUser?) =
                 isUpvoted = buildingAccessibilityUpvoteInfo?.isUpvoted ?: false,
                 totalUpvoteCount = buildingAccessibilityUpvoteInfo?.totalUpvoteCount ?: 0,
                 registeredUserName = it.accessibilityRegisterer?.nickname,
+                authUser = authUser,
                 challengeCrusherGroup = buildingAccessibilityChallengeCrusherGroup
             )
         },
@@ -140,6 +143,7 @@ fun PlaceAccessibility.toDTO(
         hasSlope = hasSlope,
         entranceDoorTypes = entranceDoorTypes?.map { it.toDTO() },
         registeredUserName = registeredAccessibilityRegisterer?.nickname,
+        isDeletable = isDeletable(authUser?.id),
         challengeCrusherGroup = challengeCrusherGroup?.toDTO(),
         deletionInfo = if (isDeletable(authUser?.id)) {
             PlaceAccessibilityDeletionInfo(

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/DeleteAccessibilityController.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/DeleteAccessibilityController.kt
@@ -1,7 +1,9 @@
 package club.staircrusher.place.infra.adapter.`in`.controller.accessibility
 
 import club.staircrusher.api.spec.dto.DeleteAccessibilityPostRequest
-import club.staircrusher.place.application.port.`in`.accessibility.DeleteAccessibilityUseCase
+import club.staircrusher.api.spec.dto.DeleteBuildingAccessibilityPostRequest
+import club.staircrusher.place.application.port.`in`.accessibility.DeleteBuildingAccessibilityUseCase
+import club.staircrusher.place.application.port.`in`.accessibility.DeletePlaceAccessibilityUseCase
 import club.staircrusher.spring_web.security.app.SccAppAuthentication
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -10,16 +12,48 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class DeleteAccessibilityController(
-    private val deleteAccessibilityUseCase: DeleteAccessibilityUseCase,
+    private val deletePlaceAccessibilityUseCase: DeletePlaceAccessibilityUseCase,
+    private val deleteBuildingAccessibilityUseCase: DeleteBuildingAccessibilityUseCase,
 ) {
+    @Deprecated("Use deletePlaceAccessibility or deleteBuildingAccessibility instead")
     @PostMapping("/deleteAccessibility")
     fun deleteAccessibility(
         @RequestBody request: DeleteAccessibilityPostRequest,
         authentication: SccAppAuthentication,
     ) : ResponseEntity<Unit> {
-        deleteAccessibilityUseCase.handle(
+        deletePlaceAccessibilityUseCase.handle(
             userId = authentication.principal,
             placeAccessibilityId = request.placeAccessibilityId,
+        )
+        return ResponseEntity
+            .noContent()
+            .build()
+    }
+
+    @PostMapping("/deletePlaceAccessibility")
+    fun deletePlaceAccessibility(
+        // By default, the OpenAPI Generator re-uses DTOs that have identical fields
+        // even if they are declared separately in different operations
+        @RequestBody request: DeleteAccessibilityPostRequest,
+        authentication: SccAppAuthentication,
+    ) : ResponseEntity<Unit> {
+        deletePlaceAccessibilityUseCase.handle(
+            userId = authentication.principal,
+            placeAccessibilityId = request.placeAccessibilityId,
+        )
+        return ResponseEntity
+            .noContent()
+            .build()
+    }
+
+    @PostMapping("/deleteBuildingAccessibility")
+    fun deleteBuildingAccessibility(
+        @RequestBody request: DeleteBuildingAccessibilityPostRequest,
+        authentication: SccAppAuthentication,
+    ) : ResponseEntity<Unit> {
+        deleteBuildingAccessibilityUseCase.handle(
+            userId = authentication.principal,
+            buildingAccessibilityId = request.buildingAccessibilityId,
         )
         return ResponseEntity
             .noContent()

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/security/PlaceBoundedContextSecurityConfig.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/security/PlaceBoundedContextSecurityConfig.kt
@@ -25,6 +25,8 @@ class PlaceBoundedContextSecurityConfig : SccSecurityConfig {
         "/giveBuildingAccessibilityUpvote",
         "/cancelBuildingAccessibilityUpvote",
         "/deleteAccessibility",
+        "/deleteBuildingAccessibility",
+        "/deletePlaceAccessibility",
         "/getAccessibilityRank",
         "/getCountForNextRank",
         "/registerPlaceAccessibility",


### PR DESCRIPTION
## Checklist
- 기존에 건물 내 장소 정보가 모두 삭제되면 건물 정보가 삭제되는 로직 삭제
- 건물 / 장소 각각 삭제 가능
- 건물 정보는 내가 등록한 경우에만 삭제 가능
- deleteAccessibility 엔드포인트는 하위호환성을 위해 남겨두고, 코드 푸시가 완료되면 삭제할 예정
- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 