### PR TITLE
공공데이터 API Read Timeout 늘리기

### DIFF
--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/GovernmentOpenDataService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/GovernmentOpenDataService.kt
@@ -9,6 +9,7 @@ import club.staircrusher.stdlib.geography.CrsType
 import club.staircrusher.stdlib.geography.Location
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.service.annotation.GetExchange
+import java.time.Duration
 import java.time.LocalDate
 
 @Component
@@ -24,6 +25,7 @@ class GovernmentOpenDataService(
                 .map { RuntimeException(it) }
                 .onErrorResume { response.createException() }
         },
+        readTimeout = READ_TIMEOUT,
     )
 
     override fun getClosedPlaces(): List<ClosedPlaceResult> {
@@ -196,6 +198,7 @@ class GovernmentOpenDataService(
         private const val CLOSED_STATE = "03"
         private const val RESTAURANT_CODE = "07_24_04_P"
         private const val CAFE_CODE = "07_24_05_P"
+        private val READ_TIMEOUT: Duration = Duration.ofSeconds(30L)
 
         private val locationConverter = CrsConverter(CrsType.EPSG_5174, CrsType.EPSG_4326)
     }


### PR DESCRIPTION
## Checklist
- ReadTimeout 이 나면서 curl container 가 재시작 하는 것 같아서 좀 늘려줍니다
- 왜 나는건진 아직 조사 안했습니다

```
{"timestamp":"2025-07-28 14:00:11.572Z","level":"WARN","thread":"reactor-http-epoll-4","logger":"reactor.netty.http.client.HttpClientConnect","message":"[88185879-1, L:/10.42.3.89:53412 - R:www.localdata.go.kr/152.99.104.122:80] The connection observed an error","exception":"io.netty.handler.timeout.ReadTimeoutException: null\n"}
```

- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 