### PR TITLE
fix: 접근성 이미지 타입 오타 수정

### DIFF
--- a/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/toilet_review/ToiletReviewService.kt
+++ b/app-server/subprojects/bounded_context/place/application/src/main/kotlin/club/staircrusher/place/application/port/in/accessibility/toilet_review/ToiletReviewService.kt
@@ -31,7 +31,7 @@ class ToiletReviewService(
                     AccessibilityImage(
                         id = EntityIdGenerator.generateRandom(),
                         accessibilityId = it.id,
-                        accessibilityType = AccessibilityImage.AccessibilityType.Toilet,
+                        accessibilityType = AccessibilityImage.AccessibilityType.ToiletReview,
                         originalImageUrl = url,
                         displayOrder = index,
                     )

--- a/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/accessibility/AccessibilityImage.kt
+++ b/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/accessibility/AccessibilityImage.kt
@@ -66,6 +66,6 @@ class AccessibilityImage(
     }
 
     enum class AccessibilityType {
-        Place, Building, PlaceReview, Toilet
+        Place, Building, PlaceReview, ToiletReview
     }
 }


### PR DESCRIPTION
https://github.com/Stair-Crusher-Club/scc-server/blob/f263126ecf1a00ebf62ee8073d34c851ab01b81a/app-server/subprojects/bounded_context/place/domain/src/main/kotlin/club/staircrusher/place/domain/model/accessibility/toilet_review/ToiletReview.kt#L40-L43

Column 의 필터 값이랑 이넘 이름이 달라서 수정합니다.
수정하면 DB 접근하면 터질거 같은데(이넘 문제로), 이거 테섭이니까 매뉴얼하게 수정해두겠습니다