### PR TITLE
Spring Boot 3.1 업그레이드

### DIFF
--- a/app-server/gradle/libs.versions.toml
+++ b/app-server/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # plugins
 kotlin = "1.8.20"
-springBoot = "3.0.5"
+springBoot = "3.1.12"
 springDependencyManagement = "1.1.7"
 detekt = "1.21.0"
 ksp = "1.8.20-1.0.10"


### PR DESCRIPTION
## Checklist
- 3.1 [Release Note](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.1-Release-Notes)
- 큰 breaking change 는 없어 보입니다
- 주목할만한 업데이트는 Hibernate 가 6.2 버전으로 올라가는 것
  - native query eager loading 과 optional one to one unique contraint 핸들링이 제대로 됨
- 3.0 -> 3.1 -> 3.2 순서로 차근차근 올릴 계획인데, 3.2 에는 Class Loading 도중 deadlock [이슈](https://github.com/spring-projects/spring-boot/pull/41665)가 있었다가 3.2.9 에서 해결된 것으로 보입니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 