### PR TITLE
파트너사 라벨 이미지 저장용 S3 bucket

### DIFF
--- a/infra/terraform/scc/iam-dev.tf
+++ b/infra/terraform/scc/iam-dev.tf
@@ -52,6 +52,18 @@ data "aws_iam_policy_document" "scc_dev_home_banners_full_access" {
   }
 }
 
+data "aws_iam_policy_document" "scc_dev_partner_labels_full_access" {
+  statement {
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      aws_s3_bucket.dev_partner_labels.arn,
+      "${aws_s3_bucket.dev_partner_labels.arn}/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "scc_dev_rekognition_access" {
   statement {
     actions = [
@@ -79,6 +91,11 @@ resource "aws_iam_policy" "scc_dev_accessibility_thumbnails_full_access" {
 resource "aws_iam_policy" "scc_dev_home_banners_full_access" {
   name   = "scc-dev-home-banners-full-access"
   policy = data.aws_iam_policy_document.scc_dev_home_banners_full_access.json
+}
+
+resource "aws_iam_policy" "scc_dev_partner_labels_full_access" {
+  name   = "scc-dev-partner-labels-full-access"
+  policy = data.aws_iam_policy_document.scc_dev_partner_labels_full_access.json
 }
 
 resource "aws_iam_policy" "scc_dev_rekognition_access" {

--- a/infra/terraform/scc/iam.tf
+++ b/infra/terraform/scc/iam.tf
@@ -52,6 +52,18 @@ data "aws_iam_policy_document" "scc_home_banners_full_access" {
   }
 }
 
+data "aws_iam_policy_document" "scc_partner_labels_full_access" {
+  statement {
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      aws_s3_bucket.partner_labels.arn,
+      "${aws_s3_bucket.partner_labels.arn}/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "scc_rekognition_access" {
   statement {
     actions = [
@@ -79,6 +91,11 @@ resource "aws_iam_policy" "scc_accessibility_thumbnails_full_access" {
 resource "aws_iam_policy" "scc_home_banners_full_access" {
   name   = "scc-home-banners-full-access"
   policy = data.aws_iam_policy_document.scc_home_banners_full_access.json
+}
+
+resource "aws_iam_policy" "scc_partner_labels_full_access" {
+  name   = "scc-partner-labels-full-access"
+  policy = data.aws_iam_policy_document.scc_partner_labels_full_access.json
 }
 
 resource "aws_iam_policy" "scc_rekognition_access" {

--- a/infra/terraform/scc/s3.tf
+++ b/infra/terraform/scc/s3.tf
@@ -177,3 +177,99 @@ resource "aws_s3_bucket_cors_configuration" "home_banners" {
     max_age_seconds = 3000
   }
 }
+
+resource "aws_s3_bucket" "dev_partner_labels" {
+  bucket = "scc-dev-partner-labels"
+}
+
+resource "aws_s3_bucket_ownership_controls" "dev_partner_labels" {
+  bucket = aws_s3_bucket.dev_partner_labels.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "dev_partner_labels" {
+  bucket = aws_s3_bucket.dev_partner_labels.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "dev_partner_labels" {
+  bucket = aws_s3_bucket.dev_partner_labels.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "s3:GetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Resource  = "${aws_s3_bucket.dev_partner_labels.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_cors_configuration" "dev_partner_labels" {
+  bucket = aws_s3_bucket.dev_partner_labels.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = ["http://localhost:3066", "https://admin.dev.staircrusher.club"]
+    max_age_seconds = 3000
+  }
+}
+
+resource "aws_s3_bucket" "partner_labels" {
+  bucket = "scc-prod-partner-labels"
+}
+
+resource "aws_s3_bucket_ownership_controls" "partner_labels" {
+  bucket = aws_s3_bucket.partner_labels.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "partner_labels" {
+  bucket = aws_s3_bucket.partner_labels.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "partner_labels" {
+  bucket = aws_s3_bucket.partner_labels.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "s3:GetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Resource  = "${aws_s3_bucket.partner_labels.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_cors_configuration" "partner_labels" {
+  bucket = aws_s3_bucket.partner_labels.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = ["https://admin.staircrusher.club"]
+    max_age_seconds = 3000
+  }
+}


### PR DESCRIPTION
## Checklist
- https://agnica-coworkingspace.slack.com/archives/C052R57TZDW/p1748313130985659?thread_ts=1748313074.086079&cid=C052R57TZDW
- 파트너사 라벨을 붙여주기 위해서 이미지 저장용 s3 파기
- 어드민에서 관리 예정
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 