### PR TITLE
Loki 오래된 로그 삭제하기

### DIFF
--- a/infra/terraform/monitoring/s3.tf
+++ b/infra/terraform/monitoring/s3.tf
@@ -1,3 +1,33 @@
 resource "aws_s3_bucket" "scc_loki_storage" {
   bucket = "scc-loki-storage"
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "scc_loki_retention" {
+  bucket = aws_s3_bucket.scc_loki_storage.id
+
+  rule {
+    id     = "scc-loki-data-expiration"
+    status = "Enabled"
+
+    filter {
+      prefix = "fake/"
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+
+  rule {
+    id     = "scc-loki-index-expiration"
+    status = "Enabled"
+
+    filter {
+      prefix = "index/"
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+}


### PR DESCRIPTION
## Checklist
- loki 에서 retention period 가 28일로 설정되어 있기 때문에 S3 에서는 안전하게 30일 뒤에 삭제합니다
- root 에 삭제하면 안되는 `loki_cluster_seed.json` 파일이 존재하기 때문에 fake (data), index 디렉토리에 각각 rule 을 설정합니다
<img width="724" alt="image" src="https://github.com/user-attachments/assets/7b74d359-0b7c-4631-97fa-ff7bdad67e9a" />
