### PR TITLE
chore: add scc-admin-frontend deploy secret

### DIFF
--- a/infra/terraform/scc/iam-dev.tf
+++ b/infra/terraform/scc/iam-dev.tf
@@ -159,7 +159,10 @@ data "aws_iam_policy_document" "scc_deploy_secret_dev" {
     condition {
       test     = "StringEquals"
       variable = "k3s.staircrusher.club:sub"
-      values = ["system:serviceaccount:dev:scc-server-deploy-secret"]
+      values = [
+        "system:serviceaccount:dev:scc-server-deploy-secret",
+        "system:serviceaccount:dev:scc-admin-frontend-deploy-secret"
+      ]
     }
   }
 }

--- a/infra/terraform/scc/iam.tf
+++ b/infra/terraform/scc/iam.tf
@@ -161,6 +161,7 @@ data "aws_iam_policy_document" "scc_deploy_secret" {
       variable = "k3s.staircrusher.club:sub"
       values = [
         "system:serviceaccount:scc:scc-server-deploy-secret",
+        "system:serviceaccount:scc:scc-admin-frontend-deploy-secret",
         "system:serviceaccount:scc-redash:scc-redash-deploy-secret",
       ]
     }


### PR DESCRIPTION
## Checklist
- 어드민에서는 사용하고 있지 않아서 설정이 안되어 있었네요
- 지금은 ecr prive repo 접근용으로 쓰고 나중에 어드민에서 sops 등도 사용할 수도 있음
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded permissions to allow additional Kubernetes service accounts to access deployment secrets. This enhances support for more components during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->