### PR TITLE
어드민에서 아직 안보낸 푸시 알림 예약 스케줄만 보여주기

### DIFF
--- a/app-server/subprojects/bounded_context/notification/application/src/main/kotlin/club/staircrusher/notification/port/in/PushScheduleService.kt
+++ b/app-server/subprojects/bounded_context/notification/application/src/main/kotlin/club/staircrusher/notification/port/in/PushScheduleService.kt
@@ -38,7 +38,7 @@ class PushScheduleService(
             overFetchLimit,
         )
         val result = pushNotificationScheduleRepository.findCursored(
-            cursorCreatedAt = cursor.timestamp,
+            cursorScheduledAt = cursor.timestamp,
             cursorId = cursor.id,
             pageable = pageRequest,
         )
@@ -53,7 +53,6 @@ class PushScheduleService(
                     body = schedules.first().body,
                     deepLink = schedules.first().deepLink,
                     userIds = schedules.flatMap { it.userIds },
-                    createdAt = schedules.first().createdAt,
                 )
             }
         val selected = grouped.take(normalizedLimit)
@@ -81,7 +80,6 @@ class PushScheduleService(
             body = pushNotificationSchedules.first().body,
             deepLink = pushNotificationSchedules.first().deepLink,
             userIds = pushNotificationSchedules.flatMap { it.userIds },
-            createdAt = pushNotificationSchedules.first().createdAt,
         )
     }
 
@@ -214,11 +212,11 @@ class PushScheduleService(
     }
 
     private data class Cursor(
-        val createdAt: Instant,
+        val scheduledAt: Instant,
         val groupId: String,
-    ) : TimestampCursor(createdAt, groupId) {
+    ) : TimestampCursor(scheduledAt, groupId) {
         constructor(schedule: FlattenedPushSchedule) : this(
-            createdAt = schedule.createdAt,
+            scheduledAt = schedule.scheduledAt,
             groupId = schedule.groupId,
         )
 

--- a/app-server/subprojects/bounded_context/notification/application/src/main/kotlin/club/staircrusher/notification/port/in/result/FlattenedPushSchedule.kt
+++ b/app-server/subprojects/bounded_context/notification/application/src/main/kotlin/club/staircrusher/notification/port/in/result/FlattenedPushSchedule.kt
@@ -10,5 +10,4 @@ class FlattenedPushSchedule(
     val body: String,
     val deepLink: String?,
     val userIds: List<String>,
-    val createdAt: Instant,
 )

--- a/app-server/subprojects/bounded_context/notification/application/src/main/kotlin/club/staircrusher/notification/port/out/persistence/PushNotificationScheduleRepository.kt
+++ b/app-server/subprojects/bounded_context/notification/application/src/main/kotlin/club/staircrusher/notification/port/out/persistence/PushNotificationScheduleRepository.kt
@@ -13,13 +13,13 @@ interface PushNotificationScheduleRepository : CrudRepository<PushNotificationSc
         FROM PushNotificationSchedule s
         WHERE
             (
-                (s.createdAt = :cursorCreatedAt AND s.groupId < :cursorId)
-                OR (s.createdAt < :cursorCreatedAt)
+                (s.scheduledAt = :cursorScheduledAt AND s.groupId < :cursorId)
+                OR (s.scheduledAt > :cursorScheduledAt)
             )
-        ORDER BY s.createdAt DESC, s.groupId DESC
+        ORDER BY s.scheduledAt ASC, s.groupId DESC
     """)
     fun findCursored(
-        cursorCreatedAt: Instant,
+        cursorScheduledAt: Instant,
         cursorId: String,
         pageable: Pageable
     ): Page<PushNotificationSchedule>


### PR DESCRIPTION
## Checklist
- 어드민에서 과거의 기록을 볼 필요는 없을 것 같아서 아직 scheduledAt 이 지나지 않은 스케줄만 보여줍니다
- [x] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 