### PR TITLE
이미지 후처리 한번에 한개씩만 하기

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/AccessibilityImagePipeline.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/AccessibilityImagePipeline.kt
@@ -31,8 +31,10 @@ class AccessibilityImagePipeline(
     fun asyncPostProcessImages(images: List<AccessibilityImage>) {
         transactionManager.doAfterCommit {
             taskExecutor.submit {
-                runBlocking {
-                    postProcessImages(images)
+                images.forEach { image ->
+                    runBlocking {
+                        postProcessImages(listOf(image))
+                    }
                 }
             }
         }

--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/accessibility/persistence/AccessibilityImageRepository.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/out/accessibility/persistence/AccessibilityImageRepository.kt
@@ -16,7 +16,7 @@ interface AccessibilityImageRepository : CrudRepository<AccessibilityImage, Stri
             OR
             images.lastPostProcessedAt < :at
         ORDER BY images.createdAt DESC
-        LIMIT 3
+        LIMIT 10
     """)
     fun findBatchTargetsBefore(at: Instant): List<AccessibilityImage>
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePipelineTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePipelineTest.kt
@@ -43,8 +43,10 @@ class AccessibilityImagePipelineTest : AccessibilityITBase() {
             )
         }.toList()
 
-        runBlocking {
-            accessibilityImagePipeline.postProcessImages(savedImages)
+        savedImages.forEach {
+            runBlocking {
+                accessibilityImagePipeline.postProcessImages(listOf(it))
+            }
         }
 
         transactionManager.doInTransaction {

--- a/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePipelineTest.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/integrationTest/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePipelineTest.kt
@@ -64,8 +64,8 @@ class AccessibilityImagePipelineTest : AccessibilityITBase() {
     }
 
     @Test
-    fun `배치는 최대 3개의 이미지를 가져온다`() {
-        val savedImages = transactionManager.doInTransaction {
+    fun `배치는 최대 10개의 이미지를 가져온다`() {
+        transactionManager.doInTransaction {
             imageRepository.saveAll(
                 (0 until 20).map {
                     AccessibilityImage(
@@ -79,7 +79,7 @@ class AccessibilityImagePipelineTest : AccessibilityITBase() {
         val retrievedImages = transactionManager.doInTransaction {
             accessibilityImagePipeline.getTargetImages()
         }
-        assertEquals(3, retrievedImages.size)
+        assertEquals(10, retrievedImages.size)
     }
 
     @Test

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePostProcessController.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/accessibility/AccessibilityImagePostProcessController.kt
@@ -35,8 +35,10 @@ class AccessibilityImagePostProcessController(
 
         val targetImages = accessibilityImagePipeline.getTargetImages()
         taskExecutor1.submit {
-            runBlocking {
-                accessibilityImagePipeline.postProcessImages(targetImages)
+            targetImages.forEach {
+                runBlocking {
+                    accessibilityImagePipeline.postProcessImages(listOf(it))
+                }
             }
         }
     }


### PR DESCRIPTION
## Checklist
- 현재 coroutine 으로 동시에 10개의 이미지 처리를 하다 보니 cpu 사용량을 50%를 찍고 메모리가 터져서
- 한개씩 처리하도록 동시성을 낮춥니다
- 함수에 넣어주는 param 만 변경

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 