### PR TITLE
fix: iam configuration

### DIFF
--- a/infra/terraform/scc/ecr.tf
+++ b/infra/terraform/scc/ecr.tf
@@ -1,0 +1,45 @@
+data "aws_iam_policy_document" "scc_server_ecr_pull_access" {
+  statement {
+    actions = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+    resources = [
+      data.terraform_remote_state.ecr.outputs.scc_server_repository_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "scc_server_ecr_pull_access" {
+  name   = "scc-server-ecr-pull-access"
+  policy = data.aws_iam_policy_document.scc_server_ecr_pull_access.json
+}
+
+data "aws_iam_policy_document" "scc_admin_frontend_ecr_pull_access" {
+  statement {
+    actions = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+    resources = [
+      data.terraform_remote_state.ecr.outputs.scc_admin_frontend_repository_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "scc_admin_frontend_ecr_pull_access" {
+  name   = "scc-admin-frontend-ecr-pull-access"
+  policy = data.aws_iam_policy_document.scc_admin_frontend_ecr_pull_access.json
+}

--- a/infra/terraform/scc/iam-dev.tf
+++ b/infra/terraform/scc/iam-dev.tf
@@ -147,6 +147,11 @@ resource "aws_iam_role_policy_attachment" "scc_dev_common_queue_full_access" {
   policy_arn = aws_iam_policy.scc_dev_common_queue_full_access.arn
 }
 
+resource "aws_iam_role_policy_attachment" "dev_scc_server_ecr_pull_access" {
+  role       = aws_iam_role.scc_dev.name
+  policy_arn = aws_iam_policy.scc_server_ecr_pull_access.arn
+}
+
 data "aws_iam_policy_document" "scc_deploy_secret_dev" {
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
@@ -160,8 +165,7 @@ data "aws_iam_policy_document" "scc_deploy_secret_dev" {
       test     = "StringEquals"
       variable = "k3s.staircrusher.club:sub"
       values = [
-        "system:serviceaccount:dev:scc-server-deploy-secret",
-        "system:serviceaccount:dev:scc-admin-frontend-deploy-secret"
+        "system:serviceaccount:dev:scc-server-deploy-secret"
       ]
     }
   }
@@ -182,27 +186,6 @@ data "aws_iam_policy_document" "scc_deploy_secret_dev_kms_access" {
   }
 }
 
-data "aws_iam_policy_document" "scc_deploy_secret_dev_ecr_pull_access" {
-  statement {
-    actions = ["ecr:GetAuthorizationToken"]
-    resources = ["*"]
-  }
-
-  statement {
-    sid    = "AllowImagePull"
-    actions = [
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage"
-    ]
-    # Restrict permissions to a specific repository for security
-    resources = [
-      data.terraform_remote_state.ecr.outputs.scc_server_repository_arn,
-      data.terraform_remote_state.ecr.outputs.scc_admin_frontend_repository_arn
-    ]
-  }
-}
-
 resource "aws_iam_role" "scc_deploy_secret_dev" {
   name               = "scc-deploy-secret-dev"
   assume_role_policy = data.aws_iam_policy_document.scc_deploy_secret_dev.json
@@ -213,17 +196,34 @@ resource "aws_iam_policy" "scc_deploy_secret_dev_kms_access" {
   policy = data.aws_iam_policy_document.scc_deploy_secret_dev_kms_access.json
 }
 
-resource "aws_iam_policy" "scc_deploy_secret_dev_ecr_pull_access" {
-  name   = "scc-deploy-secret-dev-ecr-pull-access"
-  policy = data.aws_iam_policy_document.scc_deploy_secret_dev_ecr_pull_access.json
-}
-
 resource "aws_iam_role_policy_attachment" "scc_deploy_secret_dev_kms_read_access" {
   role       = aws_iam_role.scc_deploy_secret_dev.name
   policy_arn = aws_iam_policy.scc_deploy_secret_dev_kms_access.arn
 }
 
-resource "aws_iam_role_policy_attachment" "scc_deploy_secret_dev_ecr_pull_access" {
-  role       = aws_iam_role.scc_deploy_secret_dev.name
-  policy_arn = aws_iam_policy.scc_deploy_secret_dev_ecr_pull_access.arn
+data "aws_iam_policy_document" "scc_admin_frontend_dev" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+      identifiers = [data.terraform_remote_state.oidc.outputs.k3s_oidc_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "k3s.staircrusher.club:sub"
+      values = ["system:serviceaccount:dev:scc-admin-frontend"]
+    }
+  }
+}
+
+resource "aws_iam_role" "scc_admin_frontend_dev" {
+  name               = "scc-admin-frontend-dev"
+  assume_role_policy = data.aws_iam_policy_document.scc_admin_frontend_dev.json
+}
+
+resource "aws_iam_role_policy_attachment" "dev_scc_admin_frontend_ecr_pull_access" {
+  role       = aws_iam_role.scc_admin_frontend_dev.name
+  policy_arn = aws_iam_policy.scc_admin_frontend_ecr_pull_access.arn
 }


### PR DESCRIPTION
## Checklist
- 이미지 pull 은 deploy-secret 이 아니라 scc-server serviceAccount 에서 직접 하는 것이므로 iam 설정을 바꿔줍니다
- 추가로 admin-frontend 는 지금까지 iam + assume role 이 필요 없어서 설정이 안되어 있었는데, 이번에 추가합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 