### PR TITLE
ECR private repository 로 옮기기 위한 인프라 작업

### DIFF
--- a/infra/terraform/ecr/ecr.tf
+++ b/infra/terraform/ecr/ecr.tf
@@ -1,4 +1,24 @@
+resource "aws_ecr_repository" "scc_server" {
+  provider = aws
+  name = "scc-server"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_repository" "scc_admin_frontend" {
+  provider = aws
+  name = "scc-admin-frontend"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# Deprecated
 resource "aws_ecrpublic_repository" "scc_server" {
+  provider = aws.us-east-1
   repository_name = "scc-server"
   catalog_data {
     architectures     = ["ARM64", "x86-64"]
@@ -6,10 +26,55 @@ resource "aws_ecrpublic_repository" "scc_server" {
   }
 }
 
+# Deprecated
 resource "aws_ecrpublic_repository" "scc_admin_frontend" {
+  provider = aws.us-east-1
   repository_name = "scc-admin-frontend"
   catalog_data {
     architectures     = ["ARM64", "x86-64"]
     operating_systems = ["Linux"]
   }
+}
+
+resource "aws_ecr_lifecycle_policy" "scc_server_policy" {
+  repository = aws_ecr_repository.scc_server.name
+  policy = local.standard_policy
+}
+
+resource "aws_ecr_lifecycle_policy" "scc_admin_frontend_policy" {
+  repository = aws_ecr_repository.scc_admin_frontend.name
+  policy = local.standard_policy
+}
+
+locals {
+  standard_policy = jsonencode({
+    rules = [
+      {
+        rulePriority: 1,
+        description: "Expire untagged images older than 3 days",
+        selection: {
+          tagStatus: "untagged",
+          countType: "sinceImagePushed",
+          countUnit: "days",
+          countNumber: 3
+        },
+        action: {
+          type: "expire"
+        }
+      },
+      {
+        rulePriority: 2,
+        description: "Expire any image older than 365 days (1 year)",
+        selection: {
+          tagStatus: "any",
+          countType: "sinceImagePushed",
+          countUnit: "days",
+          countNumber: 365
+        },
+        action: {
+          type: "expire"
+        }
+      }
+    ]
+  })
 }

--- a/infra/terraform/ecr/ecr.tf
+++ b/infra/terraform/ecr/ecr.tf
@@ -59,7 +59,7 @@ locals {
           countNumber = 3
         }
         action = {
-          type: "expire"
+          type = "expire"
         }
       },
       {

--- a/infra/terraform/ecr/ecr.tf
+++ b/infra/terraform/ecr/ecr.tf
@@ -50,29 +50,29 @@ locals {
   standard_policy = jsonencode({
     rules = [
       {
-        rulePriority: 1,
-        description: "Expire untagged images older than 3 days",
-        selection: {
-          tagStatus: "untagged",
-          countType: "sinceImagePushed",
-          countUnit: "days",
-          countNumber: 3
-        },
-        action: {
+        rulePriority = 1
+        description = "Expire untagged images older than 3 days"
+        selection = {
+          tagStatus = "untagged"
+          countType = "sinceImagePushed"
+          countUnit = "days"
+          countNumber = 3
+        }
+        action = {
           type: "expire"
         }
       },
       {
-        rulePriority: 2,
-        description: "Expire any image older than 365 days (1 year)",
-        selection: {
-          tagStatus: "any",
-          countType: "sinceImagePushed",
-          countUnit: "days",
-          countNumber: 365
-        },
-        action: {
-          type: "expire"
+        rulePriority = 2
+        description = "Expire any image older than 365 days (1 year)"
+        selection = {
+          tagStatus = "any"
+          countType = "sinceImagePushed"
+          countUnit = "days"
+          countNumber = 365
+        }
+        action = {
+          type = "expire"
         }
       }
     ]

--- a/infra/terraform/ecr/main.tf
+++ b/infra/terraform/ecr/main.tf
@@ -1,4 +1,11 @@
 provider "aws" {
+  region = "ap-northeast-2"
+}
+
+# Alias provider specifically for ECR Public operations
+# Delete when public repositories are no longer needed
+provider "aws" {
+  alias  = "us-east-1"
   region = "us-east-1"
 }
 

--- a/infra/terraform/ecr/outputs.tf
+++ b/infra/terraform/ecr/outputs.tf
@@ -1,0 +1,7 @@
+output "scc_server_repository_arn" {
+  value = aws_ecr_repository.scc_server.arn
+}
+
+output "scc_admin_frontend_repository_arn" {
+  value = aws_ecr_repository.scc_admin_frontend.arn
+}

--- a/infra/terraform/iam/github-action.tf
+++ b/infra/terraform/iam/github-action.tf
@@ -31,7 +31,21 @@ resource "aws_iam_policy" "github_action_ci_cd_policy" {
       {
         "Effect": "Allow",
         "Action": [
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ],
+        "Resource": "arn:aws:ecr::${var.account_id}:repository/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
           "ecr-public:GetAuthorizationToken",
+          "ecr:GetAuthorizationToken",
           "sts:GetServiceBearerToken"
         ],
         "Resource": "*"

--- a/infra/terraform/iam/github-action.tf
+++ b/infra/terraform/iam/github-action.tf
@@ -39,7 +39,7 @@ resource "aws_iam_policy" "github_action_ci_cd_policy" {
           "ecr:BatchGetImage",
           "ecr:BatchCheckLayerAvailability"
         ],
-        "Resource": "arn:aws:ecr::${var.account_id}:repository/*"
+        "Resource": "arn:aws:ecr:${var.region}:${var.account_id}:repository/*"
       },
       {
         "Effect": "Allow",

--- a/infra/terraform/iam/iam.tf
+++ b/infra/terraform/iam/iam.tf
@@ -134,6 +134,14 @@ resource "aws_iam_group" "developer" {
 resource "aws_iam_user" "developer" {
   for_each = toset(var.developer)
   name     = each.key
+
+  lifecycle {
+    // Iam 유저가 Access Key 를 생성할 때마다 change 가 잡히므로 무시해둔다
+    ignore_changes = [
+      tags,
+      tags_all
+    ]
+  }
 }
 
 resource "aws_iam_group_membership" "developer" {

--- a/infra/terraform/iam/variables.tf
+++ b/infra/terraform/iam/variables.tf
@@ -2,6 +2,10 @@ variable "account_id" {
   default = 291889421067
 }
 
+variable "region" {
+  default = "ap-northeast-2"
+}
+
 variable "developer" {
   default = [
     "doogie.min",

--- a/infra/terraform/iam/variables.tf
+++ b/infra/terraform/iam/variables.tf
@@ -3,6 +3,7 @@ variable "account_id" {
 }
 
 variable "region" {
+  type    = string
   default = "ap-northeast-2"
 }
 

--- a/infra/terraform/scc/main.tf
+++ b/infra/terraform/scc/main.tf
@@ -33,3 +33,12 @@ data "terraform_remote_state" "kms" {
     region = "ap-northeast-2"
   }
 }
+
+data "terraform_remote_state" "ecr" {
+  backend = "s3"
+  config = {
+    bucket = "scc-prod-tf-remote-state"
+    key    = "ecr.tfstate"
+    region = "ap-northeast-2"
+  }
+}


### PR DESCRIPTION
## Checklist
- private repository 로 옮기려고 일단 infra 부터 변경합니다
- 보안 + lifecycle policy 를 private 에서만 쓸 수 있어서
  - 물론 public repository 는 월 50G 까지 무료기 때문에 비용보다는 보안 문제가 조금 더 비중이 큼
- 그에 따라 github action 과 deploy-secret 에 필요한 권한을 추가해줍니다
- 참고) ECR public repository 은 global resource 라서 provider region 이 us-east-1 여야 함
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced private container registries for server and admin frontend images with automated image scanning and lifecycle policies for improved security and image management.
  * Added outputs to easily access repository ARNs for integration with other services.

* **Chores**
  * Updated AWS provider configurations to support both standard and public container repositories.
  * Enhanced IAM policies to allow secure image push and pull operations for CI/CD workflows and deployment roles, covering both public and private registries.
  * Improved IAM user management by preventing unnecessary updates due to tag changes during access key creation.
  * Added remote state data source for ECR to enable cross-configuration references.
  * Added a default region variable to standardize AWS region configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->