### PR TITLE
Loki-backend IRSA 설정

### DIFF
--- a/infra/helm/monitoring/values.yaml
+++ b/infra/helm/monitoring/values.yaml
@@ -153,6 +153,24 @@ loki:
 
   backend:
     replicas: 1
+    extraEnv:
+      - name: AWS_ROLE_ARN
+        value: arn:aws:iam::291889421067:role/monitoring
+      - name: AWS_WEB_IDENTITY_TOKEN_FILE
+        value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+    extraVolumeMounts:
+      - name: aws-iam-token
+        mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+        readOnly: true
+    extraVolumes:
+      - name: aws-iam-token
+        projected:
+          defaultMode: 420
+          sources:
+            - serviceAccountToken:
+                audience: sts.amazonaws.com
+                expirationSeconds: 86400
+                path: token
   read:
     replicas: 1
     extraEnv:
@@ -213,9 +231,7 @@ loki:
 alloy:
   serviceAccount:
     create: true
-    name: loki
-    annotations:
-      eks.amazonaws.com/role-arn: arn:aws:iam::291889421067:role/monitoring
+    name: alloy
   alloy:
     enableReporting: false
     mounts:


### PR DESCRIPTION
## Checklist
- loki 가 로그를 잘 가져오기는 하는데 loki-backend 팟에서 아래와 같은 에러가 찍히고 있었습니다
- 찾아보니 loki-backend 팟에서도 s3 에 접근해서 index 테이블을 관리해야 하는데, irsa 설정이 안되어 있어서 에러가 뜨고 있었습니다
- loki-read 와 loki-write 팟과 같이 irsa 설정을 해줍니다
```
level=error ts=2025-07-10T06:11:25.507569885Z caller=index_set.go:308 table-name=loki_index_20279 msg="sync failed, retrying it" err="AccessDenied: Access Denied\n\tstatus code: 403
level=error ts=2025-07-10T06:11:25.511513409Z caller=index_set.go:308 table-name=loki_index_20279 msg="sync failed, retrying it" err="AccessDenied:
```

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 