### PR TITLE
[FIX] 키워드 검색시 폐업 장소 필터링

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
@@ -94,7 +94,7 @@ class PlaceApplicationService(
         // DB 에서 장소를 검색하는 것은 키워드와 일치하는데 지도 API 의 결과에 나오지 않는 문제를 해결하기 위한 것이다
         // 따라서 10 개만 검색하더라도 충분하다
         val pageRequest = PageRequest.of(0, limit ?: DEFAULT_PLACE_KEYWORD_SEARCH_LIMIT)
-        return placeRepository.findAllByNameStartsWithAndClosedIsFalse(keyword, pageRequest)
+        return placeRepository.findAllByNameStartsWithAndIsClosedFalse(keyword, pageRequest)
             .sortedBy { it.name.getSimilarityWith(keyword) }
     }
 

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/place/PlaceApplicationService.kt
@@ -87,14 +87,14 @@ class PlaceApplicationService(
         return placeRepository.findByBuildingId(buildingId)
     }
 
-    fun findByNameLike(keyword: String, limit: Int? = null): List<Place> {
+    fun findByNameLikeAndNotClosed(keyword: String, limit: Int? = null): List<Place> {
         if (keyword.isBlank() || keyword.length < MIN_KEYWORD_LENGTH) {
             return emptyList()
         }
         // DB 에서 장소를 검색하는 것은 키워드와 일치하는데 지도 API 의 결과에 나오지 않는 문제를 해결하기 위한 것이다
         // 따라서 10 개만 검색하더라도 충분하다
         val pageRequest = PageRequest.of(0, limit ?: DEFAULT_PLACE_KEYWORD_SEARCH_LIMIT)
-        return placeRepository.findAllByNameStartsWith(keyword, pageRequest)
+        return placeRepository.findAllByNameStartsWithAndClosedIsFalse(keyword, pageRequest)
             .sortedBy { it.name.getSimilarityWith(keyword) }
     }
 

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/search/PlaceSearchService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/search/PlaceSearchService.kt
@@ -122,7 +122,7 @@ class PlaceSearchService(
                 it
             }
         }
-        val placesInPersistence = placeApplicationService.findByNameLike(searchText, BIG_FRANCHISE_THRESHOLD)
+        val placesInPersistence = placeApplicationService.findByNameLikeAndNotClosed(searchText, BIG_FRANCHISE_THRESHOLD)
         val combinedPlaces = (placesInPersistence + places).removeDuplicates()
 
         val bigFranchisePlaceCount = combinedPlaces.count { it.name.startsWith(searchText) }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/place/persistence/PlaceRepository.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/place/persistence/PlaceRepository.kt
@@ -36,5 +36,5 @@ interface PlaceRepository : CrudRepository<Place, String> {
     fun findAllByIdIn(ids: List<String>): List<Place>
 
     @EntityGraph(attributePaths = ["building"])
-    fun findAllByNameStartsWith(name: String, pageable: Pageable): List<Place>
+    fun findAllByNameStartsWithAndClosedIsFalse(name: String, pageable: Pageable): List<Place>
 }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/place/persistence/PlaceRepository.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/place/persistence/PlaceRepository.kt
@@ -36,5 +36,5 @@ interface PlaceRepository : CrudRepository<Place, String> {
     fun findAllByIdIn(ids: List<String>): List<Place>
 
     @EntityGraph(attributePaths = ["building"])
-    fun findAllByNameStartsWithAndClosedIsFalse(name: String, pageable: Pageable): List<Place>
+    fun findAllByNameStartsWithAndIsClosedFalse(name: String, pageable: Pageable): List<Place>
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/SearchPlacesTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/search/SearchPlacesTest.kt
@@ -442,7 +442,7 @@ class SearchPlacesTest : PlaceSearchITBase() {
             .getResult(SearchPlacesPost200Response::class)
             .apply {
                 verifyBlocking(placeApplicationService, times(1)) { findAllByCategory(placeCategory, option, true) }
-                verify(placeApplicationService, never()).findByNameLike(eq(placeCategory.humanReadableName), anyOrNull())
+                verify(placeApplicationService, never()).findByNameLikeAndNotClosed(eq(placeCategory.humanReadableName), anyOrNull())
 
                 assertEquals(1, items!!.size)
                 assertEquals(place.id, items!![0].place.id)


### PR DESCRIPTION
## Checklist
- persistence 에서 검색하는 경우 폐업 필터링이 적용되어 있지 않아서 적용합니다
- keyword 와 비슷한 name 으로 가져와서 애플리케이션 레벨에서 필터링 해도 되지만, 쿼리의 결과 개수와 대형 프랜차이즈 로직이 엮여 있기 때문에 필터링 로직을 쿼리에 녹여냈습니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 