### PR TITLE
이미 시작한 챌린지는 수정할 수 없도록

### DIFF
--- a/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/UpdateChallengeUseCase.kt
+++ b/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/UpdateChallengeUseCase.kt
@@ -3,6 +3,7 @@ package club.staircrusher.challenge.application.port.`in`.use_case
 import club.staircrusher.challenge.application.port.out.persistence.ChallengeRepository
 import club.staircrusher.challenge.domain.model.Challenge
 import club.staircrusher.challenge.domain.model.UpdateChallengeRequest
+import club.staircrusher.stdlib.clock.SccClock
 import club.staircrusher.stdlib.di.annotation.Component
 import club.staircrusher.stdlib.domain.SccDomainException
 import club.staircrusher.stdlib.persistence.TransactionManager
@@ -14,14 +15,27 @@ class UpdateChallengeUseCase(
     private val challengeRepository: ChallengeRepository,
 ) {
     fun handle(updateRequest: UpdateChallengeRequest): Challenge = transactionManager.doInTransaction {
+        val now = SccClock.instant()
         val updatingChallenge = challengeRepository.findByIdOrNull(updateRequest.id) ?: throw SccDomainException("챌린지를 찾을 수 없습니다.")
+        if (updateRequest.startsAt.isBefore(now)) {
+            throw SccDomainException(
+                "챌린지 시작일은 현재 시간 이후여야 합니다.(${updateRequest.startsAt})",
+                errorCode = SccDomainException.ErrorCode.INVALID_ARGUMENTS,
+            )
+        }
+        if (updatingChallenge.startsAt.isBefore(now)) {
+            throw SccDomainException(
+                "이미 시작된 챌린지는 수정할 수 없습니다.",
+                errorCode = SccDomainException.ErrorCode.INVALID_ARGUMENTS,
+            )
+        }
         val challengeFromInvitationCode = updateRequest.invitationCode?.let {
             challengeRepository.findFirstByInvitationCode(it)
         }
         if (challengeFromInvitationCode != null && challengeFromInvitationCode.id != updatingChallenge.id) {
             throw SccDomainException(
                 "해당 참여코드로 만든 챌린지가 이미 존재합니다.(${updateRequest.invitationCode})",
-                errorCode = SccDomainException.ErrorCode.INVALID_ARGUMENTS
+                errorCode = SccDomainException.ErrorCode.INVALID_ARGUMENTS,
             )
         }
 

--- a/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/Challenge.kt
+++ b/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/Challenge.kt
@@ -46,18 +46,24 @@ class Challenge(
     fun update(updateRequest: UpdateChallengeRequest) {
         val invitationCode = updateRequest.invitationCode?.let { validateAndNormalizeString(it) }
         val passcode = updateRequest.passcode?.let { validateAndNormalizeString(it) }
-        val startsAt = Instant.ofEpochMilli(updateRequest.startsAtMillis)
-        val endsAt = updateRequest.endsAtMillis?.let { Instant.ofEpochMilli(it) }
         val milestones = updateRequest.milestones.sorted()
-        validate(invitationCode, updateRequest.isPublic, startsAt, endsAt, updateRequest.goal, milestones, updateRequest.conditions)
+        validate(
+            invitationCode,
+            updateRequest.isPublic,
+            updateRequest.startsAt,
+            updateRequest.endsAt,
+            updateRequest.goal,
+            milestones,
+            updateRequest.conditions,
+        )
 
         this.name = validateAndNormalizeString(updateRequest.name)
         this.isPublic = updateRequest.isPublic
         this.invitationCode = invitationCode
         this.passcode = passcode
         this.crusherGroup = updateRequest.crusherGroup
-        this.startsAt = startsAt
-        this.endsAt = endsAt
+        this.startsAt = updateRequest.startsAt
+        this.endsAt = updateRequest.endsAt
         this.goal = updateRequest.goal
         this.milestones = milestones
         this.conditions = updateRequest.conditions

--- a/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/UpdateChallengeRequest.kt
+++ b/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/UpdateChallengeRequest.kt
@@ -1,13 +1,15 @@
 package club.staircrusher.challenge.domain.model
 
+import java.time.Instant
+
 data class UpdateChallengeRequest(
     val id: String,
     val name: String,
     val isPublic: Boolean,
     val invitationCode: String?,
     val passcode: String?,
-    val startsAtMillis: Long,
-    val endsAtMillis: Long?,
+    val startsAt: Instant,
+    val endsAt: Instant?,
     val goal: Int,
     val milestones: List<Int>,
     val conditions: List<ChallengeCondition>,

--- a/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/controller/AdminConverters.kt
+++ b/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/controller/AdminConverters.kt
@@ -16,6 +16,7 @@ import club.staircrusher.challenge.domain.model.ChallengeCondition
 import club.staircrusher.challenge.domain.model.ChallengeCrusherGroup
 import club.staircrusher.challenge.domain.model.CreateChallengeRequest
 import club.staircrusher.challenge.domain.model.UpdateChallengeRequest
+import java.time.Instant
 
 fun Challenge.toAdminDTO() = AdminChallengeDTO(
     id = id,
@@ -55,8 +56,8 @@ fun AdminUpdateChallengeRequestDTO.toModel(challengeId: String) = UpdateChalleng
     isPublic = isPublic,
     invitationCode = invitationCode,
     passcode = passcode,
-    startsAtMillis = startsAtMillis,
-    endsAtMillis = endsAtMillis,
+    startsAt = Instant.ofEpochMilli(startsAtMillis),
+    endsAt = endsAtMillis?.let { Instant.ofEpochMilli(it) },
     goal = goal,
     milestones = milestones,
     conditions = conditions.map { it.toModel() },


### PR DESCRIPTION
## Checklist
- 데이터 정합성을 위해 이미 시작한 챌린지는 수정할 수 없도록 막습니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 