### PR TITLE
dependabot 설정

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,7 @@ updates:
     ignore:
       # kotlin + spring-boot 버전에 의해 bom 으로 관리되는 라이브러리들
       - dependency-name: "org.jetbrains.kotlin*"
+      - dependency-name: "com.google.devtools.ksp"
       - dependency-name: "org.springframework.boot"
       - dependency-name: "io.gitlab.arturbosch.detekt"
       - dependency-name: "com.fasterxml.jackson.module:jackson-module-kotlin"


### PR DESCRIPTION
- ksp 는 kotlin 버전에 종속되므로 무시합니다
- 그리고 갑자기 파이썬 라이브러리를 업데이트하는 PR (#599)가 열려서 pip 은 무시하도록 설정을 바꾸려 했는데 놀랍게도 dependabot 에 그런 설정은 없다네요
- `package-ecosystem: "gradle"` 를 적용해도 gradle 외에 detect 되면 다 업데이트 한다고 함;;
- 관련해서 이슈도 있지만 동작을 바꿀 생각은 없어 보입니다
  - https://github.com/dependabot/dependabot-core/issues/2883

## Checklist
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 