### PR TITLE
Alloy 를 Promtail 과 유사하게 동작하도록 설정

### DIFF
--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -227,16 +227,14 @@ alloy:
       content: |-
         discovery.kubernetes "kubernetes_pods" {
           role = "pod"
+
+          namespaces {
+            names = ["scc", "dev"]
+          }
         }
         
         discovery.relabel "kubernetes_pods" {
           targets = discovery.kubernetes.kubernetes_pods.targets
-        
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            regex         = "scc|dev"
-            action        = "keep"
-          }
 
           rule {
             source_labels = ["__meta_kubernetes_pod_controller_name"]
@@ -309,6 +307,7 @@ alloy:
         }
 
         loki.process "kubernetes_pods" {
+          stage.cri {}
           forward_to = [loki.write.default.receiver]
         }
 


### PR DESCRIPTION
## Checklist
- promtail 의 경우 pod log 를 알아서 파싱해주는데, alloy 같은 경우는 그렇지 않아서 기존과 동일하게 동작하도록 `stage.cri` 를 추가해줍니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 