### PR TITLE
업데이트 가능한 챌린지 필드 제한

### DIFF
--- a/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/UpdateChallengeUseCase.kt
+++ b/app-server/subprojects/bounded_context/challenge/application/src/main/kotlin/club/staircrusher/challenge/application/port/in/use_case/UpdateChallengeUseCase.kt
@@ -15,15 +15,6 @@ class UpdateChallengeUseCase(
 ) {
     fun handle(updateRequest: UpdateChallengeRequest): Challenge = transactionManager.doInTransaction {
         val updatingChallenge = challengeRepository.findByIdOrNull(updateRequest.id) ?: throw SccDomainException("챌린지를 찾을 수 없습니다.")
-        val challengeFromInvitationCode = updateRequest.invitationCode?.let {
-            challengeRepository.findFirstByInvitationCode(it)
-        }
-        if (challengeFromInvitationCode != null && challengeFromInvitationCode.id != updatingChallenge.id) {
-            throw SccDomainException(
-                "해당 참여코드로 만든 챌린지가 이미 존재합니다.(${updateRequest.invitationCode})",
-                errorCode = SccDomainException.ErrorCode.INVALID_ARGUMENTS
-            )
-        }
 
         updatingChallenge.update(updateRequest)
         challengeRepository.save(updatingChallenge)

--- a/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/Challenge.kt
+++ b/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/Challenge.kt
@@ -1,6 +1,7 @@
 package club.staircrusher.challenge.domain.model
 
 import club.staircrusher.stdlib.clock.SccClock
+import club.staircrusher.stdlib.domain.SccDomainException
 import club.staircrusher.stdlib.domain.entity.EntityIdGenerator
 import club.staircrusher.stdlib.persistence.jpa.IntListToTextAttributeConverter
 import jakarta.persistence.Column
@@ -44,23 +45,14 @@ class Challenge(
     }
 
     fun update(updateRequest: UpdateChallengeRequest) {
-        val invitationCode = updateRequest.invitationCode?.let { validateAndNormalizeString(it) }
-        val passcode = updateRequest.passcode?.let { validateAndNormalizeString(it) }
-        val startsAt = Instant.ofEpochMilli(updateRequest.startsAtMillis)
-        val endsAt = updateRequest.endsAtMillis?.let { Instant.ofEpochMilli(it) }
-        val milestones = updateRequest.milestones.sorted()
-        validate(invitationCode, updateRequest.isPublic, startsAt, endsAt, updateRequest.goal, milestones, updateRequest.conditions)
+        val endsAt = updateRequest.endsAt
+        if (endsAt != null && startsAt.isAfter(endsAt)) {
+            throw SccDomainException("시작 시각은 종료시각보다 빨라야 합니다.")
+        }
 
         this.name = validateAndNormalizeString(updateRequest.name)
-        this.isPublic = updateRequest.isPublic
-        this.invitationCode = invitationCode
-        this.passcode = passcode
         this.crusherGroup = updateRequest.crusherGroup
-        this.startsAt = startsAt
         this.endsAt = endsAt
-        this.goal = updateRequest.goal
-        this.milestones = milestones
-        this.conditions = updateRequest.conditions
         this.description = updateRequest.description.trim()
         this.updatedAt = SccClock.instant()
     }

--- a/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/UpdateChallengeRequest.kt
+++ b/app-server/subprojects/bounded_context/challenge/domain/src/main/kotlin/club/staircrusher/challenge/domain/model/UpdateChallengeRequest.kt
@@ -1,16 +1,11 @@
 package club.staircrusher.challenge.domain.model
 
+import java.time.Instant
+
 data class UpdateChallengeRequest(
     val id: String,
     val name: String,
-    val isPublic: Boolean,
-    val invitationCode: String?,
-    val passcode: String?,
-    val startsAtMillis: Long,
-    val endsAtMillis: Long?,
-    val goal: Int,
-    val milestones: List<Int>,
-    val conditions: List<ChallengeCondition>,
+    val endsAt: Instant?,
     val description: String,
     val crusherGroup: ChallengeCrusherGroup?,
 )

--- a/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/controller/AdminConverters.kt
+++ b/app-server/subprojects/bounded_context/challenge/infra/src/main/kotlin/club/staircrusher/challenge/infra/adapter/in/controller/AdminConverters.kt
@@ -16,6 +16,7 @@ import club.staircrusher.challenge.domain.model.ChallengeCondition
 import club.staircrusher.challenge.domain.model.ChallengeCrusherGroup
 import club.staircrusher.challenge.domain.model.CreateChallengeRequest
 import club.staircrusher.challenge.domain.model.UpdateChallengeRequest
+import java.time.Instant
 
 fun Challenge.toAdminDTO() = AdminChallengeDTO(
     id = id,
@@ -52,14 +53,7 @@ fun AdminCreateChallengeRequestDTO.toModel() = CreateChallengeRequest(
 fun AdminUpdateChallengeRequestDTO.toModel(challengeId: String) = UpdateChallengeRequest(
     id = challengeId,
     name = name,
-    isPublic = isPublic,
-    invitationCode = invitationCode,
-    passcode = passcode,
-    startsAtMillis = startsAtMillis,
-    endsAtMillis = endsAtMillis,
-    goal = goal,
-    milestones = milestones,
-    conditions = conditions.map { it.toModel() },
+    endsAt = endsAtMillis?.let { Instant.ofEpochMilli(it) },
     description = description,
     crusherGroup = crusherGroup?.toModel(),
 )


### PR DESCRIPTION
## Checklist
- 업데이트 되어도 정합성에 문제가 없고, 바뀔법한 필드로만 제한합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 