### PR TITLE
[폐업추정] Pod restart 고치기

### DIFF
--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/place/PlaceController.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/in/controller/place/PlaceController.kt
@@ -13,6 +13,6 @@ class PlaceController(
     @PostMapping("/createClosedPlaceCandidates")
     fun createClosedPlaceCandidates(request: HttpServletRequest) {
         InternalIpAddressChecker.check(request)
-        createClosedPlaceCandidatesUseCase.handle()
+        createClosedPlaceCandidatesUseCase.handleAsync()
     }
 }

--- a/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/GovernmentOpenDataService.kt
+++ b/app-server/subprojects/bounded_context/place/infra/src/main/kotlin/club/staircrusher/place/infra/adapter/out/web/GovernmentOpenDataService.kt
@@ -9,7 +9,6 @@ import club.staircrusher.stdlib.geography.CrsType
 import club.staircrusher.stdlib.geography.Location
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.service.annotation.GetExchange
-import java.time.Duration
 import java.time.LocalDate
 
 @Component
@@ -25,7 +24,6 @@ class GovernmentOpenDataService(
                 .map { RuntimeException(it) }
                 .onErrorResume { response.createException() }
         },
-        readTimeout = READ_TIMEOUT,
     )
 
     override fun getClosedPlaces(): List<ClosedPlaceResult> {
@@ -198,7 +196,6 @@ class GovernmentOpenDataService(
         private const val CLOSED_STATE = "03"
         private const val RESTAURANT_CODE = "07_24_04_P"
         private const val CAFE_CODE = "07_24_05_P"
-        private val READ_TIMEOUT: Duration = Duration.ofSeconds(30L)
 
         private val locationConverter = CrsConverter(CrsType.EPSG_5174, CrsType.EPSG_4326)
     }


### PR DESCRIPTION
This reverts commit d9a1f77.

## Checklist
- 근본적인 원인으로는 curl container 에서 server pod 을 때릴 때 timeout 이 나는 것 같아서 executor 에 던지는 것으로 해결합니다
- [ ] 충분한 양의 자동화 테스트를 작성했는가?
  - 계단정복지도 서비스는 사이드 프로젝트로 진행되는 만큼 충분한 QA 없이 배포되는 경우가 많습니다. 따라서 자동화 테스트를 꼼꼼하게 작성하는 것이 서비스 품질을 유지하는 데 매우 중요합니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the process for creating closed place candidates by making it run asynchronously in the background, enhancing overall responsiveness.
  * Internal cleanup of unused timeout settings for external data services, with no impact on user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->