### PR TITLE
이미지 후처리 한번에 한개씩만 하기

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/AccessibilityImageFaceBlurringService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/AccessibilityImageFaceBlurringService.kt
@@ -6,8 +6,6 @@ import club.staircrusher.place.application.port.out.accessibility.DetectFacesSer
 import club.staircrusher.place.domain.model.accessibility.AccessibilityImage
 import club.staircrusher.stdlib.di.annotation.Component
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
@@ -20,15 +18,13 @@ class AccessibilityImageFaceBlurringService(
 ) {
     private val logger = KotlinLogging.logger {}
 
-    suspend fun blurImages(accessibilityImages: List<AccessibilityImage>): List<AccessibilityImage> = coroutineScope {
-        accessibilityImages
-            .filter { it.blurredImageUrl == null }
-            .map { async { detectAndBlurFaces(it.originalImageUrl) to it } }
-            .awaitAll()
-            .map { (blurResult, image) ->
-                image.blurredImageUrl = blurResult.blurredImageUrl
-                return@map image
-            }
+    suspend fun blurImage(accessibilityImage: AccessibilityImage): AccessibilityImage = coroutineScope {
+        if (accessibilityImage.blurredImageUrl != null) return@coroutineScope accessibilityImage
+
+        val blurResult = detectAndBlurFaces(accessibilityImage.originalImageUrl)
+        accessibilityImage.blurredImageUrl = blurResult.blurredImageUrl
+
+        return@coroutineScope accessibilityImage
     }
 
     @Suppress("ReturnCount")

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/accessibility/persistence/AccessibilityImageRepository.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/accessibility/persistence/AccessibilityImageRepository.kt
@@ -16,7 +16,7 @@ interface AccessibilityImageRepository : CrudRepository<AccessibilityImage, Stri
             OR
             images.lastPostProcessedAt < :at
         ORDER BY images.createdAt DESC
-        LIMIT 3
+        LIMIT 10
     """)
     fun findBatchTargetsBefore(at: Instant): List<AccessibilityImage>
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePipelineTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePipelineTest.kt
@@ -27,7 +27,6 @@ class AccessibilityImagePipelineTest : AccessibilityITBase() {
         imageRepository.deleteAll()
     }
 
-    @Disabled
     @Test
     fun `이미지 처리`() {
         val fixedAccessibilityId = "someidnotused!"
@@ -43,8 +42,10 @@ class AccessibilityImagePipelineTest : AccessibilityITBase() {
             )
         }.toList()
 
-        runBlocking {
-            accessibilityImagePipeline.postProcessImages(savedImages)
+        savedImages.forEach {
+            runBlocking {
+                accessibilityImagePipeline.postProcessImage(it)
+            }
         }
 
         transactionManager.doInTransaction {

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePostProcessController.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePostProcessController.kt
@@ -35,8 +35,8 @@ class AccessibilityImagePostProcessController(
 
         val targetImages = accessibilityImagePipeline.getTargetImages()
         taskExecutor1.submit {
-            runBlocking {
-                accessibilityImagePipeline.postProcessImages(targetImages)
+            targetImages.forEach {
+                runBlocking { accessibilityImagePipeline.postProcessImage(it) }
             }
         }
     }


### PR DESCRIPTION
## Checklist
- 현재 coroutine 으로 동시에 10개의 이미지 처리를 하다 보니 cpu 사용량을 50%를 찍고 메모리가 터져서
- 한개씩 처리하도록 동시성을 낮춥니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 